### PR TITLE
feat: expand default equipment items and refine status tracking

### DIFF
--- a/apps/backend/prisma/migrations/20260417000000_add_standard_equipment_items/migration.sql
+++ b/apps/backend/prisma/migrations/20260417000000_add_standard_equipment_items/migration.sql
@@ -1,0 +1,69 @@
+-- Add standard equipment items across BOXES, HIVE_PARTS, TOOLS, PROTECTIVE, and EXTRACTION categories.
+-- Existing items (DEEP_BOX, MEDIUM_BOX, SHALLOW_BOX, BOTTOM_BOARD, COVER, QUEEN_EXCLUDER,
+-- FRAMES, FEEDER, SUGAR, SYRUP) are unchanged.
+
+-- Update seed function to include new items for future registrations
+CREATE OR REPLACE FUNCTION create_default_equipment_items(user_id_param TEXT)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO "EquipmentMultiplier" (id, "userId", "targetHives", "createdAt", "updatedAt")
+  VALUES (gen_random_uuid(), user_id_param, 0, NOW(), NOW())
+  ON CONFLICT ("userId") DO NOTHING;
+
+  INSERT INTO "EquipmentItem" (id, "userId", "itemId", name, enabled, "perHive", extra, "inExtraction", damaged, "neededOverride", category, scope, unit, "isCustom", "displayOrder", "createdAt", "updatedAt")
+  VALUES
+    -- BOXES
+    (gen_random_uuid(), user_id_param, 'DEEP_BOX',      'Deep Boxes',         true,  1, 0, 0, 0, null, 'BOXES',      'PER_HIVE', 'pieces', false,  1, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'MEDIUM_BOX',    'Medium Boxes',       true,  0, 0, 0, 0, null, 'BOXES',      'PER_HIVE', 'pieces', false,  2, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'SHALLOW_BOX',   'Shallow Boxes',      true,  2, 0, 0, 0, null, 'BOXES',      'PER_HIVE', 'pieces', false,  3, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'NUC_BOX',       'Nucleus Boxes',      false, 0, 0, 0, 0, null, 'BOXES',      'PER_HIVE', 'pieces', false,  4, NOW(), NOW()),
+
+    -- HIVE_PARTS
+    (gen_random_uuid(), user_id_param, 'BOTTOM_BOARD',     'Bottom Boards',     true,  1, 0, 0, 0, null, 'HIVE_PARTS', 'PER_HIVE', 'pieces', false,  5, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'INNER_COVER',      'Inner Covers',      true,  1, 0, 0, 0, null, 'HIVE_PARTS', 'PER_HIVE', 'pieces', false,  6, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'COVER',            'Outer Covers',      true,  1, 0, 0, 0, null, 'HIVE_PARTS', 'PER_HIVE', 'pieces', false,  7, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'QUEEN_EXCLUDER',   'Queen Excluders',   true,  1, 0, 0, 0, null, 'HIVE_PARTS', 'PER_HIVE', 'pieces', false,  8, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'HIVE_STAND',       'Hive Stands',       true,  1, 0, 0, 0, null, 'HIVE_PARTS', 'PER_HIVE', 'pieces', false,  9, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'ENTRANCE_REDUCER', 'Entrance Reducers', true,  1, 0, 0, 0, null, 'HIVE_PARTS', 'PER_HIVE', 'pieces', false, 10, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'MOUSE_GUARD',      'Mouse Guards',      false, 1, 0, 0, 0, null, 'HIVE_PARTS', 'PER_HIVE', 'pieces', false, 11, NOW(), NOW()),
+
+    -- FRAMES
+    (gen_random_uuid(), user_id_param, 'FRAMES', 'Frames', true, 0, 0, 0, 0, null, 'FRAMES', 'PER_HIVE', 'pieces', false, 12, NOW(), NOW()),
+
+    -- FEEDING
+    (gen_random_uuid(), user_id_param, 'FEEDER', 'Feeders', false, 0, 0, 0, 0, null, 'FEEDING', 'PER_HIVE', 'pieces', false, 13, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'SUGAR',  'Sugar',   true, 12, 0, 0, 0, null, 'FEEDING', 'PER_HIVE', 'kg',     false, 14, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'SYRUP',  'Syrup',   false, 0, 0, 0, 0, null, 'FEEDING', 'PER_HIVE', 'liters', false, 15, NOW(), NOW()),
+
+    -- CONSUMABLES
+    (gen_random_uuid(), user_id_param, 'WAX_FOUNDATION', 'Wax Foundation', false, 0, 0, 0, 0, null, 'CONSUMABLES', 'PER_HIVE', 'sheets', false, 16, NOW(), NOW()),
+
+    -- TOOLS
+    (gen_random_uuid(), user_id_param, 'HIVE_TOOL',   'Hive Tool',    true,  0, 0, 0, 0, null, 'TOOLS', 'SHARED', 'pieces', false, 17, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'SMOKER',      'Smoker',       true,  0, 0, 0, 0, null, 'TOOLS', 'SHARED', 'pieces', false, 18, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'MARKING_PEN', 'Marking Pen',  true,  0, 0, 0, 0, null, 'TOOLS', 'SHARED', 'pieces', false, 19, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'FRAME_GRIP',  'Frame Grip',   true,  0, 0, 0, 0, null, 'TOOLS', 'SHARED', 'pieces', false, 20, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'FRAME_PERCH', 'Frame Perch',  false, 0, 0, 0, 0, null, 'TOOLS', 'SHARED', 'pieces', false, 21, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'QUEEN_CAGE',  'Queen Cages',  false, 0, 0, 0, 0, null, 'TOOLS', 'SHARED', 'pieces', false, 22, NOW(), NOW()),
+
+    -- PROTECTIVE
+    (gen_random_uuid(), user_id_param, 'BEE_SUIT', 'Bee Suit or Jacket', true,  0, 0, 0, 0, null, 'PROTECTIVE', 'SHARED', 'pieces', false, 23, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'GLOVES',   'Gloves',             true,  0, 0, 0, 0, null, 'PROTECTIVE', 'SHARED', 'pieces', false, 24, NOW(), NOW()),
+
+    -- EXTRACTION
+    (gen_random_uuid(), user_id_param, 'EXTRACTOR',       'Extractor',       false, 0, 0, 0, 0, null, 'EXTRACTION', 'SHARED', 'pieces', false, 25, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'UNCAPPING_KNIFE', 'Uncapping Knife', false, 0, 0, 0, 0, null, 'EXTRACTION', 'SHARED', 'pieces', false, 26, NOW(), NOW()),
+    (gen_random_uuid(), user_id_param, 'UNCAPPING_TANK',  'Uncapping Tank',  false, 0, 0, 0, 0, null, 'EXTRACTION', 'SHARED', 'pieces', false, 27, NOW(), NOW())
+  ON CONFLICT ("userId", "itemId") DO NOTHING;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Backfill new items for all existing users
+DO $$
+DECLARE
+    user_record RECORD;
+BEGIN
+    FOR user_record IN SELECT id FROM "User" LOOP
+        PERFORM create_default_equipment_items(user_record.id);
+    END LOOP;
+END $$;

--- a/apps/frontend/src/pages/equipment/components/equipment-table.tsx
+++ b/apps/frontend/src/pages/equipment/components/equipment-table.tsx
@@ -26,7 +26,8 @@ import {
   EquipmentScope,
   UpdateEquipmentItem,
   CreateEquipmentItem,
-  STATUS_TRACKING_CATEGORIES,
+  EXTRACTION_TRACKING_CATEGORIES,
+  DAMAGE_TRACKING_CATEGORIES,
   SHARED_SCOPE_CATEGORIES,
 } from 'shared-schemas';
 import { useState } from 'react';
@@ -90,7 +91,8 @@ export const EquipmentRow = ({
   });
 
   const isShared = item.scope === EquipmentScope.SHARED;
-  const hasStatusTracking = STATUS_TRACKING_CATEGORIES.has(item.category);
+  const hasExtractionTracking = EXTRACTION_TRACKING_CATEGORIES.has(item.category);
+  const hasDamageTracking = DAMAGE_TRACKING_CATEGORIES.has(item.category);
 
   const handleEdit = () => {
     setEditData({
@@ -238,29 +240,29 @@ export const EquipmentRow = ({
             min="0"
             placeholder="Storage"
           />
-          {hasStatusTracking && (
-            <>
-              <Input
-                type="number"
-                value={editData.inExtraction}
-                onChange={e =>
-                  setEditData(prev => ({ ...prev, inExtraction: parseInt(e.target.value) || 0 }))
-                }
-                className="w-20 text-center mx-auto block text-amber-600"
-                min="0"
-                placeholder="Extracting"
-              />
-              <Input
-                type="number"
-                value={editData.damaged}
-                onChange={e =>
-                  setEditData(prev => ({ ...prev, damaged: parseInt(e.target.value) || 0 }))
-                }
-                className="w-20 text-center mx-auto block text-red-500"
-                min="0"
-                placeholder="Damaged"
-              />
-            </>
+          {hasExtractionTracking && (
+            <Input
+              type="number"
+              value={editData.inExtraction}
+              onChange={e =>
+                setEditData(prev => ({ ...prev, inExtraction: parseInt(e.target.value) || 0 }))
+              }
+              className="w-20 text-center mx-auto block text-amber-600"
+              min="0"
+              placeholder="Extracting"
+            />
+          )}
+          {hasDamageTracking && (
+            <Input
+              type="number"
+              value={editData.damaged}
+              onChange={e =>
+                setEditData(prev => ({ ...prev, damaged: parseInt(e.target.value) || 0 }))
+              }
+              className="w-20 text-center mx-auto block text-red-500"
+              min="0"
+              placeholder="Damaged"
+            />
           )}
         </div>
 
@@ -376,13 +378,13 @@ export const EquipmentRow = ({
 
       {/* Storage / status */}
       <div className="text-center">
-        {hasStatusTracking ? (
+        {(hasExtractionTracking || hasDamageTracking) ? (
           <div className="flex flex-col items-center gap-0.5 text-xs">
             <span>{round2(extra)} stored</span>
-            {inExtraction > 0 && (
+            {hasExtractionTracking && inExtraction > 0 && (
               <span className="text-amber-600">{round2(inExtraction)} extracting</span>
             )}
-            {damaged > 0 && (
+            {hasDamageTracking && damaged > 0 && (
               <span className="text-red-500">{round2(damaged)} damaged</span>
             )}
           </div>
@@ -626,7 +628,7 @@ export const EquipmentTable = ({
   ];
 
   return (
-    <div className="space-y-6 min-w-[700px]">
+    <div className="space-y-6 min-w-[750px]">
       {showAddForm && (
         <div className="bg-muted/20 rounded-md p-4 border-2 border-dashed border-muted-foreground/25">
           <div className="grid grid-cols-7 gap-4 items-end">

--- a/apps/frontend/src/pages/equipment/equipment-planning-page.tsx
+++ b/apps/frontend/src/pages/equipment/equipment-planning-page.tsx
@@ -361,7 +361,7 @@ export const EquipmentPlanningPage = () => {
                 {t('hive:equipment.table.addEquipment', { defaultValue: 'Add Equipment' })}
               </Button>
             </CardHeader>
-            <CardContent>
+            <CardContent className="min-w-0">
               {localTargetHives === 0 && (
                 <div className="flex items-center gap-2 text-sm text-amber-700 bg-amber-50 dark:bg-amber-950/30 dark:text-amber-400 border border-amber-200 dark:border-amber-800 rounded-md px-3 py-2 mb-4">
                   <AlertCircle className="h-4 w-4 shrink-0" />

--- a/packages/shared-schemas/src/equipment/types.ts
+++ b/packages/shared-schemas/src/equipment/types.ts
@@ -22,8 +22,16 @@ export const SHARED_SCOPE_CATEGORIES = new Set([
   EquipmentCategory.EXTRACTION,
 ]);
 
-// Categories that support in-extraction and damaged status tracking
-export const STATUS_TRACKING_CATEGORIES = new Set([
+// Categories that support in-extraction status tracking (items that can be temporarily in the extractor)
+export const EXTRACTION_TRACKING_CATEGORIES = new Set([
   EquipmentCategory.BOXES,
+  EquipmentCategory.FRAMES,
+]);
+
+// Categories that support damaged status tracking
+export const DAMAGE_TRACKING_CATEGORIES = new Set([
+  EquipmentCategory.BOXES,
+  EquipmentCategory.FRAMES,
   EquipmentCategory.HIVE_PARTS,
 ]);
+


### PR DESCRIPTION
## What changed and why

### New default equipment items

Added 17 new default equipment items that most beekeepers would recognise, across categories that previously had no defaults (TOOLS, PROTECTIVE, EXTRACTION) as well as additions to HIVE_PARTS, BOXES, and CONSUMABLES.

Items that are nearly universal are **enabled by default**:
- Hive Tool, Smoker, Marking Pen, Frame Grip (TOOLS)
- Bee Suit or Jacket, Gloves (PROTECTIVE)
- Inner Cover, Hive Stand, Entrance Reducer (HIVE_PARTS)
- Nucleus Box (BOXES)

Less common or more situational items are **disabled by default** so they do not clutter the view for new users, but are available to enable:
- Frame Perch, Queen Cage (TOOLS)
- Mouse Guard (HIVE_PARTS)
- Wax Foundation (CONSUMABLES)
- Extractor, Uncapping Knife, Uncapping Tank (EXTRACTION)

All new items are backfilled for existing users via the migration.

### Extraction vs damage tracking

`STATUS_TRACKING_CATEGORIES` has been split into two more precise sets:

- `EXTRACTION_TRACKING_CATEGORIES` — BOXES and FRAMES (items that can be temporarily in an extractor)
- `DAMAGE_TRACKING_CATEGORIES` — BOXES, FRAMES, and HIVE_PARTS (items that can be damaged)

Hive parts such as bottom boards, covers, and entrance reducers can be damaged but would never go into an extractor, so the "extracting" field is now correctly hidden for that category.

### Mobile horizontal scroll fix

The equipment table was being clipped on narrow screens rather than scrolling. The root cause was that `CardContent` is a flex item inside the `Card` component (`flex flex-col`), and flex items default to `min-width: auto`, which causes them to expand to fit their content rather than being constrained by the card width. Adding `min-w-0` to `CardContent` allows it to shrink correctly so `overflow-x-auto` works as intended.

## Testing

- Register a new account and verify all new items appear under the correct categories
- Confirm enabled/disabled defaults match the list above
- Edit a HIVE_PARTS item and confirm only the "damaged" field appears (no "extracting" field)
- Edit a BOXES or FRAMES item and confirm both "extracting" and "damaged" fields appear
- Check the equipment page on a narrow screen and confirm the table scrolls horizontally