### PR TITLE
Bug/inspection percent fix

### DIFF
--- a/apps/frontend/src/pages/inspection/components/inspection-form/frame-counts.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/frame-counts.tsx
@@ -156,12 +156,16 @@ export const FrameCountSection: React.FC<FrameCountSectionProps> = ({
     name: 'observations.eggsFrames',
     control,
   });
+  const uncappedBroodFrames = useWatch({
+    name: 'observations.uncappedBroodFrames',
+    control,
+  });
   const cappedBroodFrames = useWatch({
     name: 'observations.cappedBroodFrames',
     control,
   });
-  const openBroodFrames = useWatch({
-    name: 'observations.openBroodFrames',
+  const droneBroodFrames = useWatch({
+    name: 'observations.droneBroodFrames',
     control,
   });
   const pollenFrames = useWatch({
@@ -183,8 +187,9 @@ export const FrameCountSection: React.FC<FrameCountSectionProps> = ({
 
   const frameValues = [
     eggsFrames,
+    uncappedBroodFrames,
     cappedBroodFrames,
-    openBroodFrames,
+    droneBroodFrames,
     pollenFrames,
     nectarFrames,
     honeyFrames,


### PR DESCRIPTION
The frameValues array was built in the wrong order and watched a non-existent field (openBroodFrames), causing every frame type from Uncapped Brood onward to display another type's percentage. Drone Brood was missing entirely, and Capped Brood and Empty/Foundation showed no percentage or progress bar.

Reordered the useWatch calls and frameValues array to match FRAME_FIELDS order, and added the missing droneBroodFrames watch.