### PR TITLE
fix: prevent FAB container from blocking mobile touch input

### DIFF
--- a/apps/frontend/src/components/common/floating-action-button.tsx
+++ b/apps/frontend/src/components/common/floating-action-button.tsx
@@ -95,11 +95,11 @@ export const FloatingActionButton = () => {
         />
       )}
 
-      <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end">
+      <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end pointer-events-none">
         {/* Action buttons */}
         <div className={cn(
           "flex flex-col items-end gap-3 mb-3 bg-background/95 backdrop-blur-sm rounded-2xl p-3 shadow-lg border border-border transition-all duration-300",
-          isOpen && actions.length > 1 ? "opacity-100" : "opacity-0 pointer-events-none"
+          isOpen && actions.length > 1 ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
         )}>
           {actions.map((action, index) => (
             <div
@@ -138,7 +138,7 @@ export const FloatingActionButton = () => {
         {/* Main FAB button */}
         <Button
           className={cn(
-            'h-14 w-14 rounded-full shadow-lg transition-all duration-300',
+            'h-14 w-14 rounded-full shadow-lg transition-all duration-300 pointer-events-auto',
             'bg-primary hover:bg-primary/90',
             isOpen && actions.length > 1 && 'rotate-45',
           )}


### PR DESCRIPTION
Fix: FAB container blocking mobile touch input

The floating action button's outer fixed wrapper extended upward to encompass the hidden action menu panel, creating a large transparent element that intercepted taps on anything underneath it — most notably form buttons like Save on the queen edit page.

Changes

Added pointer-events-none to the FAB outer container so it never blocks underlying elements by default
Action panel switches to pointer-events-auto when open, and keeps pointer-events-none when closed
Main FAB button gets explicit pointer-events-auto so it remains tappable at all times
Testing

Open the edit queen page on mobile and confirm the Save button is responsive.