### PR TITLE
Add Additional swarm management techniques to tools

### DIFF
--- a/apps/frontend/public/locales/da/common.json
+++ b/apps/frontend/public/locales/da/common.json
@@ -416,11 +416,15 @@
       },
       "pagden": {
         "title": "Pagden split",
-        "description": "Placeholder for a future guide covering the classic artificial swarm split."
+        "description": "Placeholder for a future guide covering the classic artificial swarm split.",
+        "detail": "",
+        "cta": ""
       },
       "artificialSwarm": {
         "title": "Artificial swarm",
-        "description": "Placeholder for a future guide focused on moving flying bees and brood apart."
+        "description": "Placeholder for a future guide focused on moving flying bees and brood apart.",
+        "detail": "",
+        "cta": ""
       }
     },
     "aside": {
@@ -654,7 +658,430 @@
         "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
       }
     },
-    "intro": "Gratis reference guide i at kontrollere sværmning af honningbier. Sammenlign kendte metoder, som Demaree, planlægning opfølgende inspektioner, og reducer risikoen for at miste familie til sværmning, under det travle forårstræk."
+    "intro": "Gratis reference guide i at kontrollere sværmning af honningbier. Sammenlign kendte metoder, som Demaree, planlægning opfølgende inspektioner, og reducer risikoen for at miste familie til sværmning, under det travle forårstræk.",
+    "pagden": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "artificialSwarm": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "cushmanCredit": {
+      "text": "",
+      "linkLabel": ""
+    }
   },
   "footer": {
     "privacyPolicy": "Privatlivspolitik"

--- a/apps/frontend/public/locales/de/common.json
+++ b/apps/frontend/public/locales/de/common.json
@@ -527,11 +527,15 @@
       },
       "pagden": {
         "title": "Pagden split",
-        "description": "Placeholder for a future guide covering the classic artificial swarm split."
+        "description": "Placeholder for a future guide covering the classic artificial swarm split.",
+        "detail": "",
+        "cta": ""
       },
       "artificialSwarm": {
         "title": "Artificial swarm",
-        "description": "Placeholder for a future guide focused on moving flying bees and brood apart."
+        "description": "Placeholder for a future guide focused on moving flying bees and brood apart.",
+        "detail": "",
+        "cta": ""
       }
     },
     "aside": {
@@ -757,6 +761,429 @@
         "title": "Checkpoint order is no longer chronological",
         "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
       }
+    },
+    "pagden": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "artificialSwarm": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "cushmanCredit": {
+      "text": "",
+      "linkLabel": ""
     }
   },
   "varroaManagement": {

--- a/apps/frontend/public/locales/en/common.json
+++ b/apps/frontend/public/locales/en/common.json
@@ -689,11 +689,15 @@
       },
       "pagden": {
         "title": "Pagden split",
-        "description": "Placeholder for a future guide covering the classic artificial swarm split."
+        "description": "The classic artificial swarm technique. Move the original queen to a new hive on the original stand, controlling swarming impulse while maintaining colony strength.",
+        "detail": "Review the method, generate a follow-up plan, and save the checkpoints as scheduled inspections.",
+        "cta": "Open guide"
       },
       "artificialSwarm": {
         "title": "Artificial swarm",
-        "description": "Placeholder for a future guide focused on moving flying bees and brood apart."
+        "description": "A variation where the queen stays in the parent colony. Move a frame with one queen cell to the new hive on the original stand — useful when the queen cannot be found.",
+        "detail": "Review the method, generate a follow-up plan, and save the checkpoints as scheduled inspections.",
+        "cta": "Open guide"
       }
     },
     "aside": {
@@ -955,6 +959,429 @@
         "title": "Checkpoint order is no longer chronological",
         "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
       }
+    },
+    "pagden": {
+      "badge": "Reference method",
+      "title": "Pagden Split",
+      "description": "A classic split method where the queen is moved to a new hive on the original stand, while the parent colony with brood is moved aside.",
+      "intro": "The Pagden split is a proven swarm-control and colony-increase method that separates the laying queen from most brood by moving the queen to a new hive positioned on the original stand. Flying bees return to the queen, while the parent colony with brood is placed nearby and allowed to raise a new queen from its existing queen cells. Follow up around day 7–8, day 14–15, and day 21–22 to monitor queen cell development and confirm the new queen has mated and is laying.",
+      "overviewTitle": "Method overview",
+      "overviewLead": "Use the Pagden split when you want to control swarm pressure while keeping both the queen and brood in active colonies, and when you have a spare hive body and drawn comb available.",
+      "overviewPoints": [
+        "The queen is moved to a new hive on the original stand, so flying bees return to her and the new colony builds up quickly.",
+        "The parent colony with brood is moved aside and left with its queen cells — it will raise a new queen, resulting in colony increase.",
+        "Both colonies remain active and productive, making the Pagden split a good choice when you want to increase colony numbers while controlling swarming."
+      ],
+      "prerequisitesTitle": "Prerequisites",
+      "prerequisites": [
+        "Confirm the colony is strong with enough bees and brood to justify the split.",
+        "Locate and confidently retain the laying queen — you will need to move her to the new hive.",
+        "Have a spare hive floor, brood box with drawn comb, queen excluder, crown board, and roof ready.",
+        "Prepare a second hive floor and stand for the parent colony with brood.",
+        "Choose a settled weather window so both colonies can reorganise without prolonged interruption."
+      ],
+      "stepsTitle": "Method Detail",
+      "stepsDescription": "Follow these steps to perform the Pagden split",
+      "methodDetail": {
+        "preparation": {
+          "title": "Preparation",
+          "items": [
+            {
+              "text": "Find a spare brood box with drawn comb (not foundation — foundation slows the new colony's build-up)."
+            },
+            {
+              "text": "Prepare a second hive floor and stand positioned a few metres away from the original location."
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "Relocate the Queen",
+          "items": [
+            {
+              "text": "Inspect the original hive and locate the laying queen."
+            },
+            {
+              "text": "Take the frame with the queen and place it in the centre of the new brood box, removing any queen cells on that frame."
+            },
+            {
+              "text": "Fill the new box with frames of drawn comb, ensuring the queen has room to lay."
+            },
+            {
+              "text": "Place the new box on the original hive floor — flying bees will return here."
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "Manage the Parent Colony",
+          "items": [
+            {
+              "text": "Move the original hive (now without the queen) to the second floor a few metres away."
+            },
+            {
+              "text": "Inspect all brood frames and reduce the queen cells down to one or two good, well-placed cells — do not destroy all of them, as the parent colony needs a queen cell to raise a new queen."
+            },
+            {
+              "text": "Ensure the parent colony has adequate stores and space to develop."
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "Reassembly",
+          "items": [
+            {
+              "text": "Place a queen excluder on top of the new hive (with the queen) if you want to add supers for honey storage."
+            },
+            {
+              "text": "Add supers as needed for the season's nectar flow."
+            },
+            {
+              "text": "Fit crown board and roof on both hives."
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "Why the method works",
+      "advantagesDescription": "The Pagden split relieves swarm pressure by separating the queen from brood while maintaining two productive colonies.",
+      "advantages": [
+        "The queen on the original stand attracts flying bees, building up the new colony quickly and maintaining foraging activity.",
+        "The parent colony with brood is moved aside and left with its queen cells, allowing it to raise a new queen and become a second productive colony.",
+        "Both colonies remain active and can contribute to honey production or build up for winter."
+      ],
+      "followUpTitle": "Follow-up timing",
+      "followUpDayHeader": "Day",
+      "followUpTaskHeader": "Task",
+      "followUp": [
+        {
+          "day": "Day 7-8",
+          "task": "Inspect the parent colony and reduce queen cells to one or two well-placed, well-formed cells. The colony needs at least one to raise a new queen."
+        },
+        {
+          "day": "Day 14-15",
+          "task": "Check that the retained queen cell is capped and developing. Look for any additional cells that may have been started and remove extras, leaving just one."
+        },
+        {
+          "day": "Day 21-22",
+          "task": "Carry out a final review to assess both colonies and decide on next steps for the season."
+        }
+      ],
+      "prosConsTitle": "Pros and Cons",
+      "prosTitle": "Advantages",
+      "consTitle": "Disadvantages",
+      "pros": [
+        "Effective swarm control that maintains two productive colonies.",
+        "The queen on the original stand attracts flying bees, building up quickly.",
+        "Both colonies can contribute to honey production.",
+        "Simpler than some methods — no complex stacking or excluders required.",
+        "Good for increasing colony numbers while managing swarm pressure."
+      ],
+      "cons": [
+        "Requires finding and moving the queen, which takes skill and confidence.",
+        "Requires a spare hive body with drawn comb and a second floor.",
+        "The parent colony may produce a virgin queen that needs to mate successfully.",
+        "Regular inspections are essential to manage queen cells.",
+        "Not suitable for beginners unfamiliar with queen handling."
+      ],
+      "faq": {
+        "title": "Frequently asked questions",
+        "items": [
+          {
+            "question": "What is the Pagden split?",
+            "answer": "The Pagden split is a swarm-control method where the laying queen is moved to a new hive positioned on the original stand, while the parent colony with brood is moved aside. Flying bees return to the queen, building up the new colony, while the parent colony develops and produces a new queen."
+          },
+          {
+            "question": "When should I use the Pagden split?",
+            "answer": "Use the Pagden split on strong colonies showing clear swarm pressure when you want to control swarming while maintaining two productive colonies. It works well when you have spare equipment and are confident finding and moving the queen."
+          },
+          {
+            "question": "What is the biggest risk with the Pagden split?",
+            "answer": "The main risk is leaving too many queen cells in the parent colony — the first virgin queen to emerge may swarm off with some bees if other sealed cells are present. Reduce to one or two well-placed cells at the day 7–8 check, shaking bees off frames to spot them all. Do not destroy all cells, as the colony needs one to raise a new queen."
+          },
+          {
+            "question": "How long does it take for the parent colony to produce a new queen?",
+            "answer": "The parent colony will raise an emergency queen from the youngest larvae. The new queen emerges around day 16 and needs 1-2 weeks to mate and start laying, so the parent colony is typically laying again by day 21-28."
+          }
+        ]
+      },
+      "planner": {
+        "title": "Pagden inspection planner",
+        "description": "Generate the standard checkpoints, adjust dates if needed, and save them as scheduled inspections for one hive.",
+        "selectHiveLabel": "Hive",
+        "selectHivePlaceholder": "Select a hive",
+        "startDateLabel": "Pagden split date",
+        "startDatePlaceholder": "Pick the split date",
+        "generateButton": "Generate checkpoints",
+        "saveButton": "Save scheduled inspections",
+        "checkpointPrefix": "Pagden checkpoint:",
+        "notesChecklistLabel": "Checklist",
+        "savedSuccess": "Saved {{count}} Pagden checkpoint as scheduled inspection.",
+        "savedPartial": "Saved {{successCount}} checkpoints, but {{failedCount}} failed. Review upcoming inspections before retrying.",
+        "savedError": "Unable to save the Pagden plan. Some inspections may not have been created.",
+        "noHivesMessage": "You need at least one hive in the active apiary before you can create a Pagden plan.",
+        "checkpoints": {
+          "setup": {
+            "title": "Initial Pagden split",
+            "summary": "Move the queen to the new hive on the original stand, move the parent colony with brood aside, and reduce queen cells to one or two well-placed cells.",
+            "checklist": [
+              "Locate and move the laying queen to the new hive on the original stand.",
+              "Move the parent colony with brood to a new location a few metres away.",
+              "Reduce queen cells on the parent colony to one or two well-formed, well-placed cells — the colony needs at least one to raise a new queen."
+            ]
+          },
+          "queenCellCheck": {
+            "title": "Queen-cell check",
+            "summary": "Inspect the parent colony around day 7 to 8 and reduce queen cells to one, leaving the best-placed, well-formed cell to raise the new queen.",
+            "checklist": [
+              "Inspect every brood frame in the parent colony for queen cells.",
+              "Retain one well-placed, well-formed queen cell and remove any others to reduce the risk of secondary swarming.",
+              "Confirm the parent colony has adequate stores and space."
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "Second queen-cell check",
+            "summary": "Recheck about a week later to catch any late-started cells and confirm the new queen is developing.",
+            "checklist": [
+              "Look again for newly started or missed queen cells.",
+              "Check whether the parent colony is developing normally.",
+              "Note whether the new queen is emerging or has emerged."
+            ]
+          },
+          "colonyReview": {
+            "title": "Colony review",
+            "summary": "Assess both colonies, confirm the new queen is laying, and decide on next steps for the season.",
+            "checklist": [
+              "Check the new colony for laying pattern and stores.",
+              "Confirm the parent colony has a laying queen.",
+              "Assess space, brood pattern, and nectar intake in both colonies."
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "First queen-cell check is later than day 8",
+          "description": "This delay increases the risk of queen cells emerging before you can review and reduce them. Try to keep the first follow-up within the 7 to 8 day window."
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "Checkpoint spacing looks risky",
+          "description": "These follow-up inspections are spread unusually far apart or packed too tightly, which can make queen-cell control less reliable."
+        },
+        "illogicalScheduleOrder": {
+          "title": "Checkpoint order is no longer chronological",
+          "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
+        }
+      }
+    },
+    "artificialSwarm": {
+      "badge": "Reference method",
+      "title": "Artificial Swarm",
+      "description": "A swarm-control method where the queen stays in the parent hive while a new colony is created on the original stand with a frame containing a queen cell.",
+      "intro": "The artificial swarm method is a practical swarm-control technique when the queen cannot be found or you prefer not to move her. The parent colony is moved to a new stand, and a new hive is placed on the original stand with one frame of brood containing eggs or an existing queen cell, filled with drawn comb. Flying bees return to the original stand, building up the new hive quickly. Follow up around day 7–8, day 14–15, and day 21–22 to manage queen cells and monitor both colonies.",
+      "overviewTitle": "Method overview",
+      "overviewLead": "Use the artificial swarm method when you want to control swarm pressure without finding the queen, or when you prefer to keep the queen in the parent colony while creating a new unit.",
+      "overviewPoints": [
+        "The queen remains in the parent colony, which is moved aside to a new location.",
+        "A new hive is placed on the original stand with one frame of brood containing a queen cell, attracting flying bees.",
+        "The new colony builds up from the queen cell while the parent colony continues laying, creating two productive units."
+      ],
+      "prerequisitesTitle": "Prerequisites",
+      "prerequisites": [
+        "Confirm the colony is strong with enough bees and brood to justify the split.",
+        "Identify a frame with a queen cell (or one that will develop into a queen cell) to move to the new hive.",
+        "Have a spare hive floor, brood box with drawn comb, and roof ready for the new colony.",
+        "Prepare a second location for the parent colony.",
+        "Choose a settled weather window so both colonies can reorganise without prolonged interruption."
+      ],
+      "stepsTitle": "Method Detail",
+      "stepsDescription": "Follow these steps to perform the artificial swarm",
+      "methodDetail": {
+        "preparation": {
+          "title": "Preparation",
+          "items": [
+            {
+              "text": "Find a spare brood box with drawn comb (not foundation — foundation slows the new colony's build-up)."
+            },
+            {
+              "text": "Prepare a second hive floor and stand positioned a few metres away from the original location."
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "Move the Parent Colony",
+          "items": [
+            {
+              "text": "Move the original hive (with the queen) to a new location a few metres away."
+            },
+            {
+              "text": "Inspect the brood frames and identify one frame with a queen cell (or one that will develop into a queen cell)."
+            },
+            {
+              "text": "Knock down any other queen cells on the parent colony brood frames."
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "Set Up the New Colony",
+          "items": [
+            {
+              "text": "Place the new brood box on the original hive floor — flying bees will return here."
+            },
+            {
+              "text": "Move the frame with the queen cell into the centre of the new box."
+            },
+            {
+              "text": "Fill the new box with frames of drawn comb, ensuring adequate stores."
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "Reassembly",
+          "items": [
+            {
+              "text": "Add a queen excluder on top of the new hive if you want to add supers for honey storage."
+            },
+            {
+              "text": "Add supers as needed for the season's nectar flow."
+            },
+            {
+              "text": "Fit crown board and roof on both hives."
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "Why the method works",
+      "advantagesDescription": "The artificial swarm relieves swarm pressure by creating a new colony on the original stand while keeping the queen in the parent colony.",
+      "advantages": [
+        "The queen is not moved, making the method simpler when the queen is hard to find or you prefer not to handle her.",
+        "Flying bees return to the original stand, building up the new colony quickly.",
+        "The parent colony continues laying and remains productive, contributing to honey production or building up for winter."
+      ],
+      "followUpTitle": "Follow-up timing",
+      "followUpDayHeader": "Day",
+      "followUpTaskHeader": "Task",
+      "followUp": [
+        {
+          "day": "Day 7-8",
+          "task": "Inspect the new colony to confirm the queen cell is developing and check for any additional queen cells."
+        },
+        {
+          "day": "Day 14-15",
+          "task": "Review the new colony for capped queen cells and confirm the parent colony is settling."
+        },
+        {
+          "day": "Day 21-22",
+          "task": "Carry out a final review to assess both colonies and decide on next steps for the season."
+        }
+      ],
+      "prosConsTitle": "Pros and Cons",
+      "prosTitle": "Advantages",
+      "consTitle": "Disadvantages",
+      "pros": [
+        "Effective swarm control without needing to find and move the queen.",
+        "Flying bees return to the original stand, building up the new colony quickly.",
+        "Both colonies remain productive and can contribute to honey production.",
+        "Simpler than methods requiring queen handling.",
+        "Good for increasing colony numbers while managing swarm pressure."
+      ],
+      "cons": [
+        "Requires identifying a frame with a suitable queen cell.",
+        "Requires a spare hive body with drawn comb and a second floor.",
+        "The new colony depends on the queen cell developing successfully.",
+        "Regular inspections are essential to monitor queen cell development.",
+        "The parent colony may still show swarm pressure if not managed carefully."
+      ],
+      "faq": {
+        "title": "Frequently asked questions",
+        "items": [
+          {
+            "question": "What is the artificial swarm method?",
+            "answer": "The artificial swarm method is a swarm-control technique where the queen remains in the parent colony (moved to a new location) while a new hive is placed on the original stand with one frame containing a queen cell. Flying bees return to the new hive, building it up from the queen cell."
+          },
+          {
+            "question": "When should I use the artificial swarm method?",
+            "answer": "Use the artificial swarm method when you want to control swarm pressure but cannot find the queen, or when you prefer not to move her. It works well when you have spare equipment and can identify a suitable queen cell."
+          },
+          {
+            "question": "What frame should I move to the new hive?",
+            "answer": "Move one frame of brood containing a queen cell (or one that will develop into a queen cell) to the new hive. The frame should have adequate stores and be positioned in the centre of the new box so the queen cell develops properly."
+          },
+          {
+            "question": "How long does it take for the new queen to start laying?",
+            "answer": "The queen cell will emerge around day 16, and the new queen needs 1-2 weeks to mate and start laying. The new colony is typically laying again by day 21-28."
+          }
+        ]
+      },
+      "planner": {
+        "title": "Artificial swarm inspection planner",
+        "description": "Generate the standard checkpoints, adjust dates if needed, and save them as scheduled inspections for one hive.",
+        "selectHiveLabel": "Hive",
+        "selectHivePlaceholder": "Select a hive",
+        "startDateLabel": "Artificial swarm date",
+        "startDatePlaceholder": "Pick the swarm date",
+        "generateButton": "Generate checkpoints",
+        "saveButton": "Save scheduled inspections",
+        "checkpointPrefix": "Artificial swarm checkpoint:",
+        "notesChecklistLabel": "Checklist",
+        "savedSuccess": "Saved {{count}} artificial swarm checkpoint as scheduled inspection.",
+        "savedPartial": "Saved {{successCount}} checkpoints, but {{failedCount}} failed. Review upcoming inspections before retrying.",
+        "savedError": "Unable to save the artificial swarm plan. Some inspections may not have been created.",
+        "noHivesMessage": "You need at least one hive in the active apiary before you can create an artificial swarm plan.",
+        "checkpoints": {
+          "setup": {
+            "title": "Initial artificial swarm setup",
+            "summary": "Move the parent colony aside, place the new hive on the original stand with a frame containing a queen cell, and knock down other queen cells.",
+            "checklist": [
+              "Move the parent colony with the queen to a new location.",
+              "Identify and move one frame with a queen cell to the new hive on the original stand.",
+              "Knock down all other queen cells on the parent colony brood frames."
+            ]
+          },
+          "queenCellCheck": {
+            "title": "Queen-cell check",
+            "summary": "Inspect the new colony around day 7 to 8 to confirm the queen cell is developing and check for any additional cells.",
+            "checklist": [
+              "Inspect the new colony to confirm the queen cell is developing.",
+              "Check for any additional queen cells that may have been started.",
+              "Confirm the new colony has adequate stores and space."
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "Second queen-cell check",
+            "summary": "Recheck about a week later to confirm the queen cell is capped and monitor the parent colony.",
+            "checklist": [
+              "Confirm the queen cell is capped and developing normally.",
+              "Check the parent colony for any new queen cells.",
+              "Assess space and stores in both colonies."
+            ]
+          },
+          "colonyReview": {
+            "title": "Colony review",
+            "summary": "Assess both colonies, confirm the new queen is emerging or laying, and decide on next steps for the season.",
+            "checklist": [
+              "Check the new colony for queen emergence or laying pattern.",
+              "Confirm the parent colony is settling and laying normally.",
+              "Assess space, brood pattern, and nectar intake in both colonies."
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "First queen-cell check is later than day 8",
+          "description": "This delay increases the risk of missing queen cell development. Try to keep the first follow-up within the 7 to 8 day window."
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "Checkpoint spacing looks risky",
+          "description": "These follow-up inspections are spread unusually far apart or packed too tightly, which can make monitoring less reliable."
+        },
+        "illogicalScheduleOrder": {
+          "title": "Checkpoint order is no longer chronological",
+          "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
+        }
+      }
+    },
+    "cushmanCredit": {
+      "text": "Method references sourced from the Dave Cushman Beekeeping Website.",
+      "linkLabel": "Dave Cushman Beekeeping Website"
     }
   },
   "varroaManagement": {

--- a/apps/frontend/public/locales/es/common.json
+++ b/apps/frontend/public/locales/es/common.json
@@ -8,5 +8,440 @@
         }
       }
     }
+  },
+  "swarmManagement": {
+    "pagden": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "artificialSwarm": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "cushmanCredit": {
+      "text": "",
+      "linkLabel": ""
+    },
+    "cards": {
+      "pagden": {
+        "detail": "",
+        "cta": ""
+      },
+      "artificialSwarm": {
+        "detail": "",
+        "cta": ""
+      }
+    }
   }
 }

--- a/apps/frontend/public/locales/fr/common.json
+++ b/apps/frontend/public/locales/fr/common.json
@@ -455,11 +455,15 @@
       },
       "pagden": {
         "title": "Pagden split",
-        "description": "Placeholder for a future guide covering the classic artificial swarm split."
+        "description": "Placeholder for a future guide covering the classic artificial swarm split.",
+        "detail": "",
+        "cta": ""
       },
       "artificialSwarm": {
         "title": "Artificial swarm",
-        "description": "Placeholder for a future guide focused on moving flying bees and brood apart."
+        "description": "Placeholder for a future guide focused on moving flying bees and brood apart.",
+        "detail": "",
+        "cta": ""
       }
     },
     "aside": {
@@ -685,6 +689,429 @@
         "title": "Checkpoint order is no longer chronological",
         "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
       }
+    },
+    "pagden": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "artificialSwarm": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "cushmanCredit": {
+      "text": "",
+      "linkLabel": ""
     }
   },
   "footer": {

--- a/apps/frontend/public/locales/it/common.json
+++ b/apps/frontend/public/locales/it/common.json
@@ -239,11 +239,15 @@
       },
       "pagden": {
         "title": "Pagden split",
-        "description": "Placeholder for a future guide covering the classic artificial swarm split."
+        "description": "Placeholder for a future guide covering the classic artificial swarm split.",
+        "detail": "",
+        "cta": ""
       },
       "artificialSwarm": {
         "title": "Artificial swarm",
-        "description": "Placeholder for a future guide focused on moving flying bees and brood apart."
+        "description": "Placeholder for a future guide focused on moving flying bees and brood apart.",
+        "detail": "",
+        "cta": ""
       }
     },
     "aside": {
@@ -469,6 +473,429 @@
         "title": "Checkpoint order is no longer chronological",
         "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
       }
+    },
+    "pagden": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "artificialSwarm": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "cushmanCredit": {
+      "text": "",
+      "linkLabel": ""
     }
   },
   "footer": {

--- a/apps/frontend/public/locales/nl/common.json
+++ b/apps/frontend/public/locales/nl/common.json
@@ -42,11 +42,15 @@
       },
       "pagden": {
         "title": "Pagden split",
-        "description": "Placeholder for a future guide covering the classic artificial swarm split."
+        "description": "Placeholder for a future guide covering the classic artificial swarm split.",
+        "detail": "",
+        "cta": ""
       },
       "artificialSwarm": {
         "title": "Artificial swarm",
-        "description": "Placeholder for a future guide focused on moving flying bees and brood apart."
+        "description": "Placeholder for a future guide focused on moving flying bees and brood apart.",
+        "detail": "",
+        "cta": ""
       }
     },
     "aside": {
@@ -272,6 +276,429 @@
         "title": "Checkpoint order is no longer chronological",
         "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
       }
+    },
+    "pagden": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "artificialSwarm": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "cushmanCredit": {
+      "text": "",
+      "linkLabel": ""
     }
   },
   "marketing": {

--- a/apps/frontend/public/locales/sk/common.json
+++ b/apps/frontend/public/locales/sk/common.json
@@ -383,11 +383,15 @@
       },
       "pagden": {
         "title": "Pagden split",
-        "description": "Placeholder for a future guide covering the classic artificial swarm split."
+        "description": "Placeholder for a future guide covering the classic artificial swarm split.",
+        "detail": "",
+        "cta": ""
       },
       "artificialSwarm": {
         "title": "Artificial swarm",
-        "description": "Placeholder for a future guide focused on moving flying bees and brood apart."
+        "description": "Placeholder for a future guide focused on moving flying bees and brood apart.",
+        "detail": "",
+        "cta": ""
       }
     },
     "aside": {
@@ -613,6 +617,429 @@
         "title": "Checkpoint order is no longer chronological",
         "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
       }
+    },
+    "pagden": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "artificialSwarm": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "cushmanCredit": {
+      "text": "",
+      "linkLabel": ""
     }
   },
   "footer": {

--- a/apps/frontend/public/locales/sr/common.json
+++ b/apps/frontend/public/locales/sr/common.json
@@ -376,11 +376,15 @@
       },
       "pagden": {
         "title": "Pagden split",
-        "description": "Placeholder for a future guide covering the classic artificial swarm split."
+        "description": "Placeholder for a future guide covering the classic artificial swarm split.",
+        "detail": "",
+        "cta": ""
       },
       "artificialSwarm": {
         "title": "Artificial swarm",
-        "description": "Placeholder for a future guide focused on moving flying bees and brood apart."
+        "description": "Placeholder for a future guide focused on moving flying bees and brood apart.",
+        "detail": "",
+        "cta": ""
       }
     },
     "aside": {
@@ -606,6 +610,429 @@
         "title": "Checkpoint order is no longer chronological",
         "description": "One of the later checkpoints is scheduled on or before an earlier visit. Reorder the dates before saving the plan."
       }
+    },
+    "pagden": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "artificialSwarm": {
+      "badge": "",
+      "title": "",
+      "description": "",
+      "intro": "",
+      "overviewTitle": "",
+      "overviewLead": "",
+      "overviewPoints": [
+        "",
+        "",
+        ""
+      ],
+      "prerequisitesTitle": "",
+      "prerequisites": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "stepsTitle": "",
+      "stepsDescription": "",
+      "methodDetail": {
+        "preparation": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "relocateQueen": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "queenCells": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        },
+        "reassembly": {
+          "title": "",
+          "items": [
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            },
+            {
+              "text": ""
+            }
+          ]
+        }
+      },
+      "advantagesTitle": "",
+      "advantagesDescription": "",
+      "advantages": [
+        "",
+        "",
+        ""
+      ],
+      "followUpTitle": "",
+      "followUpDayHeader": "",
+      "followUpTaskHeader": "",
+      "followUp": [
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        },
+        {
+          "day": "",
+          "task": ""
+        }
+      ],
+      "prosConsTitle": "",
+      "prosTitle": "",
+      "consTitle": "",
+      "pros": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "cons": [
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "faq": {
+        "title": "",
+        "items": [
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          },
+          {
+            "question": "",
+            "answer": ""
+          }
+        ]
+      },
+      "planner": {
+        "title": "",
+        "description": "",
+        "selectHiveLabel": "",
+        "selectHivePlaceholder": "",
+        "startDateLabel": "",
+        "startDatePlaceholder": "",
+        "generateButton": "",
+        "saveButton": "",
+        "checkpointPrefix": "",
+        "notesChecklistLabel": "",
+        "savedSuccess": "",
+        "savedPartial": "",
+        "savedError": "",
+        "noHivesMessage": "",
+        "checkpoints": {
+          "setup": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "queenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "secondQueenCellCheck": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          },
+          "colonyReview": {
+            "title": "",
+            "summary": "",
+            "checklist": [
+              "",
+              "",
+              ""
+            ]
+          }
+        }
+      },
+      "warnings": {
+        "lateQueenCellCheck": {
+          "title": "",
+          "description": ""
+        },
+        "unsafeCheckpointSpacing": {
+          "title": "",
+          "description": ""
+        },
+        "illogicalScheduleOrder": {
+          "title": "",
+          "description": ""
+        }
+      }
+    },
+    "cushmanCredit": {
+      "text": "",
+      "linkLabel": ""
     }
   },
   "footer": {

--- a/apps/frontend/src/pages/tools/__tests__/artificial-swarm-planner.test.ts
+++ b/apps/frontend/src/pages/tools/__tests__/artificial-swarm-planner.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateArtificialSwarmPlan,
+  getArtificialSwarmWarnings,
+  type ArtificialSwarmCheckpointPlan,
+} from '../artificial-swarm-planner';
+
+describe('Artificial Swarm Planner', () => {
+  describe('generateArtificialSwarmPlan', () => {
+    it('generates 4 checkpoints at correct day offsets (0, 7, 14, 21)', () => {
+      const startDate = new Date('2025-06-01');
+      const plan = generateArtificialSwarmPlan(startDate);
+
+      expect(plan).toHaveLength(4);
+      expect(plan[0].dayOffset).toBe(0);
+      expect(plan[1].dayOffset).toBe(7);
+      expect(plan[2].dayOffset).toBe(14);
+      expect(plan[3].dayOffset).toBe(21);
+    });
+
+    it('generates correct dates for known start date', () => {
+      const startDate = new Date('2025-06-01');
+      const plan = generateArtificialSwarmPlan(startDate);
+
+      expect(plan[0].date.toISOString().split('T')[0]).toBe('2025-06-01');
+      expect(plan[1].date.toISOString().split('T')[0]).toBe('2025-06-08');
+      expect(plan[2].date.toISOString().split('T')[0]).toBe('2025-06-15');
+      expect(plan[3].date.toISOString().split('T')[0]).toBe('2025-06-22');
+    });
+
+    it('includes correct checkpoint IDs', () => {
+      const startDate = new Date('2025-06-01');
+      const plan = generateArtificialSwarmPlan(startDate);
+
+      expect(plan[0].id).toBe('setup');
+      expect(plan[1].id).toBe('queenCellCheck');
+      expect(plan[2].id).toBe('secondQueenCellCheck');
+      expect(plan[3].id).toBe('colonyReview');
+    });
+
+    it('includes i18n keys for each checkpoint', () => {
+      const startDate = new Date('2025-06-01');
+      const plan = generateArtificialSwarmPlan(startDate);
+
+      plan.forEach(checkpoint => {
+        expect(checkpoint.titleKey).toContain('swarmManagement.artificialSwarm.planner.checkpoints');
+        expect(checkpoint.summaryKey).toContain('swarmManagement.artificialSwarm.planner.checkpoints');
+        expect(checkpoint.checklistKeys.length).toBeGreaterThan(0);
+        checkpoint.checklistKeys.forEach(key => {
+          expect(key).toContain('swarmManagement.artificialSwarm.planner.checkpoints');
+        });
+      });
+    });
+  });
+
+  describe('getArtificialSwarmWarnings', () => {
+    it('emits lateQueenCellCheck warning when gap exceeds 8 days', () => {
+      const checkpoints: Pick<ArtificialSwarmCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-06-01') },
+        { id: 'queenCellCheck', date: new Date('2025-06-10') }, // 9 days gap
+        { id: 'secondQueenCellCheck', date: new Date('2025-06-17') },
+        { id: 'colonyReview', date: new Date('2025-06-24') },
+      ];
+
+      const warnings = getArtificialSwarmWarnings(checkpoints);
+
+      expect(warnings).toContainEqual({
+        code: 'lateQueenCellCheck',
+        checkpointIds: ['setup', 'queenCellCheck'],
+      });
+    });
+
+    it('does not emit lateQueenCellCheck warning when gap is 8 days or less', () => {
+      const checkpoints: Pick<ArtificialSwarmCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-06-01') },
+        { id: 'queenCellCheck', date: new Date('2025-06-09') }, // 8 days gap
+        { id: 'secondQueenCellCheck', date: new Date('2025-06-16') },
+        { id: 'colonyReview', date: new Date('2025-06-23') },
+      ];
+
+      const warnings = getArtificialSwarmWarnings(checkpoints);
+
+      expect(warnings.find(w => w.code === 'lateQueenCellCheck')).toBeUndefined();
+    });
+
+    it('emits unsafeCheckpointSpacing warning when gap is less than 5 days', () => {
+      const checkpoints: Pick<ArtificialSwarmCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-06-01') },
+        { id: 'queenCellCheck', date: new Date('2025-06-05') }, // 4 days gap
+        { id: 'secondQueenCellCheck', date: new Date('2025-06-12') },
+        { id: 'colonyReview', date: new Date('2025-06-19') },
+      ];
+
+      const warnings = getArtificialSwarmWarnings(checkpoints);
+
+      expect(warnings).toContainEqual({
+        code: 'unsafeCheckpointSpacing',
+        checkpointIds: ['setup', 'queenCellCheck'],
+      });
+    });
+
+    it('emits unsafeCheckpointSpacing warning when gap is more than 10 days', () => {
+      const checkpoints: Pick<ArtificialSwarmCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-06-01') },
+        { id: 'queenCellCheck', date: new Date('2025-06-08') },
+        { id: 'secondQueenCellCheck', date: new Date('2025-06-20') }, // 12 days gap
+        { id: 'colonyReview', date: new Date('2025-06-27') },
+      ];
+
+      const warnings = getArtificialSwarmWarnings(checkpoints);
+
+      expect(warnings).toContainEqual({
+        code: 'unsafeCheckpointSpacing',
+        checkpointIds: ['queenCellCheck', 'secondQueenCellCheck'],
+      });
+    });
+
+    it('emits illogicalScheduleOrder warning when dates are out of order', () => {
+      const checkpoints: Pick<ArtificialSwarmCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-06-01') },
+        { id: 'queenCellCheck', date: new Date('2025-06-08') },
+        { id: 'secondQueenCellCheck', date: new Date('2025-06-07') }, // Before previous
+        { id: 'colonyReview', date: new Date('2025-06-22') },
+      ];
+
+      const warnings = getArtificialSwarmWarnings(checkpoints);
+
+      expect(warnings).toContainEqual({
+        code: 'illogicalScheduleOrder',
+        checkpointIds: ['queenCellCheck', 'secondQueenCellCheck'],
+      });
+    });
+
+    it('returns empty array when no warnings are triggered', () => {
+      const checkpoints: Pick<ArtificialSwarmCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-06-01') },
+        { id: 'queenCellCheck', date: new Date('2025-06-08') }, // 7 days
+        { id: 'secondQueenCellCheck', date: new Date('2025-06-15') }, // 7 days
+        { id: 'colonyReview', date: new Date('2025-06-22') }, // 7 days
+      ];
+
+      const warnings = getArtificialSwarmWarnings(checkpoints);
+
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});

--- a/apps/frontend/src/pages/tools/__tests__/pagden-planner.test.ts
+++ b/apps/frontend/src/pages/tools/__tests__/pagden-planner.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generatePagdenPlan,
+  getPagdenWarnings,
+  type PagdenCheckpointPlan,
+} from '../pagden-planner';
+
+describe('Pagden Planner', () => {
+  describe('generatePagdenPlan', () => {
+    it('generates 4 checkpoints at correct day offsets (0, 7, 14, 21)', () => {
+      const startDate = new Date('2025-05-01');
+      const plan = generatePagdenPlan(startDate);
+
+      expect(plan).toHaveLength(4);
+      expect(plan[0].dayOffset).toBe(0);
+      expect(plan[1].dayOffset).toBe(7);
+      expect(plan[2].dayOffset).toBe(14);
+      expect(plan[3].dayOffset).toBe(21);
+    });
+
+    it('generates correct dates for known start date', () => {
+      const startDate = new Date('2025-05-01');
+      const plan = generatePagdenPlan(startDate);
+
+      expect(plan[0].date.toISOString().split('T')[0]).toBe('2025-05-01');
+      expect(plan[1].date.toISOString().split('T')[0]).toBe('2025-05-08');
+      expect(plan[2].date.toISOString().split('T')[0]).toBe('2025-05-15');
+      expect(plan[3].date.toISOString().split('T')[0]).toBe('2025-05-22');
+    });
+
+    it('includes correct checkpoint IDs', () => {
+      const startDate = new Date('2025-05-01');
+      const plan = generatePagdenPlan(startDate);
+
+      expect(plan[0].id).toBe('setup');
+      expect(plan[1].id).toBe('queenCellCheck');
+      expect(plan[2].id).toBe('secondQueenCellCheck');
+      expect(plan[3].id).toBe('colonyReview');
+    });
+
+    it('includes i18n keys for each checkpoint', () => {
+      const startDate = new Date('2025-05-01');
+      const plan = generatePagdenPlan(startDate);
+
+      plan.forEach(checkpoint => {
+        expect(checkpoint.titleKey).toContain('swarmManagement.pagden.planner.checkpoints');
+        expect(checkpoint.summaryKey).toContain('swarmManagement.pagden.planner.checkpoints');
+        expect(checkpoint.checklistKeys.length).toBeGreaterThan(0);
+        checkpoint.checklistKeys.forEach(key => {
+          expect(key).toContain('swarmManagement.pagden.planner.checkpoints');
+        });
+      });
+    });
+  });
+
+  describe('getPagdenWarnings', () => {
+    it('emits lateQueenCellCheck warning when gap exceeds 8 days', () => {
+      const checkpoints: Pick<PagdenCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-05-01') },
+        { id: 'queenCellCheck', date: new Date('2025-05-10') }, // 9 days gap
+        { id: 'secondQueenCellCheck', date: new Date('2025-05-17') },
+        { id: 'colonyReview', date: new Date('2025-05-24') },
+      ];
+
+      const warnings = getPagdenWarnings(checkpoints);
+
+      expect(warnings).toContainEqual({
+        code: 'lateQueenCellCheck',
+        checkpointIds: ['setup', 'queenCellCheck'],
+      });
+    });
+
+    it('does not emit lateQueenCellCheck warning when gap is 8 days or less', () => {
+      const checkpoints: Pick<PagdenCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-05-01') },
+        { id: 'queenCellCheck', date: new Date('2025-05-09') }, // 8 days gap
+        { id: 'secondQueenCellCheck', date: new Date('2025-05-16') },
+        { id: 'colonyReview', date: new Date('2025-05-23') },
+      ];
+
+      const warnings = getPagdenWarnings(checkpoints);
+
+      expect(warnings.find(w => w.code === 'lateQueenCellCheck')).toBeUndefined();
+    });
+
+    it('emits unsafeCheckpointSpacing warning when gap is less than 5 days', () => {
+      const checkpoints: Pick<PagdenCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-05-01') },
+        { id: 'queenCellCheck', date: new Date('2025-05-05') }, // 4 days gap
+        { id: 'secondQueenCellCheck', date: new Date('2025-05-12') },
+        { id: 'colonyReview', date: new Date('2025-05-19') },
+      ];
+
+      const warnings = getPagdenWarnings(checkpoints);
+
+      expect(warnings).toContainEqual({
+        code: 'unsafeCheckpointSpacing',
+        checkpointIds: ['setup', 'queenCellCheck'],
+      });
+    });
+
+    it('emits unsafeCheckpointSpacing warning when gap is more than 10 days', () => {
+      const checkpoints: Pick<PagdenCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-05-01') },
+        { id: 'queenCellCheck', date: new Date('2025-05-08') },
+        { id: 'secondQueenCellCheck', date: new Date('2025-05-20') }, // 12 days gap
+        { id: 'colonyReview', date: new Date('2025-05-27') },
+      ];
+
+      const warnings = getPagdenWarnings(checkpoints);
+
+      expect(warnings).toContainEqual({
+        code: 'unsafeCheckpointSpacing',
+        checkpointIds: ['queenCellCheck', 'secondQueenCellCheck'],
+      });
+    });
+
+    it('emits illogicalScheduleOrder warning when dates are out of order', () => {
+      const checkpoints: Pick<PagdenCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-05-01') },
+        { id: 'queenCellCheck', date: new Date('2025-05-08') },
+        { id: 'secondQueenCellCheck', date: new Date('2025-05-07') }, // Before previous
+        { id: 'colonyReview', date: new Date('2025-05-22') },
+      ];
+
+      const warnings = getPagdenWarnings(checkpoints);
+
+      expect(warnings).toContainEqual({
+        code: 'illogicalScheduleOrder',
+        checkpointIds: ['queenCellCheck', 'secondQueenCellCheck'],
+      });
+    });
+
+    it('returns empty array when no warnings are triggered', () => {
+      const checkpoints: Pick<PagdenCheckpointPlan, 'id' | 'date'>[] = [
+        { id: 'setup', date: new Date('2025-05-01') },
+        { id: 'queenCellCheck', date: new Date('2025-05-08') }, // 7 days
+        { id: 'secondQueenCellCheck', date: new Date('2025-05-15') }, // 7 days
+        { id: 'colonyReview', date: new Date('2025-05-22') }, // 7 days
+      ];
+
+      const warnings = getPagdenWarnings(checkpoints);
+
+      expect(warnings).toHaveLength(0);
+    });
+  });
+});

--- a/apps/frontend/src/pages/tools/__tests__/swarm-management-i18n.test.ts
+++ b/apps/frontend/src/pages/tools/__tests__/swarm-management-i18n.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import enCommon from '../../../../public/locales/en/common.json';
+import deCommon from '../../../../public/locales/de/common.json';
+import frCommon from '../../../../public/locales/fr/common.json';
+import esCommon from '../../../../public/locales/es/common.json';
+import itCommon from '../../../../public/locales/it/common.json';
+import nlCommon from '../../../../public/locales/nl/common.json';
+import daCommon from '../../../../public/locales/da/common.json';
+import skCommon from '../../../../public/locales/sk/common.json';
+import srCommon from '../../../../public/locales/sr/common.json';
+import { PAGDEN_CHECKPOINTS } from '../pagden-planner';
+import { ARTIFICIAL_SWARM_CHECKPOINTS } from '../artificial-swarm-planner';
+
+describe('Swarm Management i18n Keys', () => {
+  const nonEnglishLocales = [
+    { name: 'de', data: deCommon },
+    { name: 'fr', data: frCommon },
+    { name: 'es', data: esCommon },
+    { name: 'it', data: itCommon },
+    { name: 'nl', data: nlCommon },
+    { name: 'da', data: daCommon },
+    { name: 'sk', data: skCommon },
+    { name: 'sr', data: srCommon },
+  ];
+
+  describe('Pagden i18n keys', () => {
+    it('has all required Pagden keys in English locale', () => {
+      expect(enCommon.swarmManagement.pagden).toBeDefined();
+      expect(enCommon.swarmManagement.pagden.title).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.description).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.intro).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.overviewTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.prerequisitesTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.stepsTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.followUpTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.prosConsTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.faq).toBeDefined();
+      expect(enCommon.swarmManagement.pagden.faq.items).toHaveLength(4);
+    });
+
+    it('has all Pagden planner checkpoint keys in English locale', () => {
+      PAGDEN_CHECKPOINTS.forEach(checkpoint => {
+        const titlePath = checkpoint.titleKey.replace('swarmManagement.pagden.planner.checkpoints.', '');
+        const summaryPath = checkpoint.summaryKey.replace('swarmManagement.pagden.planner.checkpoints.', '');
+        
+        // @ts-expect-error - dynamic path access
+        expect(enCommon.swarmManagement.pagden.planner.checkpoints[checkpoint.id]).toBeDefined();
+        // @ts-expect-error - dynamic path access
+        expect(enCommon.swarmManagement.pagden.planner.checkpoints[checkpoint.id].title).toBeTruthy();
+        // @ts-expect-error - dynamic path access
+        expect(enCommon.swarmManagement.pagden.planner.checkpoints[checkpoint.id].summary).toBeTruthy();
+        // @ts-expect-error - dynamic path access
+        expect(enCommon.swarmManagement.pagden.planner.checkpoints[checkpoint.id].checklist).toHaveLength(3);
+      });
+    });
+
+    it('has Pagden planner metadata keys in English locale', () => {
+      expect(enCommon.swarmManagement.pagden.planner.title).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.planner.description).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.planner.checkpointPrefix).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.planner.notesChecklistLabel).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.planner.savedSuccess).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.planner.savedPartial).toBeTruthy();
+      expect(enCommon.swarmManagement.pagden.planner.savedError).toBeTruthy();
+    });
+
+    it('has Pagden keys as empty strings in non-English locales', () => {
+      nonEnglishLocales.forEach(locale => {
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.pagden).toBeDefined();
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.pagden.title).toBe('');
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.pagden.description).toBe('');
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.pagden.planner.checkpointPrefix).toBe('');
+      });
+    });
+  });
+
+  describe('Artificial Swarm i18n keys', () => {
+    it('has all required Artificial Swarm keys in English locale', () => {
+      expect(enCommon.swarmManagement.artificialSwarm).toBeDefined();
+      expect(enCommon.swarmManagement.artificialSwarm.title).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.description).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.intro).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.overviewTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.prerequisitesTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.stepsTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.followUpTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.prosConsTitle).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.faq).toBeDefined();
+      expect(enCommon.swarmManagement.artificialSwarm.faq.items).toHaveLength(4);
+    });
+
+    it('has all Artificial Swarm planner checkpoint keys in English locale', () => {
+      ARTIFICIAL_SWARM_CHECKPOINTS.forEach(checkpoint => {
+        // @ts-expect-error - dynamic path access
+        expect(enCommon.swarmManagement.artificialSwarm.planner.checkpoints[checkpoint.id]).toBeDefined();
+        // @ts-expect-error - dynamic path access
+        expect(enCommon.swarmManagement.artificialSwarm.planner.checkpoints[checkpoint.id].title).toBeTruthy();
+        // @ts-expect-error - dynamic path access
+        expect(enCommon.swarmManagement.artificialSwarm.planner.checkpoints[checkpoint.id].summary).toBeTruthy();
+        // @ts-expect-error - dynamic path access
+        expect(enCommon.swarmManagement.artificialSwarm.planner.checkpoints[checkpoint.id].checklist).toHaveLength(3);
+      });
+    });
+
+    it('has Artificial Swarm planner metadata keys in English locale', () => {
+      expect(enCommon.swarmManagement.artificialSwarm.planner.title).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.planner.description).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.planner.checkpointPrefix).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.planner.notesChecklistLabel).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.planner.savedSuccess).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.planner.savedPartial).toBeTruthy();
+      expect(enCommon.swarmManagement.artificialSwarm.planner.savedError).toBeTruthy();
+    });
+
+    it('has Artificial Swarm keys as empty strings in non-English locales', () => {
+      nonEnglishLocales.forEach(locale => {
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.artificialSwarm).toBeDefined();
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.artificialSwarm.title).toBe('');
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.artificialSwarm.description).toBe('');
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.artificialSwarm.planner.checkpointPrefix).toBe('');
+      });
+    });
+  });
+
+  describe('Overview page i18n keys', () => {
+    it('has Pagden card keys in English locale', () => {
+      expect(enCommon.swarmManagement.cards.pagden.title).toBeTruthy();
+      expect(enCommon.swarmManagement.cards.pagden.description).toBeTruthy();
+      expect(enCommon.swarmManagement.cards.pagden.detail).toBeTruthy();
+      expect(enCommon.swarmManagement.cards.pagden.cta).toBeTruthy();
+    });
+
+    it('has Artificial Swarm card keys in English locale', () => {
+      expect(enCommon.swarmManagement.cards.artificialSwarm.title).toBeTruthy();
+      expect(enCommon.swarmManagement.cards.artificialSwarm.description).toBeTruthy();
+      expect(enCommon.swarmManagement.cards.artificialSwarm.detail).toBeTruthy();
+      expect(enCommon.swarmManagement.cards.artificialSwarm.cta).toBeTruthy();
+    });
+
+    it('has Dave Cushman attribution keys in English locale', () => {
+      expect(enCommon.swarmManagement.cushmanCredit.text).toBeTruthy();
+      expect(enCommon.swarmManagement.cushmanCredit.linkLabel).toBeTruthy();
+    });
+
+    it('has Dave Cushman attribution keys as empty strings in non-English locales', () => {
+      nonEnglishLocales.forEach(locale => {
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.cushmanCredit.text).toBe('');
+        // @ts-expect-error - dynamic locale access
+        expect(locale.data.swarmManagement.cushmanCredit.linkLabel).toBe('');
+      });
+    });
+  });
+
+  describe('Content verification', () => {
+    it('Pagden overview mentions queen moved to new hive on original stand', () => {
+      const overviewText = JSON.stringify(enCommon.swarmManagement.pagden.overviewPoints).toLowerCase();
+      expect(overviewText).toContain('queen');
+      expect(overviewText).toContain('original stand');
+    });
+
+    it('Pagden Day 0 checklist mentions relocating queen', () => {
+      const setupChecklist = enCommon.swarmManagement.pagden.planner.checkpoints.setup.checklist;
+      const checklistText = setupChecklist.join(' ').toLowerCase();
+      expect(checklistText).toContain('queen');
+      expect(checklistText).toContain('original stand');
+    });
+
+    it('Artificial Swarm overview mentions queen NOT moved', () => {
+      const overviewText = JSON.stringify(enCommon.swarmManagement.artificialSwarm.overviewPoints).toLowerCase();
+      expect(overviewText).toContain('queen');
+      expect(overviewText).toContain('parent');
+    });
+
+    it('Artificial Swarm Day 0 checklist mentions moving frame with queen cell', () => {
+      const setupChecklist = enCommon.swarmManagement.artificialSwarm.planner.checkpoints.setup.checklist;
+      const checklistText = setupChecklist.join(' ').toLowerCase();
+      expect(checklistText).toContain('queen cell');
+      expect(checklistText).toContain('frame');
+    });
+
+    it('Artificial Swarm description mentions queen cannot be found use case', () => {
+      const description = enCommon.swarmManagement.artificialSwarm.description.toLowerCase();
+      const intro = enCommon.swarmManagement.artificialSwarm.intro.toLowerCase();
+      const combined = description + ' ' + intro;
+      expect(combined).toContain('queen');
+    });
+  });
+});

--- a/apps/frontend/src/pages/tools/__tests__/swarm-management-i18n.test.ts
+++ b/apps/frontend/src/pages/tools/__tests__/swarm-management-i18n.test.ts
@@ -40,9 +40,6 @@ describe('Swarm Management i18n Keys', () => {
 
     it('has all Pagden planner checkpoint keys in English locale', () => {
       PAGDEN_CHECKPOINTS.forEach(checkpoint => {
-        const titlePath = checkpoint.titleKey.replace('swarmManagement.pagden.planner.checkpoints.', '');
-        const summaryPath = checkpoint.summaryKey.replace('swarmManagement.pagden.planner.checkpoints.', '');
-        
         // @ts-expect-error - dynamic path access
         expect(enCommon.swarmManagement.pagden.planner.checkpoints[checkpoint.id]).toBeDefined();
         // @ts-expect-error - dynamic path access

--- a/apps/frontend/src/pages/tools/__tests__/swarm-management-i18n.test.ts
+++ b/apps/frontend/src/pages/tools/__tests__/swarm-management-i18n.test.ts
@@ -11,16 +11,26 @@ import srCommon from '../../../../public/locales/sr/common.json';
 import { PAGDEN_CHECKPOINTS } from '../pagden-planner';
 import { ARTIFICIAL_SWARM_CHECKPOINTS } from '../artificial-swarm-planner';
 
+// Cast locale data to a loosely-typed record so dynamic property access
+// in tests does not require @ts-expect-error suppressions.
+type LocaleData = Record<string, unknown>;
+const asLocale = (data: unknown): LocaleData => data as LocaleData;
+const get = (obj: unknown, ...keys: string[]): unknown =>
+  keys.reduce(
+    (acc, key) => (acc != null ? (acc as LocaleData)[key] : undefined),
+    obj,
+  );
+
 describe('Swarm Management i18n Keys', () => {
   const nonEnglishLocales = [
-    { name: 'de', data: deCommon },
-    { name: 'fr', data: frCommon },
-    { name: 'es', data: esCommon },
-    { name: 'it', data: itCommon },
-    { name: 'nl', data: nlCommon },
-    { name: 'da', data: daCommon },
-    { name: 'sk', data: skCommon },
-    { name: 'sr', data: srCommon },
+    { name: 'de', data: asLocale(deCommon) },
+    { name: 'fr', data: asLocale(frCommon) },
+    { name: 'es', data: asLocale(esCommon) },
+    { name: 'it', data: asLocale(itCommon) },
+    { name: 'nl', data: asLocale(nlCommon) },
+    { name: 'da', data: asLocale(daCommon) },
+    { name: 'sk', data: asLocale(skCommon) },
+    { name: 'sr', data: asLocale(srCommon) },
   ];
 
   describe('Pagden i18n keys', () => {
@@ -39,15 +49,15 @@ describe('Swarm Management i18n Keys', () => {
     });
 
     it('has all Pagden planner checkpoint keys in English locale', () => {
+      const checkpoints = asLocale(
+        enCommon.swarmManagement.pagden.planner.checkpoints,
+      );
       PAGDEN_CHECKPOINTS.forEach(checkpoint => {
-        // @ts-expect-error - dynamic path access
-        expect(enCommon.swarmManagement.pagden.planner.checkpoints[checkpoint.id]).toBeDefined();
-        // @ts-expect-error - dynamic path access
-        expect(enCommon.swarmManagement.pagden.planner.checkpoints[checkpoint.id].title).toBeTruthy();
-        // @ts-expect-error - dynamic path access
-        expect(enCommon.swarmManagement.pagden.planner.checkpoints[checkpoint.id].summary).toBeTruthy();
-        // @ts-expect-error - dynamic path access
-        expect(enCommon.swarmManagement.pagden.planner.checkpoints[checkpoint.id].checklist).toHaveLength(3);
+        const cp = asLocale(checkpoints[checkpoint.id]);
+        expect(cp).toBeDefined();
+        expect(cp['title']).toBeTruthy();
+        expect(cp['summary']).toBeTruthy();
+        expect(cp['checklist']).toHaveLength(3);
       });
     });
 
@@ -63,14 +73,13 @@ describe('Swarm Management i18n Keys', () => {
 
     it('has Pagden keys as empty strings in non-English locales', () => {
       nonEnglishLocales.forEach(locale => {
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.pagden).toBeDefined();
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.pagden.title).toBe('');
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.pagden.description).toBe('');
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.pagden.planner.checkpointPrefix).toBe('');
+        const pagden = asLocale(get(locale.data, 'swarmManagement', 'pagden'));
+        expect(pagden).toBeDefined();
+        expect(pagden['title']).toBe('');
+        expect(pagden['description']).toBe('');
+        expect(
+          get(locale.data, 'swarmManagement', 'pagden', 'planner', 'checkpointPrefix'),
+        ).toBe('');
       });
     });
   });
@@ -91,15 +100,15 @@ describe('Swarm Management i18n Keys', () => {
     });
 
     it('has all Artificial Swarm planner checkpoint keys in English locale', () => {
+      const checkpoints = asLocale(
+        enCommon.swarmManagement.artificialSwarm.planner.checkpoints,
+      );
       ARTIFICIAL_SWARM_CHECKPOINTS.forEach(checkpoint => {
-        // @ts-expect-error - dynamic path access
-        expect(enCommon.swarmManagement.artificialSwarm.planner.checkpoints[checkpoint.id]).toBeDefined();
-        // @ts-expect-error - dynamic path access
-        expect(enCommon.swarmManagement.artificialSwarm.planner.checkpoints[checkpoint.id].title).toBeTruthy();
-        // @ts-expect-error - dynamic path access
-        expect(enCommon.swarmManagement.artificialSwarm.planner.checkpoints[checkpoint.id].summary).toBeTruthy();
-        // @ts-expect-error - dynamic path access
-        expect(enCommon.swarmManagement.artificialSwarm.planner.checkpoints[checkpoint.id].checklist).toHaveLength(3);
+        const cp = asLocale(checkpoints[checkpoint.id]);
+        expect(cp).toBeDefined();
+        expect(cp['title']).toBeTruthy();
+        expect(cp['summary']).toBeTruthy();
+        expect(cp['checklist']).toHaveLength(3);
       });
     });
 
@@ -115,14 +124,21 @@ describe('Swarm Management i18n Keys', () => {
 
     it('has Artificial Swarm keys as empty strings in non-English locales', () => {
       nonEnglishLocales.forEach(locale => {
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.artificialSwarm).toBeDefined();
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.artificialSwarm.title).toBe('');
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.artificialSwarm.description).toBe('');
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.artificialSwarm.planner.checkpointPrefix).toBe('');
+        const as = asLocale(
+          get(locale.data, 'swarmManagement', 'artificialSwarm'),
+        );
+        expect(as).toBeDefined();
+        expect(as['title']).toBe('');
+        expect(as['description']).toBe('');
+        expect(
+          get(
+            locale.data,
+            'swarmManagement',
+            'artificialSwarm',
+            'planner',
+            'checkpointPrefix',
+          ),
+        ).toBe('');
       });
     });
   });
@@ -149,46 +165,56 @@ describe('Swarm Management i18n Keys', () => {
 
     it('has Dave Cushman attribution keys as empty strings in non-English locales', () => {
       nonEnglishLocales.forEach(locale => {
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.cushmanCredit.text).toBe('');
-        // @ts-expect-error - dynamic locale access
-        expect(locale.data.swarmManagement.cushmanCredit.linkLabel).toBe('');
+        expect(
+          get(locale.data, 'swarmManagement', 'cushmanCredit', 'text'),
+        ).toBe('');
+        expect(
+          get(locale.data, 'swarmManagement', 'cushmanCredit', 'linkLabel'),
+        ).toBe('');
       });
     });
   });
 
   describe('Content verification', () => {
     it('Pagden overview mentions queen moved to new hive on original stand', () => {
-      const overviewText = JSON.stringify(enCommon.swarmManagement.pagden.overviewPoints).toLowerCase();
+      const overviewText = JSON.stringify(
+        enCommon.swarmManagement.pagden.overviewPoints,
+      ).toLowerCase();
       expect(overviewText).toContain('queen');
       expect(overviewText).toContain('original stand');
     });
 
     it('Pagden Day 0 checklist mentions relocating queen', () => {
-      const setupChecklist = enCommon.swarmManagement.pagden.planner.checkpoints.setup.checklist;
+      const setupChecklist =
+        enCommon.swarmManagement.pagden.planner.checkpoints.setup.checklist;
       const checklistText = setupChecklist.join(' ').toLowerCase();
       expect(checklistText).toContain('queen');
       expect(checklistText).toContain('original stand');
     });
 
     it('Artificial Swarm overview mentions queen NOT moved', () => {
-      const overviewText = JSON.stringify(enCommon.swarmManagement.artificialSwarm.overviewPoints).toLowerCase();
+      const overviewText = JSON.stringify(
+        enCommon.swarmManagement.artificialSwarm.overviewPoints,
+      ).toLowerCase();
       expect(overviewText).toContain('queen');
       expect(overviewText).toContain('parent');
     });
 
     it('Artificial Swarm Day 0 checklist mentions moving frame with queen cell', () => {
-      const setupChecklist = enCommon.swarmManagement.artificialSwarm.planner.checkpoints.setup.checklist;
+      const setupChecklist =
+        enCommon.swarmManagement.artificialSwarm.planner.checkpoints.setup
+          .checklist;
       const checklistText = setupChecklist.join(' ').toLowerCase();
       expect(checklistText).toContain('queen cell');
       expect(checklistText).toContain('frame');
     });
 
     it('Artificial Swarm description mentions queen cannot be found use case', () => {
-      const description = enCommon.swarmManagement.artificialSwarm.description.toLowerCase();
-      const intro = enCommon.swarmManagement.artificialSwarm.intro.toLowerCase();
-      const combined = description + ' ' + intro;
-      expect(combined).toContain('queen');
+      const description =
+        enCommon.swarmManagement.artificialSwarm.description.toLowerCase();
+      const intro =
+        enCommon.swarmManagement.artificialSwarm.intro.toLowerCase();
+      expect(description + ' ' + intro).toContain('queen');
     });
   });
 });

--- a/apps/frontend/src/pages/tools/artificial-swarm-method-page.tsx
+++ b/apps/frontend/src/pages/tools/artificial-swarm-method-page.tsx
@@ -1,262 +1,43 @@
-import { useMemo, useState } from 'react';
-import {
-  AlertTriangle,
-  CalendarClock,
-  ShieldAlert,
-  Waypoints,
-} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
-import { InspectionStatus, type HiveResponse } from 'shared-schemas';
-import { useCreateInspection, useHives } from '@/api/hooks';
-import { useAuth } from '@/context/auth-context';
+import { ToolMeta, buildFaqJsonLd, type FaqItem } from '@/components/tool-page';
 import {
-  MainContent,
-  PageAside,
-  PageGrid,
-} from '@/components/layout/page-grid-layout';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Textarea } from '@/components/ui/textarea';
-import { DatePickerPopover } from '@/components/common/date-picker-popover';
-import {
-  CalloutCard,
-  DotList,
-  ToolMeta,
-  ToolPageHeader,
-  ToolFaq,
-  buildFaqJsonLd,
-  type FaqItem,
-} from '@/components/tool-page';
-import { useLocalizedPath } from '@/hooks/use-language-navigation';
-import { cn } from '@/lib/utils';
-import { toInspectionDateISOString } from '@/utils/inspection-date';
-import {
-  type ArtificialSwarmCheckpointPlan,
-  type ArtificialSwarmWarning,
-  type ArtificialSwarmWarningCode,
   generateArtificialSwarmPlan,
   getArtificialSwarmWarnings,
 } from './artificial-swarm-planner';
-
-type EditableCheckpoint = ArtificialSwarmCheckpointPlan & {
-  notes: string;
-};
-
-const warningVariantClasses: Record<ArtificialSwarmWarningCode, string> = {
-  lateQueenCellCheck: 'border-amber-300 bg-amber-50 dark:bg-amber-950/30',
-  unsafeCheckpointSpacing: 'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
-  illogicalScheduleOrder: 'border-red-300 bg-red-50 dark:bg-red-950/30',
-};
-
-function buildCheckpointNotes(
-  checkpoint: ArtificialSwarmCheckpointPlan,
-  t: (key: string, options?: Record<string, unknown>) => string,
-) {
-  const checklist = checkpoint.checklistKeys.map(key => `- ${t(key)}`).join('\n');
-
-  return [
-    `${t('swarmManagement.artificialSwarm.planner.checkpointPrefix')} ${t(checkpoint.titleKey)}`,
-    t(checkpoint.summaryKey),
-    '',
-    t('swarmManagement.artificialSwarm.planner.notesChecklistLabel'),
-    checklist,
-  ].join('\n');
-}
-
-function WarningSummary({
-  warning,
-  t,
-}: Readonly<{
-  warning: ArtificialSwarmWarning;
-  t: (key: string, options?: Record<string, unknown>) => string;
-}>) {
-  return (
-    <div
-      className={cn(
-        'rounded-lg border p-3',
-        warningVariantClasses[warning.code],
-      )}
-    >
-      <p className="font-medium">
-        {t(`swarmManagement.warnings.${warning.code}.title`)}
-      </p>
-      <p className="mt-1 text-sm text-muted-foreground">
-        {t(`swarmManagement.warnings.${warning.code}.description`)}
-      </p>
-    </div>
-  );
-}
+import {
+  SwarmMethodPageLayout,
+  type CheckpointPlan,
+  type CheckpointWarning,
+} from './swarm-method-page-layout';
 
 const METHOD_DETAIL_SECTIONS = [
   {
     id: 'preparation',
-    items: [0, 1] as number[],
+    items: [0, 1],
     children: {} as Record<number, number[]>,
   },
   {
     id: 'relocateQueen',
-    items: [0, 1, 2] as number[],
+    items: [0, 1, 2],
     children: {} as Record<number, number[]>,
   },
   {
     id: 'queenCells',
-    items: [0, 1, 2] as number[],
+    items: [0, 1, 2],
     children: {} as Record<number, number[]>,
   },
   {
     id: 'reassembly',
-    items: [0, 1, 2] as number[],
+    items: [0, 1, 2],
     children: {} as Record<number, number[]>,
   },
 ];
 
-export function ArtificialSwarmMethodPage() {
+function ArtificialSwarmToolMeta() {
   const { t } = useTranslation('common');
-  const navigate = useNavigate();
-  const localize = useLocalizedPath();
-  const { isLoggedIn } = useAuth();
-  const { data: hives = [], isLoading: isLoadingHives } = useHives();
-  const { mutateAsync: createInspection, isPending: isSaving } =
-    useCreateInspection();
-
-  const [selectedHiveId, setSelectedHiveId] = useState<string>('');
-  const [startDate, setStartDate] = useState<Date | undefined>();
-  const [checkpoints, setCheckpoints] = useState<EditableCheckpoint[]>([]);
-
-  const warnings = useMemo(() => getArtificialSwarmWarnings(checkpoints), [checkpoints]);
-
-  const selectedHive = hives.find(hive => hive.id === selectedHiveId);
-
-  // Visible FAQ and FAQPage structured data share one translated source.
   const faqItems = t('swarmManagement.artificialSwarm.faq.items', {
     returnObjects: true,
   }) as FaqItem[];
-
-  const handleGeneratePlan = () => {
-    if (!startDate) return;
-
-    const nextCheckpoints = generateArtificialSwarmPlan(startDate).map(checkpoint => ({
-      ...checkpoint,
-      notes: buildCheckpointNotes(checkpoint, t),
-    }));
-
-    setCheckpoints(nextCheckpoints);
-  };
-
-  const updateCheckpoint = (
-    checkpointId: EditableCheckpoint['id'],
-    updates: Partial<EditableCheckpoint>,
-  ) => {
-    setCheckpoints(currentCheckpoints =>
-      currentCheckpoints.map(checkpoint =>
-        checkpoint.id === checkpointId
-          ? { ...checkpoint, ...updates }
-          : checkpoint,
-      ),
-    );
-  };
-
-  const getCheckpointWarnings = (checkpointId: EditableCheckpoint['id']) =>
-    warnings.filter(warning => warning.checkpointIds.includes(checkpointId));
-
-  const handleSavePlan = async () => {
-    if (!selectedHiveId || checkpoints.length === 0) return;
-
-    const results = await Promise.allSettled(
-      checkpoints.map(checkpoint =>
-        createInspection({
-          hiveId: selectedHiveId,
-          date: toInspectionDateISOString(checkpoint.date, true),
-          isAllDay: true,
-          notes: checkpoint.notes,
-          status: InspectionStatus.SCHEDULED,
-          actions: [],
-        }),
-      ),
-    );
-
-    const successCount = results.filter(
-      result => result.status === 'fulfilled',
-    ).length;
-    const failedCount = results.length - successCount;
-
-    if (successCount === checkpoints.length) {
-      toast.success(
-        t('swarmManagement.artificialSwarm.planner.savedSuccess', { count: successCount }),
-      );
-      navigate(localize('/inspections/list/upcoming'));
-      return;
-    }
-
-    if (successCount > 0) {
-      toast.warning(
-        t('swarmManagement.artificialSwarm.planner.savedPartial', {
-          successCount,
-          failedCount,
-        }),
-      );
-      navigate(localize('/inspections/list/upcoming'));
-      return;
-    }
-
-    if (failedCount > 0) {
-      toast.error(t('swarmManagement.artificialSwarm.planner.savedError'));
-    }
-  };
-
-  const handleCancel = () => {
-    setCheckpoints([]);
-    navigate(localize('/tools/swarm-management'));
-  };
-
-  const renderHiveSelect = () => {
-    if (isLoadingHives) {
-      return <Skeleton className="h-10 w-full" />;
-    }
-
-    if (hives.length === 0) {
-      return (
-        <p className="text-sm text-muted-foreground">
-          {t('swarmManagement.planner.noHives')}
-        </p>
-      );
-    }
-
-    return (
-      <Select value={selectedHiveId} onValueChange={setSelectedHiveId}>
-        <SelectTrigger>
-          <SelectValue
-            placeholder={t('swarmManagement.planner.hivePlaceholder')}
-          />
-        </SelectTrigger>
-        <SelectContent>
-          {hives.map((hive: HiveResponse) => (
-            <SelectItem key={hive.id} value={hive.id}>
-              {hive.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    );
-  };
 
   const structuredData = {
     '@context': 'https://schema.org',
@@ -293,12 +74,12 @@ export function ArtificialSwarmMethodPage() {
           {
             '@type': 'HowToStep',
             name: 'Move the Parent Colony',
-            text: 'Move the original hive (with the queen) to a new location a few metres away, identify a frame with a queen cell, and knock down any other queen cells.',
+            text: 'Move the original hive (with the queen) to a new location a few metres away. Identify a frame with a queen cell or eggs, and reduce other queen cells on the parent colony.',
           },
           {
             '@type': 'HowToStep',
             name: 'Set Up the New Colony',
-            text: 'Place the new brood box on the original hive floor with the frame containing the queen cell in the centre, and fill with frames of drawn comb.',
+            text: 'Place the new brood box on the original hive floor with the selected brood frame in the centre, and fill with frames of drawn comb.',
           },
           {
             '@type': 'HowToStep',
@@ -313,12 +94,12 @@ export function ArtificialSwarmMethodPage() {
           {
             '@type': 'HowToStep',
             name: 'Follow-up at day 14-15',
-            text: 'Recheck to confirm the queen cell is capped and monitor the parent colony.',
+            text: 'Confirm the queen cell is capped and developing normally. Monitor the parent colony.',
           },
           {
             '@type': 'HowToStep',
             name: 'Follow-up at day 21-22',
-            text: 'Carry out a final review to assess both colonies and decide on next steps for the season.',
+            text: 'Confirm the new queen in the new colony is mated and laying. Assess both colonies and decide on next steps.',
           },
         ],
       },
@@ -327,406 +108,29 @@ export function ArtificialSwarmMethodPage() {
   };
 
   return (
-    <PageGrid>
-      <ToolMeta
-        title="Artificial Swarm Method: Swarm Control Guide and Planner — Hive Pal"
-        description="Free reference guide and inspection planner for the artificial swarm swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
-        ogDescription="Step-by-step artificial swarm method for honey bee swarm control when the queen cannot be found, with follow-up timing and an inspection planner."
-        path="/tools/swarm-management/artificial"
-        structuredData={structuredData}
-      />
+    <ToolMeta
+      title="Artificial Swarm Method: Swarm Control Guide and Planner — Hive Pal"
+      description="Free reference guide and inspection planner for the artificial swarm swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
+      ogDescription="Step-by-step artificial swarm method for honey bee swarm control when the queen cannot be found, with follow-up timing and an inspection planner."
+      path="/tools/swarm-management/artificial"
+      structuredData={structuredData}
+    />
+  );
+}
 
-      <MainContent>
-        <ToolPageHeader
-          title={t('swarmManagement.artificialSwarm.title')}
-          badge={
-            <Badge variant="outline">{t('swarmManagement.artificialSwarm.badge')}</Badge>
-          }
-          description={t('swarmManagement.artificialSwarm.description')}
-          intro={t('swarmManagement.artificialSwarm.intro')}
-          backLink={{
-            to: localize('/tools/swarm-management'),
-            label: t('swarmManagement.backToOverview'),
-          }}
-        />
-
-        <div className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.artificialSwarm.overviewTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 text-sm text-muted-foreground">
-              <p>{t('swarmManagement.artificialSwarm.overviewLead')}</p>
-              <DotList
-                className="space-y-3"
-                items={[0, 1, 2].map(i =>
-                  t(`swarmManagement.artificialSwarm.overviewPoints.${i}`),
-                )}
-              />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.artificialSwarm.prerequisitesTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="list-disc space-y-3 pl-5 text-sm text-muted-foreground marker:text-primary/60">
-                {[0, 1, 2, 3, 4].map(i => (
-                  <li key={i}>{t(`swarmManagement.artificialSwarm.prerequisites.${i}`)}</li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.artificialSwarm.advantagesTitle')}</CardTitle>
-              <CardDescription>
-                {t('swarmManagement.artificialSwarm.advantagesDescription')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <DotList
-                items={[0, 1, 2].map(i =>
-                  t(`swarmManagement.artificialSwarm.advantages.${i}`),
-                )}
-              />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.artificialSwarm.stepsTitle')}</CardTitle>
-              <CardDescription>
-                {t('swarmManagement.artificialSwarm.stepsDescription')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-6 text-sm text-muted-foreground">
-                {METHOD_DETAIL_SECTIONS.map(section => (
-                  <div key={section.id} className="space-y-3">
-                    <h3 className="font-semibold text-foreground">
-                      {t(`swarmManagement.artificialSwarm.methodDetail.${section.id}.title`)}
-                    </h3>
-                    <ul className="list-disc space-y-2 pl-5 marker:text-primary/60">
-                      {section.items.map(itemIndex => (
-                        <li key={itemIndex}>
-                          <span>
-                            {t(
-                              `swarmManagement.artificialSwarm.methodDetail.${section.id}.items.${itemIndex}.text`,
-                            )}
-                          </span>
-                          {(section.children[itemIndex] ?? []).length > 0 && (
-                            <ul className="list-[circle] space-y-2 pl-5 pt-2 marker:text-muted-foreground/60">
-                              {(section.children[itemIndex] ?? []).map(childIndex => (
-                                <li key={childIndex}>
-                                  {t(
-                                    `swarmManagement.artificialSwarm.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
-                                  )}
-                                </li>
-                              ))}
-                            </ul>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.artificialSwarm.followUpTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="overflow-hidden rounded-lg border">
-                <div className="grid grid-cols-[minmax(80px,auto)_1fr] border-b bg-muted/40 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:px-4 sm:text-sm">
-                  <div>{t('swarmManagement.artificialSwarm.followUpDayHeader')}</div>
-                  <div>{t('swarmManagement.artificialSwarm.followUpTaskHeader')}</div>
-                </div>
-                {[0, 1, 2].map(index => (
-                  <div
-                    key={index}
-                    className="grid grid-cols-[minmax(80px,auto)_1fr] gap-3 border-b px-3 py-3 text-sm last:border-b-0 sm:px-4"
-                  >
-                    <div className="font-semibold text-foreground">
-                      {t(`swarmManagement.artificialSwarm.followUp.${index}.day`)}
-                    </div>
-                    <div className="text-muted-foreground">
-                      {t(`swarmManagement.artificialSwarm.followUp.${index}.task`)}
-                    </div>
-                  </div>
-                ))}
-              </div>
-              <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-muted-foreground dark:bg-amber-950/30">
-                <p className="flex items-start gap-2 font-medium text-foreground">
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-                  {t('swarmManagement.aside.criticalTimingTitle')}
-                </p>
-                <p className="mt-2">{t('swarmManagement.aside.criticalTimingLead')}</p>
-                <p className="mt-2">{t('swarmManagement.aside.criticalTimingDetail')}</p>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.artificialSwarm.prosConsTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-4 dark:border-emerald-900/40 dark:bg-emerald-950/20">
-                  <p className="mb-3 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
-                    {t('swarmManagement.artificialSwarm.prosTitle')}
-                  </p>
-                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-emerald-600/60">
-                    {[0, 1, 2, 3, 4].map(i => (
-                      <li key={i}>{t(`swarmManagement.artificialSwarm.pros.${i}`)}</li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="rounded-lg border border-rose-200 bg-rose-50/40 p-4 dark:border-rose-900/40 dark:bg-rose-950/20">
-                  <p className="mb-3 text-sm font-semibold text-rose-900 dark:text-rose-200">
-                    {t('swarmManagement.artificialSwarm.consTitle')}
-                  </p>
-                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-rose-600/60">
-                    {[0, 1, 2, 3, 4].map(i => (
-                      <li key={i}>{t(`swarmManagement.artificialSwarm.cons.${i}`)}</li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.artificialSwarm.planner.title')}</CardTitle>
-              <CardDescription>
-                {t('swarmManagement.artificialSwarm.planner.description')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {!isLoggedIn ? (
-                <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center">
-                  <p className="text-base font-semibold text-foreground">
-                    {t('swarmManagement.planner.signInTitle')}
-                  </p>
-                  <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
-                    {t('swarmManagement.planner.signInDescription')}
-                  </p>
-                  <div className="mt-4 flex flex-col items-center justify-center gap-2 sm:flex-row">
-                    <Button asChild>
-                      <Link to="/login">{t('swarmManagement.planner.signInCta')}</Link>
-                    </Button>
-                    <Button variant="outline" asChild>
-                      <Link to="/register">
-                        {t('swarmManagement.planner.registerCta')}
-                      </Link>
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">
-                        {t('swarmManagement.planner.hiveLabel')}
-                      </p>
-                      {renderHiveSelect()}
-                    </div>
-
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">
-                        {t('swarmManagement.artificialSwarm.planner.startDateLabel')}
-                      </p>
-                      <DatePickerPopover
-                        date={startDate}
-                        onDateChange={setStartDate}
-                        placeholder={t(
-                          'swarmManagement.artificialSwarm.planner.startDatePlaceholder',
-                        )}
-                      />
-                    </div>
-                  </div>
-
-                  <Button
-                    className="w-full sm:w-auto"
-                    onClick={handleGeneratePlan}
-                    disabled={!selectedHiveId || !startDate}
-                  >
-                    {t('swarmManagement.planner.generate')}
-                  </Button>
-
-                  {selectedHive && (
-                    <Alert>
-                      <Waypoints className="h-4 w-4" />
-                      <AlertTitle>
-                        {t('swarmManagement.planner.selectedHive')}
-                      </AlertTitle>
-                      <AlertDescription>{selectedHive.name}</AlertDescription>
-                    </Alert>
-                  )}
-
-                  {warnings.length > 0 && (
-                    <Alert className="border-amber-300 bg-amber-50 dark:bg-amber-950/30">
-                      <AlertTriangle className="h-4 w-4" />
-                      <AlertTitle>
-                        {t('swarmManagement.warnings.bannerTitle')}
-                      </AlertTitle>
-                      <AlertDescription className="mt-3 space-y-3">
-                        {warnings.map(warning => (
-                          <WarningSummary
-                            key={`${warning.code}-${warning.checkpointIds.join('-')}`}
-                            warning={warning}
-                            t={t}
-                          />
-                        ))}
-                      </AlertDescription>
-                    </Alert>
-                  )}
-
-                  {checkpoints.length > 0 ? (
-                    <div className="space-y-4">
-                      {checkpoints.map(checkpoint => {
-                        const checkpointWarnings = getCheckpointWarnings(
-                          checkpoint.id,
-                        );
-
-                        return (
-                          <Card key={checkpoint.id}>
-                            <CardHeader>
-                              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                <div className="min-w-0">
-                                  <CardTitle>{t(checkpoint.titleKey)}</CardTitle>
-                                  <CardDescription>
-                                    {t('swarmManagement.planner.dayOffset', {
-                                      count: checkpoint.dayOffset,
-                                    })}
-                                  </CardDescription>
-                                </div>
-                                <DatePickerPopover
-                                  date={checkpoint.date}
-                                  onDateChange={date => {
-                                    if (date) {
-                                      updateCheckpoint(checkpoint.id, { date });
-                                    }
-                                  }}
-                                  align="end"
-                                  className="w-full sm:w-auto"
-                                />
-                              </div>
-                            </CardHeader>
-                            <CardContent className="space-y-4">
-                              <p className="text-sm text-muted-foreground">
-                                {t(checkpoint.summaryKey)}
-                              </p>
-                              {checkpointWarnings.map(warning => (
-                                <Alert
-                                  key={`${checkpoint.id}-${warning.code}`}
-                                  className={warningVariantClasses[warning.code]}
-                                >
-                                  <ShieldAlert className="h-4 w-4" />
-                                  <AlertTitle>
-                                    {t(
-                                      `swarmManagement.warnings.${warning.code}.title`,
-                                    )}
-                                  </AlertTitle>
-                                  <AlertDescription>
-                                    {t(
-                                      `swarmManagement.warnings.${warning.code}.description`,
-                                    )}
-                                  </AlertDescription>
-                                </Alert>
-                              ))}
-                              <div className="space-y-2">
-                                <p className="text-sm font-medium">
-                                  {t('swarmManagement.planner.notesLabel')}
-                                </p>
-                                <Textarea
-                                  value={checkpoint.notes}
-                                  onChange={event =>
-                                    updateCheckpoint(checkpoint.id, {
-                                      notes: event.target.value,
-                                    })
-                                  }
-                                  rows={8}
-                                />
-                              </div>
-                            </CardContent>
-                          </Card>
-                        );
-                      })}
-
-                      <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                        <Button variant="outline" onClick={handleCancel}>
-                          {t('actions.cancel')}
-                        </Button>
-                        <Button onClick={handleSavePlan} disabled={isSaving}>
-                          {isSaving
-                            ? t('swarmManagement.planner.saving')
-                            : t('swarmManagement.planner.save')}
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
-                      {t('swarmManagement.planner.emptyState')}
-                    </div>
-                  )}
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        <ToolFaq title={t('swarmManagement.artificialSwarm.faq.title')} items={faqItems} />
-      </MainContent>
-
-      <PageAside>
-        <div className="space-y-4 md:sticky md:top-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-base">
-                <CalendarClock className="h-5 w-5 text-primary" />
-                {t('swarmManagement.planner.atAGlanceTitle')}
-              </CardTitle>
-              <CardDescription>
-                {t('swarmManagement.planner.atAGlanceDescription')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <ol className="space-y-3 text-sm">
-                {[0, 1, 2].map(i => (
-                  <li
-                    key={i}
-                    className="flex gap-3 border-b pb-3 last:border-b-0 last:pb-0"
-                  >
-                    <div className="min-w-[68px] font-semibold text-foreground">
-                      {t(`swarmManagement.artificialSwarm.followUp.${i}.day`)}
-                    </div>
-                    <div className="text-muted-foreground">
-                      {t(`swarmManagement.artificialSwarm.followUp.${i}.task`)}
-                    </div>
-                  </li>
-                ))}
-              </ol>
-            </CardContent>
-          </Card>
-
-          <CalloutCard
-            variant="amber"
-            icon={<AlertTriangle className="h-5 w-5" />}
-            title={t('swarmManagement.aside.criticalTimingTitle')}
-          >
-            <p>{t('swarmManagement.aside.criticalTimingLead')}</p>
-            <p>{t('swarmManagement.aside.criticalTimingDetail')}</p>
-          </CalloutCard>
-        </div>
-      </PageAside>
-    </PageGrid>
+export function ArtificialSwarmMethodPage() {
+  return (
+    <SwarmMethodPageLayout
+      ns="swarmManagement.artificialSwarm"
+      plannerNs="swarmManagement.planner"
+      methodPlannerNs="swarmManagement.artificialSwarm.planner"
+      prerequisiteCount={5}
+      prosConsCount={5}
+      methodDetailSections={METHOD_DETAIL_SECTIONS}
+      generatePlan={generateArtificialSwarmPlan as (d: Date) => CheckpointPlan[]}
+      getWarnings={getArtificialSwarmWarnings as (c: CheckpointPlan[]) => CheckpointWarning[]}
+      meta={<ArtificialSwarmToolMeta />}
+      faqI18nKey="swarmManagement.artificialSwarm.faq.items"
+    />
   );
 }

--- a/apps/frontend/src/pages/tools/artificial-swarm-method-page.tsx
+++ b/apps/frontend/src/pages/tools/artificial-swarm-method-page.tsx
@@ -1,0 +1,732 @@
+import { useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CalendarClock,
+  ShieldAlert,
+  Waypoints,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { InspectionStatus, type HiveResponse } from 'shared-schemas';
+import { useCreateInspection, useHives } from '@/api/hooks';
+import { useAuth } from '@/context/auth-context';
+import {
+  MainContent,
+  PageAside,
+  PageGrid,
+} from '@/components/layout/page-grid-layout';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import { DatePickerPopover } from '@/components/common/date-picker-popover';
+import {
+  CalloutCard,
+  DotList,
+  ToolMeta,
+  ToolPageHeader,
+  ToolFaq,
+  buildFaqJsonLd,
+  type FaqItem,
+} from '@/components/tool-page';
+import { useLocalizedPath } from '@/hooks/use-language-navigation';
+import { cn } from '@/lib/utils';
+import { toInspectionDateISOString } from '@/utils/inspection-date';
+import {
+  type ArtificialSwarmCheckpointPlan,
+  type ArtificialSwarmWarning,
+  type ArtificialSwarmWarningCode,
+  generateArtificialSwarmPlan,
+  getArtificialSwarmWarnings,
+} from './artificial-swarm-planner';
+
+type EditableCheckpoint = ArtificialSwarmCheckpointPlan & {
+  notes: string;
+};
+
+const warningVariantClasses: Record<ArtificialSwarmWarningCode, string> = {
+  lateQueenCellCheck: 'border-amber-300 bg-amber-50 dark:bg-amber-950/30',
+  unsafeCheckpointSpacing: 'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
+  illogicalScheduleOrder: 'border-red-300 bg-red-50 dark:bg-red-950/30',
+};
+
+function buildCheckpointNotes(
+  checkpoint: ArtificialSwarmCheckpointPlan,
+  t: (key: string, options?: Record<string, unknown>) => string,
+) {
+  const checklist = checkpoint.checklistKeys.map(key => `- ${t(key)}`).join('\n');
+
+  return [
+    `${t('swarmManagement.artificialSwarm.planner.checkpointPrefix')} ${t(checkpoint.titleKey)}`,
+    t(checkpoint.summaryKey),
+    '',
+    t('swarmManagement.artificialSwarm.planner.notesChecklistLabel'),
+    checklist,
+  ].join('\n');
+}
+
+function WarningSummary({
+  warning,
+  t,
+}: Readonly<{
+  warning: ArtificialSwarmWarning;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}>) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border p-3',
+        warningVariantClasses[warning.code],
+      )}
+    >
+      <p className="font-medium">
+        {t(`swarmManagement.warnings.${warning.code}.title`)}
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {t(`swarmManagement.warnings.${warning.code}.description`)}
+      </p>
+    </div>
+  );
+}
+
+const METHOD_DETAIL_SECTIONS = [
+  {
+    id: 'preparation',
+    items: [0, 1] as number[],
+    children: {} as Record<number, number[]>,
+  },
+  {
+    id: 'relocateQueen',
+    items: [0, 1, 2] as number[],
+    children: {} as Record<number, number[]>,
+  },
+  {
+    id: 'queenCells',
+    items: [0, 1, 2] as number[],
+    children: {} as Record<number, number[]>,
+  },
+  {
+    id: 'reassembly',
+    items: [0, 1, 2] as number[],
+    children: {} as Record<number, number[]>,
+  },
+];
+
+export function ArtificialSwarmMethodPage() {
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const localize = useLocalizedPath();
+  const { isLoggedIn } = useAuth();
+  const { data: hives = [], isLoading: isLoadingHives } = useHives();
+  const { mutateAsync: createInspection, isPending: isSaving } =
+    useCreateInspection();
+
+  const [selectedHiveId, setSelectedHiveId] = useState<string>('');
+  const [startDate, setStartDate] = useState<Date | undefined>();
+  const [checkpoints, setCheckpoints] = useState<EditableCheckpoint[]>([]);
+
+  const warnings = useMemo(() => getArtificialSwarmWarnings(checkpoints), [checkpoints]);
+
+  const selectedHive = hives.find(hive => hive.id === selectedHiveId);
+
+  // Visible FAQ and FAQPage structured data share one translated source.
+  const faqItems = t('swarmManagement.artificialSwarm.faq.items', {
+    returnObjects: true,
+  }) as FaqItem[];
+
+  const handleGeneratePlan = () => {
+    if (!startDate) return;
+
+    const nextCheckpoints = generateArtificialSwarmPlan(startDate).map(checkpoint => ({
+      ...checkpoint,
+      notes: buildCheckpointNotes(checkpoint, t),
+    }));
+
+    setCheckpoints(nextCheckpoints);
+  };
+
+  const updateCheckpoint = (
+    checkpointId: EditableCheckpoint['id'],
+    updates: Partial<EditableCheckpoint>,
+  ) => {
+    setCheckpoints(currentCheckpoints =>
+      currentCheckpoints.map(checkpoint =>
+        checkpoint.id === checkpointId
+          ? { ...checkpoint, ...updates }
+          : checkpoint,
+      ),
+    );
+  };
+
+  const getCheckpointWarnings = (checkpointId: EditableCheckpoint['id']) =>
+    warnings.filter(warning => warning.checkpointIds.includes(checkpointId));
+
+  const handleSavePlan = async () => {
+    if (!selectedHiveId || checkpoints.length === 0) return;
+
+    const results = await Promise.allSettled(
+      checkpoints.map(checkpoint =>
+        createInspection({
+          hiveId: selectedHiveId,
+          date: toInspectionDateISOString(checkpoint.date, true),
+          isAllDay: true,
+          notes: checkpoint.notes,
+          status: InspectionStatus.SCHEDULED,
+          actions: [],
+        }),
+      ),
+    );
+
+    const successCount = results.filter(
+      result => result.status === 'fulfilled',
+    ).length;
+    const failedCount = results.length - successCount;
+
+    if (successCount === checkpoints.length) {
+      toast.success(
+        t('swarmManagement.artificialSwarm.planner.savedSuccess', { count: successCount }),
+      );
+      navigate(localize('/inspections/list/upcoming'));
+      return;
+    }
+
+    if (successCount > 0) {
+      toast.warning(
+        t('swarmManagement.artificialSwarm.planner.savedPartial', {
+          successCount,
+          failedCount,
+        }),
+      );
+      navigate(localize('/inspections/list/upcoming'));
+      return;
+    }
+
+    if (failedCount > 0) {
+      toast.error(t('swarmManagement.artificialSwarm.planner.savedError'));
+    }
+  };
+
+  const handleCancel = () => {
+    setCheckpoints([]);
+    navigate(localize('/tools/swarm-management'));
+  };
+
+  const renderHiveSelect = () => {
+    if (isLoadingHives) {
+      return <Skeleton className="h-10 w-full" />;
+    }
+
+    if (hives.length === 0) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          {t('swarmManagement.planner.noHives')}
+        </p>
+      );
+    }
+
+    return (
+      <Select value={selectedHiveId} onValueChange={setSelectedHiveId}>
+        <SelectTrigger>
+          <SelectValue
+            placeholder={t('swarmManagement.planner.hivePlaceholder')}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          {hives.map((hive: HiveResponse) => (
+            <SelectItem key={hive.id} value={hive.id}>
+              {hive.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  };
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebApplication',
+        name: 'Artificial Swarm Method Guide and Planner',
+        url: 'https://hivepal.app/tools/swarm-management/artificial',
+        applicationCategory: 'EducationalApplication',
+        applicationSubCategory: 'Beekeeping Reference',
+        operatingSystem: 'Web',
+        browserRequirements: 'Requires JavaScript',
+        description:
+          'Reference guide and inspection planner for the artificial swarm swarm-control method, with prerequisites, step-by-step instructions, pros/cons, and follow-up timing.',
+        isAccessibleForFree: true,
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        publisher: {
+          '@type': 'Organization',
+          name: 'Hive Pal',
+          url: 'https://hivepal.app',
+        },
+      },
+      {
+        '@type': 'HowTo',
+        name: 'How to perform the artificial swarm method',
+        description:
+          'Step-by-step artificial swarm procedure for relieving swarm pressure by moving the parent colony aside while placing a new hive on the original stand with a frame containing a queen cell.',
+        step: [
+          {
+            '@type': 'HowToStep',
+            name: 'Preparation',
+            text: 'Find a spare brood box with drawn comb and prepare a second hive floor and stand positioned a few metres away from the original location.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Move the Parent Colony',
+            text: 'Move the original hive (with the queen) to a new location a few metres away, identify a frame with a queen cell, and knock down any other queen cells.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Set Up the New Colony',
+            text: 'Place the new brood box on the original hive floor with the frame containing the queen cell in the centre, and fill with frames of drawn comb.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Reassembly',
+            text: 'Place a queen excluder on top of the new hive if adding supers, add supers as needed, and fit crown board and roof on both hives.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Follow-up at day 7-8',
+            text: 'Inspect the new colony to confirm the queen cell is developing and check for any additional queen cells.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Follow-up at day 14-15',
+            text: 'Recheck to confirm the queen cell is capped and monitor the parent colony.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Follow-up at day 21-22',
+            text: 'Carry out a final review to assess both colonies and decide on next steps for the season.',
+          },
+        ],
+      },
+      buildFaqJsonLd(faqItems),
+    ],
+  };
+
+  return (
+    <PageGrid>
+      <ToolMeta
+        title="Artificial Swarm Method: Swarm Control Guide and Planner — Hive Pal"
+        description="Free reference guide and inspection planner for the artificial swarm swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
+        ogDescription="Step-by-step artificial swarm method for honey bee swarm control when the queen cannot be found, with follow-up timing and an inspection planner."
+        path="/tools/swarm-management/artificial"
+        structuredData={structuredData}
+      />
+
+      <MainContent>
+        <ToolPageHeader
+          title={t('swarmManagement.artificialSwarm.title')}
+          badge={
+            <Badge variant="outline">{t('swarmManagement.artificialSwarm.badge')}</Badge>
+          }
+          description={t('swarmManagement.artificialSwarm.description')}
+          intro={t('swarmManagement.artificialSwarm.intro')}
+          backLink={{
+            to: localize('/tools/swarm-management'),
+            label: t('swarmManagement.backToOverview'),
+          }}
+        />
+
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.artificialSwarm.overviewTitle')}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm text-muted-foreground">
+              <p>{t('swarmManagement.artificialSwarm.overviewLead')}</p>
+              <DotList
+                className="space-y-3"
+                items={[0, 1, 2].map(i =>
+                  t(`swarmManagement.artificialSwarm.overviewPoints.${i}`),
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.artificialSwarm.prerequisitesTitle')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc space-y-3 pl-5 text-sm text-muted-foreground marker:text-primary/60">
+                {[0, 1, 2, 3, 4].map(i => (
+                  <li key={i}>{t(`swarmManagement.artificialSwarm.prerequisites.${i}`)}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.artificialSwarm.advantagesTitle')}</CardTitle>
+              <CardDescription>
+                {t('swarmManagement.artificialSwarm.advantagesDescription')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DotList
+                items={[0, 1, 2].map(i =>
+                  t(`swarmManagement.artificialSwarm.advantages.${i}`),
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.artificialSwarm.stepsTitle')}</CardTitle>
+              <CardDescription>
+                {t('swarmManagement.artificialSwarm.stepsDescription')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-6 text-sm text-muted-foreground">
+                {METHOD_DETAIL_SECTIONS.map(section => (
+                  <div key={section.id} className="space-y-3">
+                    <h3 className="font-semibold text-foreground">
+                      {t(`swarmManagement.artificialSwarm.methodDetail.${section.id}.title`)}
+                    </h3>
+                    <ul className="list-disc space-y-2 pl-5 marker:text-primary/60">
+                      {section.items.map(itemIndex => (
+                        <li key={itemIndex}>
+                          <span>
+                            {t(
+                              `swarmManagement.artificialSwarm.methodDetail.${section.id}.items.${itemIndex}.text`,
+                            )}
+                          </span>
+                          {(section.children[itemIndex] ?? []).length > 0 && (
+                            <ul className="list-[circle] space-y-2 pl-5 pt-2 marker:text-muted-foreground/60">
+                              {(section.children[itemIndex] ?? []).map(childIndex => (
+                                <li key={childIndex}>
+                                  {t(
+                                    `swarmManagement.artificialSwarm.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
+                                  )}
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.artificialSwarm.followUpTitle')}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="overflow-hidden rounded-lg border">
+                <div className="grid grid-cols-[minmax(80px,auto)_1fr] border-b bg-muted/40 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:px-4 sm:text-sm">
+                  <div>{t('swarmManagement.artificialSwarm.followUpDayHeader')}</div>
+                  <div>{t('swarmManagement.artificialSwarm.followUpTaskHeader')}</div>
+                </div>
+                {[0, 1, 2].map(index => (
+                  <div
+                    key={index}
+                    className="grid grid-cols-[minmax(80px,auto)_1fr] gap-3 border-b px-3 py-3 text-sm last:border-b-0 sm:px-4"
+                  >
+                    <div className="font-semibold text-foreground">
+                      {t(`swarmManagement.artificialSwarm.followUp.${index}.day`)}
+                    </div>
+                    <div className="text-muted-foreground">
+                      {t(`swarmManagement.artificialSwarm.followUp.${index}.task`)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-muted-foreground dark:bg-amber-950/30">
+                <p className="flex items-start gap-2 font-medium text-foreground">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                  {t('swarmManagement.aside.criticalTimingTitle')}
+                </p>
+                <p className="mt-2">{t('swarmManagement.aside.criticalTimingLead')}</p>
+                <p className="mt-2">{t('swarmManagement.aside.criticalTimingDetail')}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.artificialSwarm.prosConsTitle')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-4 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+                  <p className="mb-3 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+                    {t('swarmManagement.artificialSwarm.prosTitle')}
+                  </p>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-emerald-600/60">
+                    {[0, 1, 2, 3, 4].map(i => (
+                      <li key={i}>{t(`swarmManagement.artificialSwarm.pros.${i}`)}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="rounded-lg border border-rose-200 bg-rose-50/40 p-4 dark:border-rose-900/40 dark:bg-rose-950/20">
+                  <p className="mb-3 text-sm font-semibold text-rose-900 dark:text-rose-200">
+                    {t('swarmManagement.artificialSwarm.consTitle')}
+                  </p>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-rose-600/60">
+                    {[0, 1, 2, 3, 4].map(i => (
+                      <li key={i}>{t(`swarmManagement.artificialSwarm.cons.${i}`)}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.artificialSwarm.planner.title')}</CardTitle>
+              <CardDescription>
+                {t('swarmManagement.artificialSwarm.planner.description')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {!isLoggedIn ? (
+                <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center">
+                  <p className="text-base font-semibold text-foreground">
+                    {t('swarmManagement.planner.signInTitle')}
+                  </p>
+                  <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+                    {t('swarmManagement.planner.signInDescription')}
+                  </p>
+                  <div className="mt-4 flex flex-col items-center justify-center gap-2 sm:flex-row">
+                    <Button asChild>
+                      <Link to="/login">{t('swarmManagement.planner.signInCta')}</Link>
+                    </Button>
+                    <Button variant="outline" asChild>
+                      <Link to="/register">
+                        {t('swarmManagement.planner.registerCta')}
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">
+                        {t('swarmManagement.planner.hiveLabel')}
+                      </p>
+                      {renderHiveSelect()}
+                    </div>
+
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">
+                        {t('swarmManagement.artificialSwarm.planner.startDateLabel')}
+                      </p>
+                      <DatePickerPopover
+                        date={startDate}
+                        onDateChange={setStartDate}
+                        placeholder={t(
+                          'swarmManagement.artificialSwarm.planner.startDatePlaceholder',
+                        )}
+                      />
+                    </div>
+                  </div>
+
+                  <Button
+                    className="w-full sm:w-auto"
+                    onClick={handleGeneratePlan}
+                    disabled={!selectedHiveId || !startDate}
+                  >
+                    {t('swarmManagement.planner.generate')}
+                  </Button>
+
+                  {selectedHive && (
+                    <Alert>
+                      <Waypoints className="h-4 w-4" />
+                      <AlertTitle>
+                        {t('swarmManagement.planner.selectedHive')}
+                      </AlertTitle>
+                      <AlertDescription>{selectedHive.name}</AlertDescription>
+                    </Alert>
+                  )}
+
+                  {warnings.length > 0 && (
+                    <Alert className="border-amber-300 bg-amber-50 dark:bg-amber-950/30">
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertTitle>
+                        {t('swarmManagement.warnings.bannerTitle')}
+                      </AlertTitle>
+                      <AlertDescription className="mt-3 space-y-3">
+                        {warnings.map(warning => (
+                          <WarningSummary
+                            key={`${warning.code}-${warning.checkpointIds.join('-')}`}
+                            warning={warning}
+                            t={t}
+                          />
+                        ))}
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
+                  {checkpoints.length > 0 ? (
+                    <div className="space-y-4">
+                      {checkpoints.map(checkpoint => {
+                        const checkpointWarnings = getCheckpointWarnings(
+                          checkpoint.id,
+                        );
+
+                        return (
+                          <Card key={checkpoint.id}>
+                            <CardHeader>
+                              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                <div className="min-w-0">
+                                  <CardTitle>{t(checkpoint.titleKey)}</CardTitle>
+                                  <CardDescription>
+                                    {t('swarmManagement.planner.dayOffset', {
+                                      count: checkpoint.dayOffset,
+                                    })}
+                                  </CardDescription>
+                                </div>
+                                <DatePickerPopover
+                                  date={checkpoint.date}
+                                  onDateChange={date => {
+                                    if (date) {
+                                      updateCheckpoint(checkpoint.id, { date });
+                                    }
+                                  }}
+                                  align="end"
+                                  className="w-full sm:w-auto"
+                                />
+                              </div>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                              <p className="text-sm text-muted-foreground">
+                                {t(checkpoint.summaryKey)}
+                              </p>
+                              {checkpointWarnings.map(warning => (
+                                <Alert
+                                  key={`${checkpoint.id}-${warning.code}`}
+                                  className={warningVariantClasses[warning.code]}
+                                >
+                                  <ShieldAlert className="h-4 w-4" />
+                                  <AlertTitle>
+                                    {t(
+                                      `swarmManagement.warnings.${warning.code}.title`,
+                                    )}
+                                  </AlertTitle>
+                                  <AlertDescription>
+                                    {t(
+                                      `swarmManagement.warnings.${warning.code}.description`,
+                                    )}
+                                  </AlertDescription>
+                                </Alert>
+                              ))}
+                              <div className="space-y-2">
+                                <p className="text-sm font-medium">
+                                  {t('swarmManagement.planner.notesLabel')}
+                                </p>
+                                <Textarea
+                                  value={checkpoint.notes}
+                                  onChange={event =>
+                                    updateCheckpoint(checkpoint.id, {
+                                      notes: event.target.value,
+                                    })
+                                  }
+                                  rows={8}
+                                />
+                              </div>
+                            </CardContent>
+                          </Card>
+                        );
+                      })}
+
+                      <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                        <Button variant="outline" onClick={handleCancel}>
+                          {t('actions.cancel')}
+                        </Button>
+                        <Button onClick={handleSavePlan} disabled={isSaving}>
+                          {isSaving
+                            ? t('swarmManagement.planner.saving')
+                            : t('swarmManagement.planner.save')}
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+                      {t('swarmManagement.planner.emptyState')}
+                    </div>
+                  )}
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <ToolFaq title={t('swarmManagement.artificialSwarm.faq.title')} items={faqItems} />
+      </MainContent>
+
+      <PageAside>
+        <div className="space-y-4 md:sticky md:top-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <CalendarClock className="h-5 w-5 text-primary" />
+                {t('swarmManagement.planner.atAGlanceTitle')}
+              </CardTitle>
+              <CardDescription>
+                {t('swarmManagement.planner.atAGlanceDescription')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ol className="space-y-3 text-sm">
+                {[0, 1, 2].map(i => (
+                  <li
+                    key={i}
+                    className="flex gap-3 border-b pb-3 last:border-b-0 last:pb-0"
+                  >
+                    <div className="min-w-[68px] font-semibold text-foreground">
+                      {t(`swarmManagement.artificialSwarm.followUp.${i}.day`)}
+                    </div>
+                    <div className="text-muted-foreground">
+                      {t(`swarmManagement.artificialSwarm.followUp.${i}.task`)}
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </CardContent>
+          </Card>
+
+          <CalloutCard
+            variant="amber"
+            icon={<AlertTriangle className="h-5 w-5" />}
+            title={t('swarmManagement.aside.criticalTimingTitle')}
+          >
+            <p>{t('swarmManagement.aside.criticalTimingLead')}</p>
+            <p>{t('swarmManagement.aside.criticalTimingDetail')}</p>
+          </CalloutCard>
+        </div>
+      </PageAside>
+    </PageGrid>
+  );
+}

--- a/apps/frontend/src/pages/tools/artificial-swarm-method-page.tsx
+++ b/apps/frontend/src/pages/tools/artificial-swarm-method-page.tsx
@@ -1,14 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { ToolMeta, buildFaqJsonLd, type FaqItem } from '@/components/tool-page';
-import {
-  generateArtificialSwarmPlan,
-  getArtificialSwarmWarnings,
-} from './artificial-swarm-planner';
-import {
-  SwarmMethodPageLayout,
-  type CheckpointPlan,
-  type CheckpointWarning,
-} from './swarm-method-page-layout';
+import { generateArtificialSwarmPlan, getArtificialSwarmWarnings } from './artificial-swarm-planner';
+import { SwarmMethodPageLayout, type CheckpointPlan, type CheckpointWarning } from './swarm-method-page-layout';
 
 const METHOD_DETAIL_SECTIONS = [
   {
@@ -33,92 +26,52 @@ const METHOD_DETAIL_SECTIONS = [
   },
 ];
 
-function ArtificialSwarmToolMeta() {
+export function ArtificialSwarmMethodPage() {
   const { t } = useTranslation('common');
-  const faqItems = t('swarmManagement.artificialSwarm.faq.items', {
-    returnObjects: true,
-  }) as FaqItem[];
+  const faqItems = t('swarmManagement.artificialSwarm.faq.items', { returnObjects: true }) as FaqItem[];
 
-  const structuredData = {
-    '@context': 'https://schema.org',
-    '@graph': [
-      {
-        '@type': 'WebApplication',
-        name: 'Artificial Swarm Method Guide and Planner',
-        url: 'https://hivepal.app/tools/swarm-management/artificial',
-        applicationCategory: 'EducationalApplication',
-        applicationSubCategory: 'Beekeeping Reference',
-        operatingSystem: 'Web',
-        browserRequirements: 'Requires JavaScript',
-        description:
-          'Reference guide and inspection planner for the artificial swarm swarm-control method, with prerequisites, step-by-step instructions, pros/cons, and follow-up timing.',
-        isAccessibleForFree: true,
-        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-        publisher: {
-          '@type': 'Organization',
-          name: 'Hive Pal',
-          url: 'https://hivepal.app',
-        },
-      },
-      {
-        '@type': 'HowTo',
-        name: 'How to perform the artificial swarm method',
-        description:
-          'Step-by-step artificial swarm procedure for relieving swarm pressure by moving the parent colony aside while placing a new hive on the original stand with a frame containing a queen cell.',
-        step: [
-          {
-            '@type': 'HowToStep',
-            name: 'Preparation',
-            text: 'Find a spare brood box with drawn comb and prepare a second hive floor and stand positioned a few metres away from the original location.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Move the Parent Colony',
-            text: 'Move the original hive (with the queen) to a new location a few metres away. Identify a frame with a queen cell or eggs, and reduce other queen cells on the parent colony.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Set Up the New Colony',
-            text: 'Place the new brood box on the original hive floor with the selected brood frame in the centre, and fill with frames of drawn comb.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Reassembly',
-            text: 'Place a queen excluder on top of the new hive if adding supers, add supers as needed, and fit crown board and roof on both hives.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Follow-up at day 7-8',
-            text: 'Inspect the new colony to confirm the queen cell is developing and check for any additional queen cells.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Follow-up at day 14-15',
-            text: 'Confirm the queen cell is capped and developing normally. Monitor the parent colony.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Follow-up at day 21-22',
-            text: 'Confirm the new queen in the new colony is mated and laying. Assess both colonies and decide on next steps.',
-          },
-        ],
-      },
-      buildFaqJsonLd(faqItems),
-    ],
-  };
-
-  return (
+  const meta = (
     <ToolMeta
       title="Artificial Swarm Method: Swarm Control Guide and Planner — Hive Pal"
       description="Free reference guide and inspection planner for the artificial swarm swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
       ogDescription="Step-by-step artificial swarm method for honey bee swarm control when the queen cannot be found, with follow-up timing and an inspection planner."
       path="/tools/swarm-management/artificial"
-      structuredData={structuredData}
+      structuredData={{
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'WebApplication',
+            name: 'Artificial Swarm Method Guide and Planner',
+            url: 'https://hivepal.app/tools/swarm-management/artificial',
+            applicationCategory: 'EducationalApplication',
+            applicationSubCategory: 'Beekeeping Reference',
+            operatingSystem: 'Web',
+            browserRequirements: 'Requires JavaScript',
+            description: 'Reference guide and inspection planner for the artificial swarm swarm-control method, with prerequisites, step-by-step instructions, pros/cons, and follow-up timing.',
+            isAccessibleForFree: true,
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+            publisher: { '@type': 'Organization', name: 'Hive Pal', url: 'https://hivepal.app' },
+          },
+          {
+            '@type': 'HowTo',
+            name: 'How to perform the artificial swarm method',
+            description: 'Step-by-step artificial swarm procedure for moving the parent colony aside while placing a new hive on the original stand with a frame containing a queen cell.',
+            step: [
+              { '@type': 'HowToStep', name: 'Preparation', text: 'Find a spare brood box with drawn comb and prepare a second hive floor and stand a few metres away.' },
+              { '@type': 'HowToStep', name: 'Move the Parent Colony', text: 'Move the original hive (with the queen) to a new location. Identify a frame with a queen cell or eggs and reduce other queen cells.' },
+              { '@type': 'HowToStep', name: 'Set Up the New Colony', text: 'Place the new brood box on the original stand with the selected brood frame in the centre, filled with drawn comb.' },
+              { '@type': 'HowToStep', name: 'Reassembly', text: 'Add a queen excluder and supers to the new hive as needed. Fit crown board and roof on both hives.' },
+              { '@type': 'HowToStep', name: 'Follow-up at day 7-8', text: 'Inspect the new colony to confirm the queen cell is developing and check for additional queen cells.' },
+              { '@type': 'HowToStep', name: 'Follow-up at day 14-15', text: 'Confirm the queen cell is capped and developing. Monitor the parent colony.' },
+              { '@type': 'HowToStep', name: 'Follow-up at day 21-22', text: 'Confirm the new queen is mated and laying in the new colony.' },
+            ],
+          },
+          buildFaqJsonLd(faqItems),
+        ],
+      }}
     />
   );
-}
 
-export function ArtificialSwarmMethodPage() {
   return (
     <SwarmMethodPageLayout
       ns="swarmManagement.artificialSwarm"
@@ -129,7 +82,7 @@ export function ArtificialSwarmMethodPage() {
       methodDetailSections={METHOD_DETAIL_SECTIONS}
       generatePlan={generateArtificialSwarmPlan as (d: Date) => CheckpointPlan[]}
       getWarnings={getArtificialSwarmWarnings as (c: CheckpointPlan[]) => CheckpointWarning[]}
-      meta={<ArtificialSwarmToolMeta />}
+      meta={meta}
       faqI18nKey="swarmManagement.artificialSwarm.faq.items"
     />
   );

--- a/apps/frontend/src/pages/tools/artificial-swarm-planner.ts
+++ b/apps/frontend/src/pages/tools/artificial-swarm-planner.ts
@@ -1,0 +1,144 @@
+import { addDays, differenceInCalendarDays } from 'date-fns';
+
+export type ArtificialSwarmCheckpointId =
+  | 'setup'
+  | 'queenCellCheck'
+  | 'secondQueenCellCheck'
+  | 'colonyReview';
+
+export interface ArtificialSwarmCheckpointTemplate {
+  id: ArtificialSwarmCheckpointId;
+  dayOffset: number;
+  titleKey: string;
+  summaryKey: string;
+  checklistKeys: string[];
+}
+
+export interface ArtificialSwarmCheckpointPlan
+  extends ArtificialSwarmCheckpointTemplate {
+  date: Date;
+}
+
+export type ArtificialSwarmWarningCode =
+  | 'lateQueenCellCheck'
+  | 'unsafeCheckpointSpacing'
+  | 'illogicalScheduleOrder';
+
+export interface ArtificialSwarmWarning {
+  code: ArtificialSwarmWarningCode;
+  checkpointIds: ArtificialSwarmCheckpointId[];
+}
+
+export const ARTIFICIAL_SWARM_CHECKPOINTS: ArtificialSwarmCheckpointTemplate[] = [
+  {
+    id: 'setup',
+    dayOffset: 0,
+    titleKey:
+      'swarmManagement.artificialSwarm.planner.checkpoints.setup.title',
+    summaryKey:
+      'swarmManagement.artificialSwarm.planner.checkpoints.setup.summary',
+    checklistKeys: [
+      'swarmManagement.artificialSwarm.planner.checkpoints.setup.checklist.0',
+      'swarmManagement.artificialSwarm.planner.checkpoints.setup.checklist.1',
+      'swarmManagement.artificialSwarm.planner.checkpoints.setup.checklist.2',
+    ],
+  },
+  {
+    id: 'queenCellCheck',
+    dayOffset: 7,
+    titleKey:
+      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.title',
+    summaryKey:
+      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.summary',
+    checklistKeys: [
+      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.checklist.0',
+      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.checklist.1',
+      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.checklist.2',
+    ],
+  },
+  {
+    id: 'secondQueenCellCheck',
+    dayOffset: 14,
+    titleKey:
+      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.title',
+    summaryKey:
+      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.summary',
+    checklistKeys: [
+      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.checklist.0',
+      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.checklist.1',
+      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.checklist.2',
+    ],
+  },
+  {
+    id: 'colonyReview',
+    dayOffset: 21,
+    titleKey:
+      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.title',
+    summaryKey:
+      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.summary',
+    checklistKeys: [
+      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.checklist.0',
+      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.checklist.1',
+      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.checklist.2',
+    ],
+  },
+];
+
+export const generateArtificialSwarmPlan = (
+  startDate: Date,
+): ArtificialSwarmCheckpointPlan[] =>
+  ARTIFICIAL_SWARM_CHECKPOINTS.map(checkpoint => ({
+    ...checkpoint,
+    date: addDays(startDate, checkpoint.dayOffset),
+  }));
+
+export const getArtificialSwarmWarnings = (
+  checkpoints: Array<Pick<ArtificialSwarmCheckpointPlan, 'id' | 'date'>>,
+): ArtificialSwarmWarning[] => {
+  const warnings: ArtificialSwarmWarning[] = [];
+
+  const setup = checkpoints.find(checkpoint => checkpoint.id === 'setup');
+  const queenCellCheck = checkpoints.find(
+    checkpoint => checkpoint.id === 'queenCellCheck',
+  );
+
+  if (setup && queenCellCheck) {
+    const queenCellGap = differenceInCalendarDays(
+      queenCellCheck.date,
+      setup.date,
+    );
+
+    if (queenCellGap > 8) {
+      warnings.push({
+        code: 'lateQueenCellCheck',
+        checkpointIds: ['setup', 'queenCellCheck'],
+      });
+    }
+  }
+
+  for (let index = 1; index < checkpoints.length; index += 1) {
+    const previousCheckpoint = checkpoints[index - 1];
+    const currentCheckpoint = checkpoints[index];
+    const gap = differenceInCalendarDays(
+      currentCheckpoint.date,
+      previousCheckpoint.date,
+    );
+
+    if (gap <= 0) {
+      warnings.push({
+        code: 'illogicalScheduleOrder',
+        checkpointIds: [previousCheckpoint.id, currentCheckpoint.id],
+      });
+      continue;
+    }
+
+    if (gap < 5 || gap > 10) {
+      warnings.push({
+        code: 'unsafeCheckpointSpacing',
+        checkpointIds: [previousCheckpoint.id, currentCheckpoint.id],
+      });
+    }
+  }
+
+  return warnings;
+};

--- a/apps/frontend/src/pages/tools/artificial-swarm-planner.ts
+++ b/apps/frontend/src/pages/tools/artificial-swarm-planner.ts
@@ -1,144 +1,20 @@
-import { addDays, differenceInCalendarDays } from 'date-fns';
+import {
+  buildCheckpoints,
+  buildGeneratePlan,
+  buildGetWarnings,
+} from './swarm-planner-factory';
 
-export type ArtificialSwarmCheckpointId =
-  | 'setup'
-  | 'queenCellCheck'
-  | 'secondQueenCellCheck'
-  | 'colonyReview';
+export const ARTIFICIAL_SWARM_CHECKPOINTS = buildCheckpoints(
+  'swarmManagement.artificialSwarm',
+);
 
-export interface ArtificialSwarmCheckpointTemplate {
-  id: ArtificialSwarmCheckpointId;
-  dayOffset: number;
-  titleKey: string;
-  summaryKey: string;
-  checklistKeys: string[];
-}
+export const generateArtificialSwarmPlan = buildGeneratePlan(
+  ARTIFICIAL_SWARM_CHECKPOINTS,
+);
 
-export interface ArtificialSwarmCheckpointPlan
-  extends ArtificialSwarmCheckpointTemplate {
-  date: Date;
-}
+export const getArtificialSwarmWarnings = buildGetWarnings(
+  ARTIFICIAL_SWARM_CHECKPOINTS,
+);
 
-export type ArtificialSwarmWarningCode =
-  | 'lateQueenCellCheck'
-  | 'unsafeCheckpointSpacing'
-  | 'illogicalScheduleOrder';
-
-export interface ArtificialSwarmWarning {
-  code: ArtificialSwarmWarningCode;
-  checkpointIds: ArtificialSwarmCheckpointId[];
-}
-
-export const ARTIFICIAL_SWARM_CHECKPOINTS: ArtificialSwarmCheckpointTemplate[] = [
-  {
-    id: 'setup',
-    dayOffset: 0,
-    titleKey:
-      'swarmManagement.artificialSwarm.planner.checkpoints.setup.title',
-    summaryKey:
-      'swarmManagement.artificialSwarm.planner.checkpoints.setup.summary',
-    checklistKeys: [
-      'swarmManagement.artificialSwarm.planner.checkpoints.setup.checklist.0',
-      'swarmManagement.artificialSwarm.planner.checkpoints.setup.checklist.1',
-      'swarmManagement.artificialSwarm.planner.checkpoints.setup.checklist.2',
-    ],
-  },
-  {
-    id: 'queenCellCheck',
-    dayOffset: 7,
-    titleKey:
-      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.title',
-    summaryKey:
-      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.summary',
-    checklistKeys: [
-      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.checklist.0',
-      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.checklist.1',
-      'swarmManagement.artificialSwarm.planner.checkpoints.queenCellCheck.checklist.2',
-    ],
-  },
-  {
-    id: 'secondQueenCellCheck',
-    dayOffset: 14,
-    titleKey:
-      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.title',
-    summaryKey:
-      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.summary',
-    checklistKeys: [
-      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.checklist.0',
-      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.checklist.1',
-      'swarmManagement.artificialSwarm.planner.checkpoints.secondQueenCellCheck.checklist.2',
-    ],
-  },
-  {
-    id: 'colonyReview',
-    dayOffset: 21,
-    titleKey:
-      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.title',
-    summaryKey:
-      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.summary',
-    checklistKeys: [
-      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.checklist.0',
-      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.checklist.1',
-      'swarmManagement.artificialSwarm.planner.checkpoints.colonyReview.checklist.2',
-    ],
-  },
-];
-
-export const generateArtificialSwarmPlan = (
-  startDate: Date,
-): ArtificialSwarmCheckpointPlan[] =>
-  ARTIFICIAL_SWARM_CHECKPOINTS.map(checkpoint => ({
-    ...checkpoint,
-    date: addDays(startDate, checkpoint.dayOffset),
-  }));
-
-export const getArtificialSwarmWarnings = (
-  checkpoints: Array<Pick<ArtificialSwarmCheckpointPlan, 'id' | 'date'>>,
-): ArtificialSwarmWarning[] => {
-  const warnings: ArtificialSwarmWarning[] = [];
-
-  const setup = checkpoints.find(checkpoint => checkpoint.id === 'setup');
-  const queenCellCheck = checkpoints.find(
-    checkpoint => checkpoint.id === 'queenCellCheck',
-  );
-
-  if (setup && queenCellCheck) {
-    const queenCellGap = differenceInCalendarDays(
-      queenCellCheck.date,
-      setup.date,
-    );
-
-    if (queenCellGap > 8) {
-      warnings.push({
-        code: 'lateQueenCellCheck',
-        checkpointIds: ['setup', 'queenCellCheck'],
-      });
-    }
-  }
-
-  for (let index = 1; index < checkpoints.length; index += 1) {
-    const previousCheckpoint = checkpoints[index - 1];
-    const currentCheckpoint = checkpoints[index];
-    const gap = differenceInCalendarDays(
-      currentCheckpoint.date,
-      previousCheckpoint.date,
-    );
-
-    if (gap <= 0) {
-      warnings.push({
-        code: 'illogicalScheduleOrder',
-        checkpointIds: [previousCheckpoint.id, currentCheckpoint.id],
-      });
-      continue;
-    }
-
-    if (gap < 5 || gap > 10) {
-      warnings.push({
-        code: 'unsafeCheckpointSpacing',
-        checkpointIds: [previousCheckpoint.id, currentCheckpoint.id],
-      });
-    }
-  }
-
-  return warnings;
-};
+// Re-export types consumed by the page wrapper and tests
+export type { SwarmCheckpointTemplate as ArtificialSwarmCheckpointTemplate } from './swarm-planner-factory';

--- a/apps/frontend/src/pages/tools/artificial-swarm-planner.ts
+++ b/apps/frontend/src/pages/tools/artificial-swarm-planner.ts
@@ -18,3 +18,4 @@ export const getArtificialSwarmWarnings = buildGetWarnings(
 
 // Re-export types consumed by the page wrapper and tests
 export type { SwarmCheckpointTemplate as ArtificialSwarmCheckpointTemplate } from './swarm-planner-factory';
+export type { CheckpointPlan as ArtificialSwarmCheckpointPlan } from './swarm-method-page-layout';

--- a/apps/frontend/src/pages/tools/demaree-method-page.tsx
+++ b/apps/frontend/src/pages/tools/demaree-method-page.tsx
@@ -1,123 +1,29 @@
-import { useMemo, useState } from 'react';
-import {
-  AlertTriangle,
-  CalendarClock,
-  ShieldAlert,
-  Waypoints,
-} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
-import { InspectionStatus, type HiveResponse } from 'shared-schemas';
-import { useCreateInspection, useHives } from '@/api/hooks';
-import { useAuth } from '@/context/auth-context';
+import { ToolMeta, buildFaqJsonLd, type FaqItem } from '@/components/tool-page';
 import {
-  MainContent,
-  PageAside,
-  PageGrid,
-} from '@/components/layout/page-grid-layout';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Textarea } from '@/components/ui/textarea';
-import { DatePickerPopover } from '@/components/common/date-picker-popover';
-import {
-  CalloutCard,
-  DotList,
-  ToolMeta,
-  ToolPageHeader,
-  ToolFaq,
-  buildFaqJsonLd,
-  type FaqItem,
-} from '@/components/tool-page';
-import { cn } from '@/lib/utils';
-import { toInspectionDateISOString } from '@/utils/inspection-date';
-import {
-  type DemareeCheckpointPlan,
-  type DemareeWarning,
-  type DemareeWarningCode,
   generateDemareePlan,
   getDemareeWarnings,
 } from './demaree-planner';
-
-type EditableCheckpoint = DemareeCheckpointPlan & {
-  notes: string;
-};
-
-const warningVariantClasses: Record<DemareeWarningCode, string> = {
-  lateQueenCellCheck: 'border-amber-300 bg-amber-50 dark:bg-amber-950/30',
-  unsafeCheckpointSpacing: 'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
-  illogicalScheduleOrder: 'border-red-300 bg-red-50 dark:bg-red-950/30',
-};
-
-function buildCheckpointNotes(
-  checkpoint: DemareeCheckpointPlan,
-  t: (key: string, options?: Record<string, unknown>) => string,
-) {
-  const checklist = checkpoint.checklistKeys.map(key => `- ${t(key)}`).join('\n');
-
-  return [
-    `${t('swarmManagement.planner.checkpointPrefix')} ${t(checkpoint.titleKey)}`,
-    t(checkpoint.summaryKey),
-    '',
-    t('swarmManagement.planner.notesChecklistLabel'),
-    checklist,
-  ].join('\n');
-}
-
-function WarningSummary({
-  warning,
-  t,
-}: Readonly<{
-  warning: DemareeWarning;
-  t: (key: string, options?: Record<string, unknown>) => string;
-}>) {
-  return (
-    <div
-      className={cn(
-        'rounded-lg border p-3',
-        warningVariantClasses[warning.code],
-      )}
-    >
-      <p className="font-medium">
-        {t(`swarmManagement.warnings.${warning.code}.title`)}
-      </p>
-      <p className="mt-1 text-sm text-muted-foreground">
-        {t(`swarmManagement.warnings.${warning.code}.description`)}
-      </p>
-    </div>
-  );
-}
+import {
+  SwarmMethodPageLayout,
+  type CheckpointPlan,
+  type CheckpointWarning,
+} from './swarm-method-page-layout';
 
 const METHOD_DETAIL_SECTIONS = [
   {
     id: 'preparation',
-    items: [0, 1] as number[],
-    children: { 0: [0] as number[] } as Record<number, number[]>,
+    items: [0, 1],
+    children: { 0: [0] } as Record<number, number[]>,
   },
   {
     id: 'huntTheQueen',
-    items: [0, 1] as number[],
+    items: [0, 1],
     children: {} as Record<number, number[]>,
   },
   {
     id: 'broodManipulation',
-    items: [0, 1, 2] as number[],
+    items: [0, 1, 2],
     children: {
       0: [0],
       1: [0],
@@ -126,139 +32,16 @@ const METHOD_DETAIL_SECTIONS = [
   },
   {
     id: 'reassembly',
-    items: [0, 1, 2, 3, 4] as number[],
+    items: [0, 1, 2, 3, 4],
     children: {} as Record<number, number[]>,
   },
 ];
 
-export function DemareeMethodPage() {
+function DemareeToolMeta() {
   const { t } = useTranslation('common');
-  const navigate = useNavigate();
-  const { isLoggedIn } = useAuth();
-  const { data: hives = [], isLoading: isLoadingHives } = useHives();
-  const { mutateAsync: createInspection, isPending: isSaving } =
-    useCreateInspection();
-
-  const [selectedHiveId, setSelectedHiveId] = useState<string>('');
-  const [startDate, setStartDate] = useState<Date | undefined>();
-  const [checkpoints, setCheckpoints] = useState<EditableCheckpoint[]>([]);
-
-  const warnings = useMemo(() => getDemareeWarnings(checkpoints), [checkpoints]);
-
-  const selectedHive = hives.find(hive => hive.id === selectedHiveId);
-
-  // Visible FAQ and FAQPage structured data share one translated source.
   const faqItems = t('swarmManagement.demaree.faq.items', {
     returnObjects: true,
   }) as FaqItem[];
-
-  const handleGeneratePlan = () => {
-    if (!startDate) return;
-
-    const nextCheckpoints = generateDemareePlan(startDate).map(checkpoint => ({
-      ...checkpoint,
-      notes: buildCheckpointNotes(checkpoint, t),
-    }));
-
-    setCheckpoints(nextCheckpoints);
-  };
-
-  const updateCheckpoint = (
-    checkpointId: EditableCheckpoint['id'],
-    updates: Partial<EditableCheckpoint>,
-  ) => {
-    setCheckpoints(currentCheckpoints =>
-      currentCheckpoints.map(checkpoint =>
-        checkpoint.id === checkpointId
-          ? { ...checkpoint, ...updates }
-          : checkpoint,
-      ),
-    );
-  };
-
-  const getCheckpointWarnings = (checkpointId: EditableCheckpoint['id']) =>
-    warnings.filter(warning => warning.checkpointIds.includes(checkpointId));
-
-  const handleSavePlan = async () => {
-    if (!selectedHiveId || checkpoints.length === 0) return;
-
-    const results = await Promise.allSettled(
-      checkpoints.map(checkpoint =>
-        createInspection({
-          hiveId: selectedHiveId,
-          date: toInspectionDateISOString(checkpoint.date, true),
-          isAllDay: true,
-          notes: checkpoint.notes,
-          status: InspectionStatus.SCHEDULED,
-          actions: [],
-        }),
-      ),
-    );
-
-    const successCount = results.filter(
-      result => result.status === 'fulfilled',
-    ).length;
-    const failedCount = results.length - successCount;
-
-    if (successCount === checkpoints.length) {
-      toast.success(
-        t('swarmManagement.planner.saveSuccess', { count: successCount }),
-      );
-      navigate('/inspections/list/upcoming');
-      return;
-    }
-
-    if (successCount > 0) {
-      toast.warning(
-        t('swarmManagement.planner.partialSave', {
-          successCount,
-          failedCount,
-        }),
-      );
-      navigate('/inspections/list/upcoming');
-      return;
-    }
-
-    if (failedCount > 0) {
-      toast.error(t('swarmManagement.planner.saveError'));
-    }
-  };
-
-  const handleCancel = () => {
-    setCheckpoints([]);
-    navigate('/tools/swarm-management');
-  };
-
-  const renderHiveSelect = () => {
-    if (isLoadingHives) {
-      return <Skeleton className="h-10 w-full" />;
-    }
-
-    if (hives.length === 0) {
-      return (
-        <p className="text-sm text-muted-foreground">
-          {t('swarmManagement.planner.noHives')}
-        </p>
-      );
-    }
-
-    return (
-      <Select value={selectedHiveId} onValueChange={setSelectedHiveId}>
-        <SelectTrigger>
-          <SelectValue
-            placeholder={t('swarmManagement.planner.hivePlaceholder')}
-          />
-        </SelectTrigger>
-        <SelectContent>
-          {hives.map((hive: HiveResponse) => (
-            <SelectItem key={hive.id} value={hive.id}>
-              {hive.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    );
-  };
 
   const structuredData = {
     '@context': 'https://schema.org',
@@ -329,406 +112,29 @@ export function DemareeMethodPage() {
   };
 
   return (
-    <PageGrid>
-      <ToolMeta
-        title="Demaree Method: Swarm Control Guide and Planner — Hive Pal"
-        description="Free reference guide and inspection planner for the Demaree swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
-        ogDescription="Step-by-step Demaree method for honey bee swarm control, with follow-up timing and an inspection planner."
-        path="/tools/swarm-management/demaree"
-        structuredData={structuredData}
-      />
+    <ToolMeta
+      title="Demaree Method: Swarm Control Guide and Planner — Hive Pal"
+      description="Free reference guide and inspection planner for the Demaree swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
+      ogDescription="Step-by-step Demaree method for honey bee swarm control, with follow-up timing and an inspection planner."
+      path="/tools/swarm-management/demaree"
+      structuredData={structuredData}
+    />
+  );
+}
 
-      <MainContent>
-        <ToolPageHeader
-          title={t('swarmManagement.demaree.title')}
-          badge={
-            <Badge variant="outline">{t('swarmManagement.demaree.badge')}</Badge>
-          }
-          description={t('swarmManagement.demaree.description')}
-          intro={t('swarmManagement.demaree.intro')}
-          backLink={{
-            to: '/tools/swarm-management',
-            label: t('swarmManagement.backToOverview'),
-          }}
-        />
-
-        <div className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.overviewTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 text-sm text-muted-foreground">
-              <p>{t('swarmManagement.demaree.overviewLead')}</p>
-              <DotList
-                className="space-y-3"
-                items={[0, 1, 2].map(i =>
-                  t(`swarmManagement.demaree.overviewPoints.${i}`),
-                )}
-              />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.prerequisitesTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="list-disc space-y-3 pl-5 text-sm text-muted-foreground marker:text-primary/60">
-                {[0, 1, 2, 3, 4, 5].map(i => (
-                  <li key={i}>{t(`swarmManagement.demaree.prerequisites.${i}`)}</li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.advantagesTitle')}</CardTitle>
-              <CardDescription>
-                {t('swarmManagement.demaree.advantagesDescription')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <DotList
-                items={[0, 1, 2].map(i =>
-                  t(`swarmManagement.demaree.advantages.${i}`),
-                )}
-              />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.stepsTitle')}</CardTitle>
-              <CardDescription>
-                {t('swarmManagement.demaree.stepsDescription')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-6 text-sm text-muted-foreground">
-                {METHOD_DETAIL_SECTIONS.map(section => (
-                  <div key={section.id} className="space-y-3">
-                    <h3 className="font-semibold text-foreground">
-                      {t(`swarmManagement.demaree.methodDetail.${section.id}.title`)}
-                    </h3>
-                    <ul className="list-disc space-y-2 pl-5 marker:text-primary/60">
-                      {section.items.map(itemIndex => (
-                        <li key={itemIndex}>
-                          <span>
-                            {t(
-                              `swarmManagement.demaree.methodDetail.${section.id}.items.${itemIndex}.text`,
-                            )}
-                          </span>
-                          {(section.children[itemIndex] ?? []).length > 0 && (
-                            <ul className="list-[circle] space-y-2 pl-5 pt-2 marker:text-muted-foreground/60">
-                              {(section.children[itemIndex] ?? []).map(childIndex => (
-                                <li key={childIndex}>
-                                  {t(
-                                    `swarmManagement.demaree.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
-                                  )}
-                                </li>
-                              ))}
-                            </ul>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.followUpTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="overflow-hidden rounded-lg border">
-                <div className="grid grid-cols-[minmax(80px,auto)_1fr] border-b bg-muted/40 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:px-4 sm:text-sm">
-                  <div>{t('swarmManagement.demaree.followUpDayHeader')}</div>
-                  <div>{t('swarmManagement.demaree.followUpTaskHeader')}</div>
-                </div>
-                {[0, 1, 2].map(index => (
-                  <div
-                    key={index}
-                    className="grid grid-cols-[minmax(80px,auto)_1fr] gap-3 border-b px-3 py-3 text-sm last:border-b-0 sm:px-4"
-                  >
-                    <div className="font-semibold text-foreground">
-                      {t(`swarmManagement.demaree.followUp.${index}.day`)}
-                    </div>
-                    <div className="text-muted-foreground">
-                      {t(`swarmManagement.demaree.followUp.${index}.task`)}
-                    </div>
-                  </div>
-                ))}
-              </div>
-              <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-muted-foreground dark:bg-amber-950/30">
-                <p className="flex items-start gap-2 font-medium text-foreground">
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-                  {t('swarmManagement.aside.criticalTimingTitle')}
-                </p>
-                <p className="mt-2">{t('swarmManagement.aside.criticalTimingLead')}</p>
-                <p className="mt-2">{t('swarmManagement.aside.criticalTimingDetail')}</p>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.prosConsTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-4 dark:border-emerald-900/40 dark:bg-emerald-950/20">
-                  <p className="mb-3 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
-                    {t('swarmManagement.demaree.prosTitle')}
-                  </p>
-                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-emerald-600/60">
-                    {[0, 1, 2, 3, 4].map(i => (
-                      <li key={i}>{t(`swarmManagement.demaree.pros.${i}`)}</li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="rounded-lg border border-rose-200 bg-rose-50/40 p-4 dark:border-rose-900/40 dark:bg-rose-950/20">
-                  <p className="mb-3 text-sm font-semibold text-rose-900 dark:text-rose-200">
-                    {t('swarmManagement.demaree.consTitle')}
-                  </p>
-                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-rose-600/60">
-                    {[0, 1, 2, 3, 4].map(i => (
-                      <li key={i}>{t(`swarmManagement.demaree.cons.${i}`)}</li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.planner.title')}</CardTitle>
-              <CardDescription>
-                {t('swarmManagement.planner.description')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {!isLoggedIn ? (
-                <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center">
-                  <p className="text-base font-semibold text-foreground">
-                    {t('swarmManagement.planner.signInTitle')}
-                  </p>
-                  <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
-                    {t('swarmManagement.planner.signInDescription')}
-                  </p>
-                  <div className="mt-4 flex flex-col items-center justify-center gap-2 sm:flex-row">
-                    <Button asChild>
-                      <Link to="/login">{t('swarmManagement.planner.signInCta')}</Link>
-                    </Button>
-                    <Button variant="outline" asChild>
-                      <Link to="/register">
-                        {t('swarmManagement.planner.registerCta')}
-                      </Link>
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">
-                        {t('swarmManagement.planner.hiveLabel')}
-                      </p>
-                      {renderHiveSelect()}
-                    </div>
-
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">
-                        {t('swarmManagement.planner.startDateLabel')}
-                      </p>
-                      <DatePickerPopover
-                        date={startDate}
-                        onDateChange={setStartDate}
-                        placeholder={t(
-                          'swarmManagement.planner.startDatePlaceholder',
-                        )}
-                      />
-                    </div>
-                  </div>
-
-                  <Button
-                    className="w-full sm:w-auto"
-                    onClick={handleGeneratePlan}
-                    disabled={!selectedHiveId || !startDate}
-                  >
-                    {t('swarmManagement.planner.generate')}
-                  </Button>
-
-                  {selectedHive && (
-                    <Alert>
-                      <Waypoints className="h-4 w-4" />
-                      <AlertTitle>
-                        {t('swarmManagement.planner.selectedHive')}
-                      </AlertTitle>
-                      <AlertDescription>{selectedHive.name}</AlertDescription>
-                    </Alert>
-                  )}
-
-                  {warnings.length > 0 && (
-                    <Alert className="border-amber-300 bg-amber-50 dark:bg-amber-950/30">
-                      <AlertTriangle className="h-4 w-4" />
-                      <AlertTitle>
-                        {t('swarmManagement.warnings.bannerTitle')}
-                      </AlertTitle>
-                      <AlertDescription className="mt-3 space-y-3">
-                        {warnings.map(warning => (
-                          <WarningSummary
-                            key={`${warning.code}-${warning.checkpointIds.join('-')}`}
-                            warning={warning}
-                            t={t}
-                          />
-                        ))}
-                      </AlertDescription>
-                    </Alert>
-                  )}
-
-                  {checkpoints.length > 0 ? (
-                    <div className="space-y-4">
-                      {checkpoints.map(checkpoint => {
-                        const checkpointWarnings = getCheckpointWarnings(
-                          checkpoint.id,
-                        );
-
-                        return (
-                          <Card key={checkpoint.id}>
-                            <CardHeader>
-                              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                <div className="min-w-0">
-                                  <CardTitle>{t(checkpoint.titleKey)}</CardTitle>
-                                  <CardDescription>
-                                    {t('swarmManagement.planner.dayOffset', {
-                                      count: checkpoint.dayOffset,
-                                    })}
-                                  </CardDescription>
-                                </div>
-                                <DatePickerPopover
-                                  date={checkpoint.date}
-                                  onDateChange={date => {
-                                    if (date) {
-                                      updateCheckpoint(checkpoint.id, { date });
-                                    }
-                                  }}
-                                  align="end"
-                                  className="w-full sm:w-auto"
-                                />
-                              </div>
-                            </CardHeader>
-                            <CardContent className="space-y-4">
-                              <p className="text-sm text-muted-foreground">
-                                {t(checkpoint.summaryKey)}
-                              </p>
-                              {checkpointWarnings.map(warning => (
-                                <Alert
-                                  key={`${checkpoint.id}-${warning.code}`}
-                                  className={warningVariantClasses[warning.code]}
-                                >
-                                  <ShieldAlert className="h-4 w-4" />
-                                  <AlertTitle>
-                                    {t(
-                                      `swarmManagement.warnings.${warning.code}.title`,
-                                    )}
-                                  </AlertTitle>
-                                  <AlertDescription>
-                                    {t(
-                                      `swarmManagement.warnings.${warning.code}.description`,
-                                    )}
-                                  </AlertDescription>
-                                </Alert>
-                              ))}
-                              <div className="space-y-2">
-                                <p className="text-sm font-medium">
-                                  {t('swarmManagement.planner.notesLabel')}
-                                </p>
-                                <Textarea
-                                  value={checkpoint.notes}
-                                  onChange={event =>
-                                    updateCheckpoint(checkpoint.id, {
-                                      notes: event.target.value,
-                                    })
-                                  }
-                                  rows={8}
-                                />
-                              </div>
-                            </CardContent>
-                          </Card>
-                        );
-                      })}
-
-                      <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                        <Button variant="outline" onClick={handleCancel}>
-                          {t('actions.cancel')}
-                        </Button>
-                        <Button onClick={handleSavePlan} disabled={isSaving}>
-                          {isSaving
-                            ? t('swarmManagement.planner.saving')
-                            : t('swarmManagement.planner.save')}
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
-                      {t('swarmManagement.planner.emptyState')}
-                    </div>
-                  )}
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        <ToolFaq title={t('swarmManagement.demaree.faq.title')} items={faqItems} />
-      </MainContent>
-
-      <PageAside>
-        <div className="space-y-4 md:sticky md:top-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-base">
-                <CalendarClock className="h-5 w-5 text-primary" />
-                {t('swarmManagement.planner.atAGlanceTitle')}
-              </CardTitle>
-              <CardDescription>
-                {t('swarmManagement.planner.atAGlanceDescription')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <ol className="space-y-3 text-sm">
-                {[0, 1, 2].map(i => (
-                  <li
-                    key={i}
-                    className="flex gap-3 border-b pb-3 last:border-b-0 last:pb-0"
-                  >
-                    <div className="min-w-[68px] font-semibold text-foreground">
-                      {t(`swarmManagement.demaree.followUp.${i}.day`)}
-                    </div>
-                    <div className="text-muted-foreground">
-                      {t(`swarmManagement.demaree.followUp.${i}.task`)}
-                    </div>
-                  </li>
-                ))}
-              </ol>
-            </CardContent>
-          </Card>
-
-          <CalloutCard
-            variant="amber"
-            icon={<AlertTriangle className="h-5 w-5" />}
-            title={t('swarmManagement.aside.criticalTimingTitle')}
-          >
-            <p>{t('swarmManagement.aside.criticalTimingLead')}</p>
-            <p>{t('swarmManagement.aside.criticalTimingDetail')}</p>
-          </CalloutCard>
-        </div>
-      </PageAside>
-    </PageGrid>
+export function DemareeMethodPage() {
+  return (
+    <SwarmMethodPageLayout
+      ns="swarmManagement.demaree"
+      plannerNs="swarmManagement.planner"
+      methodPlannerNs="swarmManagement.planner"
+      prerequisiteCount={6}
+      prosConsCount={5}
+      methodDetailSections={METHOD_DETAIL_SECTIONS}
+      generatePlan={generateDemareePlan as (d: Date) => CheckpointPlan[]}
+      getWarnings={getDemareeWarnings as (c: CheckpointPlan[]) => CheckpointWarning[]}
+      meta={<DemareeToolMeta />}
+      faqI18nKey="swarmManagement.demaree.faq.items"
+    />
   );
 }

--- a/apps/frontend/src/pages/tools/demaree-method-page.tsx
+++ b/apps/frontend/src/pages/tools/demaree-method-page.tsx
@@ -1,14 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { ToolMeta, buildFaqJsonLd, type FaqItem } from '@/components/tool-page';
-import {
-  generateDemareePlan,
-  getDemareeWarnings,
-} from './demaree-planner';
-import {
-  SwarmMethodPageLayout,
-  type CheckpointPlan,
-  type CheckpointWarning,
-} from './swarm-method-page-layout';
+import { generateDemareePlan, getDemareeWarnings } from './demaree-planner';
+import { SwarmMethodPageLayout, type CheckpointPlan, type CheckpointWarning } from './swarm-method-page-layout';
 
 const METHOD_DETAIL_SECTIONS = [
   {
@@ -24,11 +17,7 @@ const METHOD_DETAIL_SECTIONS = [
   {
     id: 'broodManipulation',
     items: [0, 1, 2],
-    children: {
-      0: [0],
-      1: [0],
-      2: [0, 1, 2],
-    } as Record<number, number[]>,
+    children: { 0: [0], 1: [0], 2: [0, 1, 2] } as Record<number, number[]>,
   },
   {
     id: 'reassembly',
@@ -37,92 +26,52 @@ const METHOD_DETAIL_SECTIONS = [
   },
 ];
 
-function DemareeToolMeta() {
+export function DemareeMethodPage() {
   const { t } = useTranslation('common');
-  const faqItems = t('swarmManagement.demaree.faq.items', {
-    returnObjects: true,
-  }) as FaqItem[];
+  const faqItems = t('swarmManagement.demaree.faq.items', { returnObjects: true }) as FaqItem[];
 
-  const structuredData = {
-    '@context': 'https://schema.org',
-    '@graph': [
-      {
-        '@type': 'WebApplication',
-        name: 'Demaree Swarm-Control Method Guide and Planner',
-        url: 'https://hivepal.app/tools/swarm-management/demaree',
-        applicationCategory: 'EducationalApplication',
-        applicationSubCategory: 'Beekeeping Reference',
-        operatingSystem: 'Web',
-        browserRequirements: 'Requires JavaScript',
-        description:
-          'Reference guide and inspection planner for the Demaree swarm-control method, with prerequisites, step-by-step instructions, pros/cons, and follow-up timing.',
-        isAccessibleForFree: true,
-        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-        publisher: {
-          '@type': 'Organization',
-          name: 'Hive Pal',
-          url: 'https://hivepal.app',
-        },
-      },
-      {
-        '@type': 'HowTo',
-        name: 'How to perform the Demaree swarm-control method',
-        description:
-          'Step-by-step Demaree procedure for relieving swarm pressure in a strong honey bee colony without splitting it into separate units.',
-        step: [
-          {
-            '@type': 'HowToStep',
-            name: 'Preparation',
-            text: 'Place a spare brood box with drawn comb or foundation on the hive floor below the existing brood.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Hunt the queen',
-            text: 'Find the laying queen, place her and the frame she is on into the centre of the new bottom box, and remove any queen cells from that frame.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Brood manipulation',
-            text: 'Consolidate brood frames above and knock down every queen cell. Shake bees off frames to make sure no cells are missed.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Reassembly',
-            text: 'Stack queen excluder, two or more honey supers, a second queen excluder, and the brood box above. Refit the crown board and roof.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Follow-up at day 7-8',
-            text: 'Inspect the upper brood box for emergency queen cells and remove any that have been started.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Follow-up at day 14-15',
-            text: 'Recheck for late-started queen cells and confirm the brood arrangement still supports the Demaree setup.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Follow-up at day 21-22',
-            text: 'Carry out a final review and decide whether the colony can be normalised or still needs close monitoring.',
-          },
-        ],
-      },
-      buildFaqJsonLd(faqItems),
-    ],
-  };
-
-  return (
+  const meta = (
     <ToolMeta
       title="Demaree Method: Swarm Control Guide and Planner — Hive Pal"
       description="Free reference guide and inspection planner for the Demaree swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
       ogDescription="Step-by-step Demaree method for honey bee swarm control, with follow-up timing and an inspection planner."
       path="/tools/swarm-management/demaree"
-      structuredData={structuredData}
+      structuredData={{
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'WebApplication',
+            name: 'Demaree Swarm-Control Method Guide and Planner',
+            url: 'https://hivepal.app/tools/swarm-management/demaree',
+            applicationCategory: 'EducationalApplication',
+            applicationSubCategory: 'Beekeeping Reference',
+            operatingSystem: 'Web',
+            browserRequirements: 'Requires JavaScript',
+            description: 'Reference guide and inspection planner for the Demaree swarm-control method, with prerequisites, step-by-step instructions, pros/cons, and follow-up timing.',
+            isAccessibleForFree: true,
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+            publisher: { '@type': 'Organization', name: 'Hive Pal', url: 'https://hivepal.app' },
+          },
+          {
+            '@type': 'HowTo',
+            name: 'How to perform the Demaree swarm-control method',
+            description: 'Step-by-step Demaree procedure for relieving swarm pressure in a strong honey bee colony without splitting it.',
+            step: [
+              { '@type': 'HowToStep', name: 'Preparation', text: 'Place a spare brood box with drawn comb or foundation on the hive floor below the existing brood.' },
+              { '@type': 'HowToStep', name: 'Hunt the queen', text: 'Find the laying queen, place her and the frame she is on into the centre of the new bottom box, and remove any queen cells from that frame.' },
+              { '@type': 'HowToStep', name: 'Brood manipulation', text: 'Consolidate brood frames above and knock down every queen cell. Shake bees off frames to make sure no cells are missed.' },
+              { '@type': 'HowToStep', name: 'Reassembly', text: 'Stack queen excluder, two or more honey supers, a second queen excluder, and the brood box above. Refit the crown board and roof.' },
+              { '@type': 'HowToStep', name: 'Follow-up at day 7-8', text: 'Inspect the upper brood box for emergency queen cells and remove any that have been started.' },
+              { '@type': 'HowToStep', name: 'Follow-up at day 14-15', text: 'Recheck for late-started queen cells and confirm the brood arrangement still supports the Demaree setup.' },
+              { '@type': 'HowToStep', name: 'Follow-up at day 21-22', text: 'Carry out a final review and decide whether the colony can be normalised or still needs close monitoring.' },
+            ],
+          },
+          buildFaqJsonLd(faqItems),
+        ],
+      }}
     />
   );
-}
 
-export function DemareeMethodPage() {
   return (
     <SwarmMethodPageLayout
       ns="swarmManagement.demaree"
@@ -133,7 +82,7 @@ export function DemareeMethodPage() {
       methodDetailSections={METHOD_DETAIL_SECTIONS}
       generatePlan={generateDemareePlan as (d: Date) => CheckpointPlan[]}
       getWarnings={getDemareeWarnings as (c: CheckpointPlan[]) => CheckpointWarning[]}
-      meta={<DemareeToolMeta />}
+      meta={meta}
       faqI18nKey="swarmManagement.demaree.faq.items"
     />
   );

--- a/apps/frontend/src/pages/tools/index.ts
+++ b/apps/frontend/src/pages/tools/index.ts
@@ -3,4 +3,6 @@ export { SyrupCalculatorPage } from './syrup-calculator-page';
 export { BroodTimelinePage } from './brood-timeline-page';
 export { SwarmManagementOverviewPage } from './swarm-management-overview-page';
 export { DemareeMethodPage } from './demaree-method-page';
+export { PagdenMethodPage } from './pagden-method-page';
+export { ArtificialSwarmMethodPage } from './artificial-swarm-method-page';
 export { VarroaManagementPage } from './varroa-management-page';

--- a/apps/frontend/src/pages/tools/pagden-method-page.tsx
+++ b/apps/frontend/src/pages/tools/pagden-method-page.tsx
@@ -1,14 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { ToolMeta, buildFaqJsonLd, type FaqItem } from '@/components/tool-page';
-import {
-  generatePagdenPlan,
-  getPagdenWarnings,
-} from './pagden-planner';
-import {
-  SwarmMethodPageLayout,
-  type CheckpointPlan,
-  type CheckpointWarning,
-} from './swarm-method-page-layout';
+import { generatePagdenPlan, getPagdenWarnings } from './pagden-planner';
+import { SwarmMethodPageLayout, type CheckpointPlan, type CheckpointWarning } from './swarm-method-page-layout';
 
 const METHOD_DETAIL_SECTIONS = [
   {
@@ -33,92 +26,52 @@ const METHOD_DETAIL_SECTIONS = [
   },
 ];
 
-function PagdenToolMeta() {
+export function PagdenMethodPage() {
   const { t } = useTranslation('common');
-  const faqItems = t('swarmManagement.pagden.faq.items', {
-    returnObjects: true,
-  }) as FaqItem[];
+  const faqItems = t('swarmManagement.pagden.faq.items', { returnObjects: true }) as FaqItem[];
 
-  const structuredData = {
-    '@context': 'https://schema.org',
-    '@graph': [
-      {
-        '@type': 'WebApplication',
-        name: 'Pagden Split Method Guide and Planner',
-        url: 'https://hivepal.app/tools/swarm-management/pagden',
-        applicationCategory: 'EducationalApplication',
-        applicationSubCategory: 'Beekeeping Reference',
-        operatingSystem: 'Web',
-        browserRequirements: 'Requires JavaScript',
-        description:
-          'Reference guide and inspection planner for the Pagden split swarm-control method, with prerequisites, step-by-step instructions, pros/cons, and follow-up timing.',
-        isAccessibleForFree: true,
-        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-        publisher: {
-          '@type': 'Organization',
-          name: 'Hive Pal',
-          url: 'https://hivepal.app',
-        },
-      },
-      {
-        '@type': 'HowTo',
-        name: 'How to perform the Pagden split method',
-        description:
-          'Step-by-step Pagden procedure for relieving swarm pressure by moving the queen to a new hive on the original stand while relocating the parent colony with brood.',
-        step: [
-          {
-            '@type': 'HowToStep',
-            name: 'Preparation',
-            text: 'Find a spare brood box with drawn comb and prepare a second hive floor and stand positioned a few metres away from the original location.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Relocate the Queen',
-            text: 'Locate the laying queen, place her and the frame she is on into the centre of the new brood box, and remove any queen cells from that frame. Place the new box on the original hive floor so flying bees return to her.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Manage the Parent Colony',
-            text: 'Move the original hive to the second floor a few metres away. Reduce queen cells to one or two well-placed, well-formed cells so the colony can raise a new queen.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Reassembly',
-            text: 'Place a queen excluder on top of the new hive if adding supers, add supers as needed, and fit crown board and roof on both hives.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Follow-up at day 7-8',
-            text: 'Inspect the parent colony and reduce queen cells to one well-placed, well-formed cell to reduce the risk of secondary swarming.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Follow-up at day 14-15',
-            text: 'Check that the retained queen cell is capped and developing. Remove any additional cells.',
-          },
-          {
-            '@type': 'HowToStep',
-            name: 'Follow-up at day 21-22',
-            text: 'Confirm the new queen is mated and laying in the parent colony. Assess both colonies and decide on next steps.',
-          },
-        ],
-      },
-      buildFaqJsonLd(faqItems),
-    ],
-  };
-
-  return (
+  const meta = (
     <ToolMeta
       title="Pagden Split Method: Swarm Control Guide and Planner — Hive Pal"
       description="Free reference guide and inspection planner for the Pagden split swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
       ogDescription="Step-by-step Pagden split method for honey bee swarm control, with follow-up timing and an inspection planner."
       path="/tools/swarm-management/pagden"
-      structuredData={structuredData}
+      structuredData={{
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'WebApplication',
+            name: 'Pagden Split Method Guide and Planner',
+            url: 'https://hivepal.app/tools/swarm-management/pagden',
+            applicationCategory: 'EducationalApplication',
+            applicationSubCategory: 'Beekeeping Reference',
+            operatingSystem: 'Web',
+            browserRequirements: 'Requires JavaScript',
+            description: 'Reference guide and inspection planner for the Pagden split swarm-control method, with prerequisites, step-by-step instructions, pros/cons, and follow-up timing.',
+            isAccessibleForFree: true,
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+            publisher: { '@type': 'Organization', name: 'Hive Pal', url: 'https://hivepal.app' },
+          },
+          {
+            '@type': 'HowTo',
+            name: 'How to perform the Pagden split method',
+            description: 'Step-by-step Pagden procedure for relieving swarm pressure by moving the queen to a new hive on the original stand while relocating the parent colony with brood.',
+            step: [
+              { '@type': 'HowToStep', name: 'Preparation', text: 'Find a spare brood box with drawn comb and prepare a second hive floor and stand a few metres away.' },
+              { '@type': 'HowToStep', name: 'Relocate the Queen', text: 'Locate the laying queen, place her and her frame into the new brood box on the original stand. Flying bees return to her.' },
+              { '@type': 'HowToStep', name: 'Manage the Parent Colony', text: 'Move the original hive a few metres away. Reduce queen cells to one or two well-placed cells so the colony can raise a new queen.' },
+              { '@type': 'HowToStep', name: 'Reassembly', text: 'Add a queen excluder and supers to the new hive as needed. Fit crown board and roof on both hives.' },
+              { '@type': 'HowToStep', name: 'Follow-up at day 7-8', text: 'Inspect the parent colony and reduce queen cells to one well-placed cell.' },
+              { '@type': 'HowToStep', name: 'Follow-up at day 14-15', text: 'Check the retained queen cell is capped and developing. Remove any additional cells.' },
+              { '@type': 'HowToStep', name: 'Follow-up at day 21-22', text: 'Confirm the new queen is mated and laying in the parent colony.' },
+            ],
+          },
+          buildFaqJsonLd(faqItems),
+        ],
+      }}
     />
   );
-}
 
-export function PagdenMethodPage() {
   return (
     <SwarmMethodPageLayout
       ns="swarmManagement.pagden"
@@ -129,7 +82,7 @@ export function PagdenMethodPage() {
       methodDetailSections={METHOD_DETAIL_SECTIONS}
       generatePlan={generatePagdenPlan as (d: Date) => CheckpointPlan[]}
       getWarnings={getPagdenWarnings as (c: CheckpointPlan[]) => CheckpointWarning[]}
-      meta={<PagdenToolMeta />}
+      meta={meta}
       faqI18nKey="swarmManagement.pagden.faq.items"
     />
   );

--- a/apps/frontend/src/pages/tools/pagden-method-page.tsx
+++ b/apps/frontend/src/pages/tools/pagden-method-page.tsx
@@ -1,262 +1,43 @@
-import { useMemo, useState } from 'react';
-import {
-  AlertTriangle,
-  CalendarClock,
-  ShieldAlert,
-  Waypoints,
-} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
-import { InspectionStatus, type HiveResponse } from 'shared-schemas';
-import { useCreateInspection, useHives } from '@/api/hooks';
-import { useAuth } from '@/context/auth-context';
+import { ToolMeta, buildFaqJsonLd, type FaqItem } from '@/components/tool-page';
 import {
-  MainContent,
-  PageAside,
-  PageGrid,
-} from '@/components/layout/page-grid-layout';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Textarea } from '@/components/ui/textarea';
-import { DatePickerPopover } from '@/components/common/date-picker-popover';
-import {
-  CalloutCard,
-  DotList,
-  ToolMeta,
-  ToolPageHeader,
-  ToolFaq,
-  buildFaqJsonLd,
-  type FaqItem,
-} from '@/components/tool-page';
-import { useLocalizedPath } from '@/hooks/use-language-navigation';
-import { cn } from '@/lib/utils';
-import { toInspectionDateISOString } from '@/utils/inspection-date';
-import {
-  type PagdenCheckpointPlan,
-  type PagdenWarning,
-  type PagdenWarningCode,
   generatePagdenPlan,
   getPagdenWarnings,
 } from './pagden-planner';
-
-type EditableCheckpoint = PagdenCheckpointPlan & {
-  notes: string;
-};
-
-const warningVariantClasses: Record<PagdenWarningCode, string> = {
-  lateQueenCellCheck: 'border-amber-300 bg-amber-50 dark:bg-amber-950/30',
-  unsafeCheckpointSpacing: 'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
-  illogicalScheduleOrder: 'border-red-300 bg-red-50 dark:bg-red-950/30',
-};
-
-function buildCheckpointNotes(
-  checkpoint: PagdenCheckpointPlan,
-  t: (key: string, options?: Record<string, unknown>) => string,
-) {
-  const checklist = checkpoint.checklistKeys.map(key => `- ${t(key)}`).join('\n');
-
-  return [
-    `${t('swarmManagement.pagden.planner.checkpointPrefix')} ${t(checkpoint.titleKey)}`,
-    t(checkpoint.summaryKey),
-    '',
-    t('swarmManagement.pagden.planner.notesChecklistLabel'),
-    checklist,
-  ].join('\n');
-}
-
-function WarningSummary({
-  warning,
-  t,
-}: Readonly<{
-  warning: PagdenWarning;
-  t: (key: string, options?: Record<string, unknown>) => string;
-}>) {
-  return (
-    <div
-      className={cn(
-        'rounded-lg border p-3',
-        warningVariantClasses[warning.code],
-      )}
-    >
-      <p className="font-medium">
-        {t(`swarmManagement.warnings.${warning.code}.title`)}
-      </p>
-      <p className="mt-1 text-sm text-muted-foreground">
-        {t(`swarmManagement.warnings.${warning.code}.description`)}
-      </p>
-    </div>
-  );
-}
+import {
+  SwarmMethodPageLayout,
+  type CheckpointPlan,
+  type CheckpointWarning,
+} from './swarm-method-page-layout';
 
 const METHOD_DETAIL_SECTIONS = [
   {
     id: 'preparation',
-    items: [0, 1] as number[],
+    items: [0, 1],
     children: {} as Record<number, number[]>,
   },
   {
     id: 'relocateQueen',
-    items: [0, 1, 2, 3] as number[],
+    items: [0, 1, 2, 3],
     children: {} as Record<number, number[]>,
   },
   {
     id: 'queenCells',
-    items: [0, 1, 2] as number[],
+    items: [0, 1, 2],
     children: {} as Record<number, number[]>,
   },
   {
     id: 'reassembly',
-    items: [0, 1, 2] as number[],
+    items: [0, 1, 2],
     children: {} as Record<number, number[]>,
   },
 ];
 
-export function PagdenMethodPage() {
+function PagdenToolMeta() {
   const { t } = useTranslation('common');
-  const navigate = useNavigate();
-  const localize = useLocalizedPath();
-  const { isLoggedIn } = useAuth();
-  const { data: hives = [], isLoading: isLoadingHives } = useHives();
-  const { mutateAsync: createInspection, isPending: isSaving } =
-    useCreateInspection();
-
-  const [selectedHiveId, setSelectedHiveId] = useState<string>('');
-  const [startDate, setStartDate] = useState<Date | undefined>();
-  const [checkpoints, setCheckpoints] = useState<EditableCheckpoint[]>([]);
-
-  const warnings = useMemo(() => getPagdenWarnings(checkpoints), [checkpoints]);
-
-  const selectedHive = hives.find(hive => hive.id === selectedHiveId);
-
-  // Visible FAQ and FAQPage structured data share one translated source.
   const faqItems = t('swarmManagement.pagden.faq.items', {
     returnObjects: true,
   }) as FaqItem[];
-
-  const handleGeneratePlan = () => {
-    if (!startDate) return;
-
-    const nextCheckpoints = generatePagdenPlan(startDate).map(checkpoint => ({
-      ...checkpoint,
-      notes: buildCheckpointNotes(checkpoint, t),
-    }));
-
-    setCheckpoints(nextCheckpoints);
-  };
-
-  const updateCheckpoint = (
-    checkpointId: EditableCheckpoint['id'],
-    updates: Partial<EditableCheckpoint>,
-  ) => {
-    setCheckpoints(currentCheckpoints =>
-      currentCheckpoints.map(checkpoint =>
-        checkpoint.id === checkpointId
-          ? { ...checkpoint, ...updates }
-          : checkpoint,
-      ),
-    );
-  };
-
-  const getCheckpointWarnings = (checkpointId: EditableCheckpoint['id']) =>
-    warnings.filter(warning => warning.checkpointIds.includes(checkpointId));
-
-  const handleSavePlan = async () => {
-    if (!selectedHiveId || checkpoints.length === 0) return;
-
-    const results = await Promise.allSettled(
-      checkpoints.map(checkpoint =>
-        createInspection({
-          hiveId: selectedHiveId,
-          date: toInspectionDateISOString(checkpoint.date, true),
-          isAllDay: true,
-          notes: checkpoint.notes,
-          status: InspectionStatus.SCHEDULED,
-          actions: [],
-        }),
-      ),
-    );
-
-    const successCount = results.filter(
-      result => result.status === 'fulfilled',
-    ).length;
-    const failedCount = results.length - successCount;
-
-    if (successCount === checkpoints.length) {
-      toast.success(
-        t('swarmManagement.pagden.planner.savedSuccess', { count: successCount }),
-      );
-      navigate(localize('/inspections/list/upcoming'));
-      return;
-    }
-
-    if (successCount > 0) {
-      toast.warning(
-        t('swarmManagement.pagden.planner.savedPartial', {
-          successCount,
-          failedCount,
-        }),
-      );
-      navigate(localize('/inspections/list/upcoming'));
-      return;
-    }
-
-    if (failedCount > 0) {
-      toast.error(t('swarmManagement.pagden.planner.savedError'));
-    }
-  };
-
-  const handleCancel = () => {
-    setCheckpoints([]);
-    navigate(localize('/tools/swarm-management'));
-  };
-
-  const renderHiveSelect = () => {
-    if (isLoadingHives) {
-      return <Skeleton className="h-10 w-full" />;
-    }
-
-    if (hives.length === 0) {
-      return (
-        <p className="text-sm text-muted-foreground">
-          {t('swarmManagement.planner.noHives')}
-        </p>
-      );
-    }
-
-    return (
-      <Select value={selectedHiveId} onValueChange={setSelectedHiveId}>
-        <SelectTrigger>
-          <SelectValue
-            placeholder={t('swarmManagement.planner.hivePlaceholder')}
-          />
-        </SelectTrigger>
-        <SelectContent>
-          {hives.map((hive: HiveResponse) => (
-            <SelectItem key={hive.id} value={hive.id}>
-              {hive.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    );
-  };
 
   const structuredData = {
     '@context': 'https://schema.org',
@@ -298,7 +79,7 @@ export function PagdenMethodPage() {
           {
             '@type': 'HowToStep',
             name: 'Manage the Parent Colony',
-            text: 'Move the original hive (now without the queen) to the second floor a few metres away, inspect all brood frames, and knock down any queen cells that have been started.',
+            text: 'Move the original hive to the second floor a few metres away. Reduce queen cells to one or two well-placed, well-formed cells so the colony can raise a new queen.',
           },
           {
             '@type': 'HowToStep',
@@ -308,17 +89,17 @@ export function PagdenMethodPage() {
           {
             '@type': 'HowToStep',
             name: 'Follow-up at day 7-8',
-            text: 'Inspect the parent colony for queen cells and remove any that have been started.',
+            text: 'Inspect the parent colony and reduce queen cells to one well-placed, well-formed cell to reduce the risk of secondary swarming.',
           },
           {
             '@type': 'HowToStep',
             name: 'Follow-up at day 14-15',
-            text: 'Review again for any late-started queen cells and confirm the parent colony is developing well.',
+            text: 'Check that the retained queen cell is capped and developing. Remove any additional cells.',
           },
           {
             '@type': 'HowToStep',
             name: 'Follow-up at day 21-22',
-            text: 'Carry out a final review to assess both colonies and decide on next steps for the season.',
+            text: 'Confirm the new queen is mated and laying in the parent colony. Assess both colonies and decide on next steps.',
           },
         ],
       },
@@ -327,406 +108,29 @@ export function PagdenMethodPage() {
   };
 
   return (
-    <PageGrid>
-      <ToolMeta
-        title="Pagden Split Method: Swarm Control Guide and Planner — Hive Pal"
-        description="Free reference guide and inspection planner for the Pagden split swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
-        ogDescription="Step-by-step Pagden split method for honey bee swarm control, with follow-up timing and an inspection planner."
-        path="/tools/swarm-management/pagden"
-        structuredData={structuredData}
-      />
+    <ToolMeta
+      title="Pagden Split Method: Swarm Control Guide and Planner — Hive Pal"
+      description="Free reference guide and inspection planner for the Pagden split swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
+      ogDescription="Step-by-step Pagden split method for honey bee swarm control, with follow-up timing and an inspection planner."
+      path="/tools/swarm-management/pagden"
+      structuredData={structuredData}
+    />
+  );
+}
 
-      <MainContent>
-        <ToolPageHeader
-          title={t('swarmManagement.pagden.title')}
-          badge={
-            <Badge variant="outline">{t('swarmManagement.pagden.badge')}</Badge>
-          }
-          description={t('swarmManagement.pagden.description')}
-          intro={t('swarmManagement.pagden.intro')}
-          backLink={{
-            to: localize('/tools/swarm-management'),
-            label: t('swarmManagement.backToOverview'),
-          }}
-        />
-
-        <div className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.pagden.overviewTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 text-sm text-muted-foreground">
-              <p>{t('swarmManagement.pagden.overviewLead')}</p>
-              <DotList
-                className="space-y-3"
-                items={[0, 1, 2].map(i =>
-                  t(`swarmManagement.pagden.overviewPoints.${i}`),
-                )}
-              />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.pagden.prerequisitesTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="list-disc space-y-3 pl-5 text-sm text-muted-foreground marker:text-primary/60">
-                {[0, 1, 2, 3, 4].map(i => (
-                  <li key={i}>{t(`swarmManagement.pagden.prerequisites.${i}`)}</li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.pagden.advantagesTitle')}</CardTitle>
-              <CardDescription>
-                {t('swarmManagement.pagden.advantagesDescription')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <DotList
-                items={[0, 1, 2].map(i =>
-                  t(`swarmManagement.pagden.advantages.${i}`),
-                )}
-              />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.pagden.stepsTitle')}</CardTitle>
-              <CardDescription>
-                {t('swarmManagement.pagden.stepsDescription')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-6 text-sm text-muted-foreground">
-                {METHOD_DETAIL_SECTIONS.map(section => (
-                  <div key={section.id} className="space-y-3">
-                    <h3 className="font-semibold text-foreground">
-                      {t(`swarmManagement.pagden.methodDetail.${section.id}.title`)}
-                    </h3>
-                    <ul className="list-disc space-y-2 pl-5 marker:text-primary/60">
-                      {section.items.map(itemIndex => (
-                        <li key={itemIndex}>
-                          <span>
-                            {t(
-                              `swarmManagement.pagden.methodDetail.${section.id}.items.${itemIndex}.text`,
-                            )}
-                          </span>
-                          {(section.children[itemIndex] ?? []).length > 0 && (
-                            <ul className="list-[circle] space-y-2 pl-5 pt-2 marker:text-muted-foreground/60">
-                              {(section.children[itemIndex] ?? []).map(childIndex => (
-                                <li key={childIndex}>
-                                  {t(
-                                    `swarmManagement.pagden.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
-                                  )}
-                                </li>
-                              ))}
-                            </ul>
-                          )}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.pagden.followUpTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="overflow-hidden rounded-lg border">
-                <div className="grid grid-cols-[minmax(80px,auto)_1fr] border-b bg-muted/40 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:px-4 sm:text-sm">
-                  <div>{t('swarmManagement.pagden.followUpDayHeader')}</div>
-                  <div>{t('swarmManagement.pagden.followUpTaskHeader')}</div>
-                </div>
-                {[0, 1, 2].map(index => (
-                  <div
-                    key={index}
-                    className="grid grid-cols-[minmax(80px,auto)_1fr] gap-3 border-b px-3 py-3 text-sm last:border-b-0 sm:px-4"
-                  >
-                    <div className="font-semibold text-foreground">
-                      {t(`swarmManagement.pagden.followUp.${index}.day`)}
-                    </div>
-                    <div className="text-muted-foreground">
-                      {t(`swarmManagement.pagden.followUp.${index}.task`)}
-                    </div>
-                  </div>
-                ))}
-              </div>
-              <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-muted-foreground dark:bg-amber-950/30">
-                <p className="flex items-start gap-2 font-medium text-foreground">
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-                  {t('swarmManagement.aside.criticalTimingTitle')}
-                </p>
-                <p className="mt-2">{t('swarmManagement.aside.criticalTimingLead')}</p>
-                <p className="mt-2">{t('swarmManagement.aside.criticalTimingDetail')}</p>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.pagden.prosConsTitle')}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-4 dark:border-emerald-900/40 dark:bg-emerald-950/20">
-                  <p className="mb-3 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
-                    {t('swarmManagement.pagden.prosTitle')}
-                  </p>
-                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-emerald-600/60">
-                    {[0, 1, 2, 3, 4].map(i => (
-                      <li key={i}>{t(`swarmManagement.pagden.pros.${i}`)}</li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="rounded-lg border border-rose-200 bg-rose-50/40 p-4 dark:border-rose-900/40 dark:bg-rose-950/20">
-                  <p className="mb-3 text-sm font-semibold text-rose-900 dark:text-rose-200">
-                    {t('swarmManagement.pagden.consTitle')}
-                  </p>
-                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-rose-600/60">
-                    {[0, 1, 2, 3, 4].map(i => (
-                      <li key={i}>{t(`swarmManagement.pagden.cons.${i}`)}</li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('swarmManagement.pagden.planner.title')}</CardTitle>
-              <CardDescription>
-                {t('swarmManagement.pagden.planner.description')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {!isLoggedIn ? (
-                <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center">
-                  <p className="text-base font-semibold text-foreground">
-                    {t('swarmManagement.planner.signInTitle')}
-                  </p>
-                  <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
-                    {t('swarmManagement.planner.signInDescription')}
-                  </p>
-                  <div className="mt-4 flex flex-col items-center justify-center gap-2 sm:flex-row">
-                    <Button asChild>
-                      <Link to="/login">{t('swarmManagement.planner.signInCta')}</Link>
-                    </Button>
-                    <Button variant="outline" asChild>
-                      <Link to="/register">
-                        {t('swarmManagement.planner.registerCta')}
-                      </Link>
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <>
-                  <div className="grid gap-4 sm:grid-cols-2">
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">
-                        {t('swarmManagement.planner.hiveLabel')}
-                      </p>
-                      {renderHiveSelect()}
-                    </div>
-
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">
-                        {t('swarmManagement.pagden.planner.startDateLabel')}
-                      </p>
-                      <DatePickerPopover
-                        date={startDate}
-                        onDateChange={setStartDate}
-                        placeholder={t(
-                          'swarmManagement.pagden.planner.startDatePlaceholder',
-                        )}
-                      />
-                    </div>
-                  </div>
-
-                  <Button
-                    className="w-full sm:w-auto"
-                    onClick={handleGeneratePlan}
-                    disabled={!selectedHiveId || !startDate}
-                  >
-                    {t('swarmManagement.planner.generate')}
-                  </Button>
-
-                  {selectedHive && (
-                    <Alert>
-                      <Waypoints className="h-4 w-4" />
-                      <AlertTitle>
-                        {t('swarmManagement.planner.selectedHive')}
-                      </AlertTitle>
-                      <AlertDescription>{selectedHive.name}</AlertDescription>
-                    </Alert>
-                  )}
-
-                  {warnings.length > 0 && (
-                    <Alert className="border-amber-300 bg-amber-50 dark:bg-amber-950/30">
-                      <AlertTriangle className="h-4 w-4" />
-                      <AlertTitle>
-                        {t('swarmManagement.warnings.bannerTitle')}
-                      </AlertTitle>
-                      <AlertDescription className="mt-3 space-y-3">
-                        {warnings.map(warning => (
-                          <WarningSummary
-                            key={`${warning.code}-${warning.checkpointIds.join('-')}`}
-                            warning={warning}
-                            t={t}
-                          />
-                        ))}
-                      </AlertDescription>
-                    </Alert>
-                  )}
-
-                  {checkpoints.length > 0 ? (
-                    <div className="space-y-4">
-                      {checkpoints.map(checkpoint => {
-                        const checkpointWarnings = getCheckpointWarnings(
-                          checkpoint.id,
-                        );
-
-                        return (
-                          <Card key={checkpoint.id}>
-                            <CardHeader>
-                              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                <div className="min-w-0">
-                                  <CardTitle>{t(checkpoint.titleKey)}</CardTitle>
-                                  <CardDescription>
-                                    {t('swarmManagement.planner.dayOffset', {
-                                      count: checkpoint.dayOffset,
-                                    })}
-                                  </CardDescription>
-                                </div>
-                                <DatePickerPopover
-                                  date={checkpoint.date}
-                                  onDateChange={date => {
-                                    if (date) {
-                                      updateCheckpoint(checkpoint.id, { date });
-                                    }
-                                  }}
-                                  align="end"
-                                  className="w-full sm:w-auto"
-                                />
-                              </div>
-                            </CardHeader>
-                            <CardContent className="space-y-4">
-                              <p className="text-sm text-muted-foreground">
-                                {t(checkpoint.summaryKey)}
-                              </p>
-                              {checkpointWarnings.map(warning => (
-                                <Alert
-                                  key={`${checkpoint.id}-${warning.code}`}
-                                  className={warningVariantClasses[warning.code]}
-                                >
-                                  <ShieldAlert className="h-4 w-4" />
-                                  <AlertTitle>
-                                    {t(
-                                      `swarmManagement.warnings.${warning.code}.title`,
-                                    )}
-                                  </AlertTitle>
-                                  <AlertDescription>
-                                    {t(
-                                      `swarmManagement.warnings.${warning.code}.description`,
-                                    )}
-                                  </AlertDescription>
-                                </Alert>
-                              ))}
-                              <div className="space-y-2">
-                                <p className="text-sm font-medium">
-                                  {t('swarmManagement.planner.notesLabel')}
-                                </p>
-                                <Textarea
-                                  value={checkpoint.notes}
-                                  onChange={event =>
-                                    updateCheckpoint(checkpoint.id, {
-                                      notes: event.target.value,
-                                    })
-                                  }
-                                  rows={8}
-                                />
-                              </div>
-                            </CardContent>
-                          </Card>
-                        );
-                      })}
-
-                      <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                        <Button variant="outline" onClick={handleCancel}>
-                          {t('actions.cancel')}
-                        </Button>
-                        <Button onClick={handleSavePlan} disabled={isSaving}>
-                          {isSaving
-                            ? t('swarmManagement.planner.saving')
-                            : t('swarmManagement.planner.save')}
-                        </Button>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
-                      {t('swarmManagement.planner.emptyState')}
-                    </div>
-                  )}
-                </>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        <ToolFaq title={t('swarmManagement.pagden.faq.title')} items={faqItems} />
-      </MainContent>
-
-      <PageAside>
-        <div className="space-y-4 md:sticky md:top-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-base">
-                <CalendarClock className="h-5 w-5 text-primary" />
-                {t('swarmManagement.planner.atAGlanceTitle')}
-              </CardTitle>
-              <CardDescription>
-                {t('swarmManagement.planner.atAGlanceDescription')}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <ol className="space-y-3 text-sm">
-                {[0, 1, 2].map(i => (
-                  <li
-                    key={i}
-                    className="flex gap-3 border-b pb-3 last:border-b-0 last:pb-0"
-                  >
-                    <div className="min-w-[68px] font-semibold text-foreground">
-                      {t(`swarmManagement.pagden.followUp.${i}.day`)}
-                    </div>
-                    <div className="text-muted-foreground">
-                      {t(`swarmManagement.pagden.followUp.${i}.task`)}
-                    </div>
-                  </li>
-                ))}
-              </ol>
-            </CardContent>
-          </Card>
-
-          <CalloutCard
-            variant="amber"
-            icon={<AlertTriangle className="h-5 w-5" />}
-            title={t('swarmManagement.aside.criticalTimingTitle')}
-          >
-            <p>{t('swarmManagement.aside.criticalTimingLead')}</p>
-            <p>{t('swarmManagement.aside.criticalTimingDetail')}</p>
-          </CalloutCard>
-        </div>
-      </PageAside>
-    </PageGrid>
+export function PagdenMethodPage() {
+  return (
+    <SwarmMethodPageLayout
+      ns="swarmManagement.pagden"
+      plannerNs="swarmManagement.planner"
+      methodPlannerNs="swarmManagement.pagden.planner"
+      prerequisiteCount={5}
+      prosConsCount={5}
+      methodDetailSections={METHOD_DETAIL_SECTIONS}
+      generatePlan={generatePagdenPlan as (d: Date) => CheckpointPlan[]}
+      getWarnings={getPagdenWarnings as (c: CheckpointPlan[]) => CheckpointWarning[]}
+      meta={<PagdenToolMeta />}
+      faqI18nKey="swarmManagement.pagden.faq.items"
+    />
   );
 }

--- a/apps/frontend/src/pages/tools/pagden-method-page.tsx
+++ b/apps/frontend/src/pages/tools/pagden-method-page.tsx
@@ -1,0 +1,732 @@
+import { useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CalendarClock,
+  ShieldAlert,
+  Waypoints,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { InspectionStatus, type HiveResponse } from 'shared-schemas';
+import { useCreateInspection, useHives } from '@/api/hooks';
+import { useAuth } from '@/context/auth-context';
+import {
+  MainContent,
+  PageAside,
+  PageGrid,
+} from '@/components/layout/page-grid-layout';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import { DatePickerPopover } from '@/components/common/date-picker-popover';
+import {
+  CalloutCard,
+  DotList,
+  ToolMeta,
+  ToolPageHeader,
+  ToolFaq,
+  buildFaqJsonLd,
+  type FaqItem,
+} from '@/components/tool-page';
+import { useLocalizedPath } from '@/hooks/use-language-navigation';
+import { cn } from '@/lib/utils';
+import { toInspectionDateISOString } from '@/utils/inspection-date';
+import {
+  type PagdenCheckpointPlan,
+  type PagdenWarning,
+  type PagdenWarningCode,
+  generatePagdenPlan,
+  getPagdenWarnings,
+} from './pagden-planner';
+
+type EditableCheckpoint = PagdenCheckpointPlan & {
+  notes: string;
+};
+
+const warningVariantClasses: Record<PagdenWarningCode, string> = {
+  lateQueenCellCheck: 'border-amber-300 bg-amber-50 dark:bg-amber-950/30',
+  unsafeCheckpointSpacing: 'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
+  illogicalScheduleOrder: 'border-red-300 bg-red-50 dark:bg-red-950/30',
+};
+
+function buildCheckpointNotes(
+  checkpoint: PagdenCheckpointPlan,
+  t: (key: string, options?: Record<string, unknown>) => string,
+) {
+  const checklist = checkpoint.checklistKeys.map(key => `- ${t(key)}`).join('\n');
+
+  return [
+    `${t('swarmManagement.pagden.planner.checkpointPrefix')} ${t(checkpoint.titleKey)}`,
+    t(checkpoint.summaryKey),
+    '',
+    t('swarmManagement.pagden.planner.notesChecklistLabel'),
+    checklist,
+  ].join('\n');
+}
+
+function WarningSummary({
+  warning,
+  t,
+}: Readonly<{
+  warning: PagdenWarning;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}>) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border p-3',
+        warningVariantClasses[warning.code],
+      )}
+    >
+      <p className="font-medium">
+        {t(`swarmManagement.warnings.${warning.code}.title`)}
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {t(`swarmManagement.warnings.${warning.code}.description`)}
+      </p>
+    </div>
+  );
+}
+
+const METHOD_DETAIL_SECTIONS = [
+  {
+    id: 'preparation',
+    items: [0, 1] as number[],
+    children: {} as Record<number, number[]>,
+  },
+  {
+    id: 'relocateQueen',
+    items: [0, 1, 2, 3] as number[],
+    children: {} as Record<number, number[]>,
+  },
+  {
+    id: 'queenCells',
+    items: [0, 1, 2] as number[],
+    children: {} as Record<number, number[]>,
+  },
+  {
+    id: 'reassembly',
+    items: [0, 1, 2] as number[],
+    children: {} as Record<number, number[]>,
+  },
+];
+
+export function PagdenMethodPage() {
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const localize = useLocalizedPath();
+  const { isLoggedIn } = useAuth();
+  const { data: hives = [], isLoading: isLoadingHives } = useHives();
+  const { mutateAsync: createInspection, isPending: isSaving } =
+    useCreateInspection();
+
+  const [selectedHiveId, setSelectedHiveId] = useState<string>('');
+  const [startDate, setStartDate] = useState<Date | undefined>();
+  const [checkpoints, setCheckpoints] = useState<EditableCheckpoint[]>([]);
+
+  const warnings = useMemo(() => getPagdenWarnings(checkpoints), [checkpoints]);
+
+  const selectedHive = hives.find(hive => hive.id === selectedHiveId);
+
+  // Visible FAQ and FAQPage structured data share one translated source.
+  const faqItems = t('swarmManagement.pagden.faq.items', {
+    returnObjects: true,
+  }) as FaqItem[];
+
+  const handleGeneratePlan = () => {
+    if (!startDate) return;
+
+    const nextCheckpoints = generatePagdenPlan(startDate).map(checkpoint => ({
+      ...checkpoint,
+      notes: buildCheckpointNotes(checkpoint, t),
+    }));
+
+    setCheckpoints(nextCheckpoints);
+  };
+
+  const updateCheckpoint = (
+    checkpointId: EditableCheckpoint['id'],
+    updates: Partial<EditableCheckpoint>,
+  ) => {
+    setCheckpoints(currentCheckpoints =>
+      currentCheckpoints.map(checkpoint =>
+        checkpoint.id === checkpointId
+          ? { ...checkpoint, ...updates }
+          : checkpoint,
+      ),
+    );
+  };
+
+  const getCheckpointWarnings = (checkpointId: EditableCheckpoint['id']) =>
+    warnings.filter(warning => warning.checkpointIds.includes(checkpointId));
+
+  const handleSavePlan = async () => {
+    if (!selectedHiveId || checkpoints.length === 0) return;
+
+    const results = await Promise.allSettled(
+      checkpoints.map(checkpoint =>
+        createInspection({
+          hiveId: selectedHiveId,
+          date: toInspectionDateISOString(checkpoint.date, true),
+          isAllDay: true,
+          notes: checkpoint.notes,
+          status: InspectionStatus.SCHEDULED,
+          actions: [],
+        }),
+      ),
+    );
+
+    const successCount = results.filter(
+      result => result.status === 'fulfilled',
+    ).length;
+    const failedCount = results.length - successCount;
+
+    if (successCount === checkpoints.length) {
+      toast.success(
+        t('swarmManagement.pagden.planner.savedSuccess', { count: successCount }),
+      );
+      navigate(localize('/inspections/list/upcoming'));
+      return;
+    }
+
+    if (successCount > 0) {
+      toast.warning(
+        t('swarmManagement.pagden.planner.savedPartial', {
+          successCount,
+          failedCount,
+        }),
+      );
+      navigate(localize('/inspections/list/upcoming'));
+      return;
+    }
+
+    if (failedCount > 0) {
+      toast.error(t('swarmManagement.pagden.planner.savedError'));
+    }
+  };
+
+  const handleCancel = () => {
+    setCheckpoints([]);
+    navigate(localize('/tools/swarm-management'));
+  };
+
+  const renderHiveSelect = () => {
+    if (isLoadingHives) {
+      return <Skeleton className="h-10 w-full" />;
+    }
+
+    if (hives.length === 0) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          {t('swarmManagement.planner.noHives')}
+        </p>
+      );
+    }
+
+    return (
+      <Select value={selectedHiveId} onValueChange={setSelectedHiveId}>
+        <SelectTrigger>
+          <SelectValue
+            placeholder={t('swarmManagement.planner.hivePlaceholder')}
+          />
+        </SelectTrigger>
+        <SelectContent>
+          {hives.map((hive: HiveResponse) => (
+            <SelectItem key={hive.id} value={hive.id}>
+              {hive.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  };
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebApplication',
+        name: 'Pagden Split Method Guide and Planner',
+        url: 'https://hivepal.app/tools/swarm-management/pagden',
+        applicationCategory: 'EducationalApplication',
+        applicationSubCategory: 'Beekeeping Reference',
+        operatingSystem: 'Web',
+        browserRequirements: 'Requires JavaScript',
+        description:
+          'Reference guide and inspection planner for the Pagden split swarm-control method, with prerequisites, step-by-step instructions, pros/cons, and follow-up timing.',
+        isAccessibleForFree: true,
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        publisher: {
+          '@type': 'Organization',
+          name: 'Hive Pal',
+          url: 'https://hivepal.app',
+        },
+      },
+      {
+        '@type': 'HowTo',
+        name: 'How to perform the Pagden split method',
+        description:
+          'Step-by-step Pagden procedure for relieving swarm pressure by moving the queen to a new hive on the original stand while relocating the parent colony with brood.',
+        step: [
+          {
+            '@type': 'HowToStep',
+            name: 'Preparation',
+            text: 'Find a spare brood box with drawn comb and prepare a second hive floor and stand positioned a few metres away from the original location.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Relocate the Queen',
+            text: 'Locate the laying queen, place her and the frame she is on into the centre of the new brood box, and remove any queen cells from that frame. Place the new box on the original hive floor so flying bees return to her.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Manage the Parent Colony',
+            text: 'Move the original hive (now without the queen) to the second floor a few metres away, inspect all brood frames, and knock down any queen cells that have been started.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Reassembly',
+            text: 'Place a queen excluder on top of the new hive if adding supers, add supers as needed, and fit crown board and roof on both hives.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Follow-up at day 7-8',
+            text: 'Inspect the parent colony for queen cells and remove any that have been started.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Follow-up at day 14-15',
+            text: 'Review again for any late-started queen cells and confirm the parent colony is developing well.',
+          },
+          {
+            '@type': 'HowToStep',
+            name: 'Follow-up at day 21-22',
+            text: 'Carry out a final review to assess both colonies and decide on next steps for the season.',
+          },
+        ],
+      },
+      buildFaqJsonLd(faqItems),
+    ],
+  };
+
+  return (
+    <PageGrid>
+      <ToolMeta
+        title="Pagden Split Method: Swarm Control Guide and Planner — Hive Pal"
+        description="Free reference guide and inspection planner for the Pagden split swarm-control method. Prerequisites, step-by-step instructions, follow-up timing, and pros/cons for honey bee beekeepers."
+        ogDescription="Step-by-step Pagden split method for honey bee swarm control, with follow-up timing and an inspection planner."
+        path="/tools/swarm-management/pagden"
+        structuredData={structuredData}
+      />
+
+      <MainContent>
+        <ToolPageHeader
+          title={t('swarmManagement.pagden.title')}
+          badge={
+            <Badge variant="outline">{t('swarmManagement.pagden.badge')}</Badge>
+          }
+          description={t('swarmManagement.pagden.description')}
+          intro={t('swarmManagement.pagden.intro')}
+          backLink={{
+            to: localize('/tools/swarm-management'),
+            label: t('swarmManagement.backToOverview'),
+          }}
+        />
+
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.pagden.overviewTitle')}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm text-muted-foreground">
+              <p>{t('swarmManagement.pagden.overviewLead')}</p>
+              <DotList
+                className="space-y-3"
+                items={[0, 1, 2].map(i =>
+                  t(`swarmManagement.pagden.overviewPoints.${i}`),
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.pagden.prerequisitesTitle')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc space-y-3 pl-5 text-sm text-muted-foreground marker:text-primary/60">
+                {[0, 1, 2, 3, 4].map(i => (
+                  <li key={i}>{t(`swarmManagement.pagden.prerequisites.${i}`)}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.pagden.advantagesTitle')}</CardTitle>
+              <CardDescription>
+                {t('swarmManagement.pagden.advantagesDescription')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DotList
+                items={[0, 1, 2].map(i =>
+                  t(`swarmManagement.pagden.advantages.${i}`),
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.pagden.stepsTitle')}</CardTitle>
+              <CardDescription>
+                {t('swarmManagement.pagden.stepsDescription')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-6 text-sm text-muted-foreground">
+                {METHOD_DETAIL_SECTIONS.map(section => (
+                  <div key={section.id} className="space-y-3">
+                    <h3 className="font-semibold text-foreground">
+                      {t(`swarmManagement.pagden.methodDetail.${section.id}.title`)}
+                    </h3>
+                    <ul className="list-disc space-y-2 pl-5 marker:text-primary/60">
+                      {section.items.map(itemIndex => (
+                        <li key={itemIndex}>
+                          <span>
+                            {t(
+                              `swarmManagement.pagden.methodDetail.${section.id}.items.${itemIndex}.text`,
+                            )}
+                          </span>
+                          {(section.children[itemIndex] ?? []).length > 0 && (
+                            <ul className="list-[circle] space-y-2 pl-5 pt-2 marker:text-muted-foreground/60">
+                              {(section.children[itemIndex] ?? []).map(childIndex => (
+                                <li key={childIndex}>
+                                  {t(
+                                    `swarmManagement.pagden.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
+                                  )}
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.pagden.followUpTitle')}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="overflow-hidden rounded-lg border">
+                <div className="grid grid-cols-[minmax(80px,auto)_1fr] border-b bg-muted/40 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:px-4 sm:text-sm">
+                  <div>{t('swarmManagement.pagden.followUpDayHeader')}</div>
+                  <div>{t('swarmManagement.pagden.followUpTaskHeader')}</div>
+                </div>
+                {[0, 1, 2].map(index => (
+                  <div
+                    key={index}
+                    className="grid grid-cols-[minmax(80px,auto)_1fr] gap-3 border-b px-3 py-3 text-sm last:border-b-0 sm:px-4"
+                  >
+                    <div className="font-semibold text-foreground">
+                      {t(`swarmManagement.pagden.followUp.${index}.day`)}
+                    </div>
+                    <div className="text-muted-foreground">
+                      {t(`swarmManagement.pagden.followUp.${index}.task`)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-muted-foreground dark:bg-amber-950/30">
+                <p className="flex items-start gap-2 font-medium text-foreground">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                  {t('swarmManagement.aside.criticalTimingTitle')}
+                </p>
+                <p className="mt-2">{t('swarmManagement.aside.criticalTimingLead')}</p>
+                <p className="mt-2">{t('swarmManagement.aside.criticalTimingDetail')}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.pagden.prosConsTitle')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-4 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+                  <p className="mb-3 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+                    {t('swarmManagement.pagden.prosTitle')}
+                  </p>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-emerald-600/60">
+                    {[0, 1, 2, 3, 4].map(i => (
+                      <li key={i}>{t(`swarmManagement.pagden.pros.${i}`)}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="rounded-lg border border-rose-200 bg-rose-50/40 p-4 dark:border-rose-900/40 dark:bg-rose-950/20">
+                  <p className="mb-3 text-sm font-semibold text-rose-900 dark:text-rose-200">
+                    {t('swarmManagement.pagden.consTitle')}
+                  </p>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-rose-600/60">
+                    {[0, 1, 2, 3, 4].map(i => (
+                      <li key={i}>{t(`swarmManagement.pagden.cons.${i}`)}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('swarmManagement.pagden.planner.title')}</CardTitle>
+              <CardDescription>
+                {t('swarmManagement.pagden.planner.description')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {!isLoggedIn ? (
+                <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center">
+                  <p className="text-base font-semibold text-foreground">
+                    {t('swarmManagement.planner.signInTitle')}
+                  </p>
+                  <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+                    {t('swarmManagement.planner.signInDescription')}
+                  </p>
+                  <div className="mt-4 flex flex-col items-center justify-center gap-2 sm:flex-row">
+                    <Button asChild>
+                      <Link to="/login">{t('swarmManagement.planner.signInCta')}</Link>
+                    </Button>
+                    <Button variant="outline" asChild>
+                      <Link to="/register">
+                        {t('swarmManagement.planner.registerCta')}
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">
+                        {t('swarmManagement.planner.hiveLabel')}
+                      </p>
+                      {renderHiveSelect()}
+                    </div>
+
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">
+                        {t('swarmManagement.pagden.planner.startDateLabel')}
+                      </p>
+                      <DatePickerPopover
+                        date={startDate}
+                        onDateChange={setStartDate}
+                        placeholder={t(
+                          'swarmManagement.pagden.planner.startDatePlaceholder',
+                        )}
+                      />
+                    </div>
+                  </div>
+
+                  <Button
+                    className="w-full sm:w-auto"
+                    onClick={handleGeneratePlan}
+                    disabled={!selectedHiveId || !startDate}
+                  >
+                    {t('swarmManagement.planner.generate')}
+                  </Button>
+
+                  {selectedHive && (
+                    <Alert>
+                      <Waypoints className="h-4 w-4" />
+                      <AlertTitle>
+                        {t('swarmManagement.planner.selectedHive')}
+                      </AlertTitle>
+                      <AlertDescription>{selectedHive.name}</AlertDescription>
+                    </Alert>
+                  )}
+
+                  {warnings.length > 0 && (
+                    <Alert className="border-amber-300 bg-amber-50 dark:bg-amber-950/30">
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertTitle>
+                        {t('swarmManagement.warnings.bannerTitle')}
+                      </AlertTitle>
+                      <AlertDescription className="mt-3 space-y-3">
+                        {warnings.map(warning => (
+                          <WarningSummary
+                            key={`${warning.code}-${warning.checkpointIds.join('-')}`}
+                            warning={warning}
+                            t={t}
+                          />
+                        ))}
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
+                  {checkpoints.length > 0 ? (
+                    <div className="space-y-4">
+                      {checkpoints.map(checkpoint => {
+                        const checkpointWarnings = getCheckpointWarnings(
+                          checkpoint.id,
+                        );
+
+                        return (
+                          <Card key={checkpoint.id}>
+                            <CardHeader>
+                              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                <div className="min-w-0">
+                                  <CardTitle>{t(checkpoint.titleKey)}</CardTitle>
+                                  <CardDescription>
+                                    {t('swarmManagement.planner.dayOffset', {
+                                      count: checkpoint.dayOffset,
+                                    })}
+                                  </CardDescription>
+                                </div>
+                                <DatePickerPopover
+                                  date={checkpoint.date}
+                                  onDateChange={date => {
+                                    if (date) {
+                                      updateCheckpoint(checkpoint.id, { date });
+                                    }
+                                  }}
+                                  align="end"
+                                  className="w-full sm:w-auto"
+                                />
+                              </div>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                              <p className="text-sm text-muted-foreground">
+                                {t(checkpoint.summaryKey)}
+                              </p>
+                              {checkpointWarnings.map(warning => (
+                                <Alert
+                                  key={`${checkpoint.id}-${warning.code}`}
+                                  className={warningVariantClasses[warning.code]}
+                                >
+                                  <ShieldAlert className="h-4 w-4" />
+                                  <AlertTitle>
+                                    {t(
+                                      `swarmManagement.warnings.${warning.code}.title`,
+                                    )}
+                                  </AlertTitle>
+                                  <AlertDescription>
+                                    {t(
+                                      `swarmManagement.warnings.${warning.code}.description`,
+                                    )}
+                                  </AlertDescription>
+                                </Alert>
+                              ))}
+                              <div className="space-y-2">
+                                <p className="text-sm font-medium">
+                                  {t('swarmManagement.planner.notesLabel')}
+                                </p>
+                                <Textarea
+                                  value={checkpoint.notes}
+                                  onChange={event =>
+                                    updateCheckpoint(checkpoint.id, {
+                                      notes: event.target.value,
+                                    })
+                                  }
+                                  rows={8}
+                                />
+                              </div>
+                            </CardContent>
+                          </Card>
+                        );
+                      })}
+
+                      <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                        <Button variant="outline" onClick={handleCancel}>
+                          {t('actions.cancel')}
+                        </Button>
+                        <Button onClick={handleSavePlan} disabled={isSaving}>
+                          {isSaving
+                            ? t('swarmManagement.planner.saving')
+                            : t('swarmManagement.planner.save')}
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+                      {t('swarmManagement.planner.emptyState')}
+                    </div>
+                  )}
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <ToolFaq title={t('swarmManagement.pagden.faq.title')} items={faqItems} />
+      </MainContent>
+
+      <PageAside>
+        <div className="space-y-4 md:sticky md:top-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <CalendarClock className="h-5 w-5 text-primary" />
+                {t('swarmManagement.planner.atAGlanceTitle')}
+              </CardTitle>
+              <CardDescription>
+                {t('swarmManagement.planner.atAGlanceDescription')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ol className="space-y-3 text-sm">
+                {[0, 1, 2].map(i => (
+                  <li
+                    key={i}
+                    className="flex gap-3 border-b pb-3 last:border-b-0 last:pb-0"
+                  >
+                    <div className="min-w-[68px] font-semibold text-foreground">
+                      {t(`swarmManagement.pagden.followUp.${i}.day`)}
+                    </div>
+                    <div className="text-muted-foreground">
+                      {t(`swarmManagement.pagden.followUp.${i}.task`)}
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </CardContent>
+          </Card>
+
+          <CalloutCard
+            variant="amber"
+            icon={<AlertTriangle className="h-5 w-5" />}
+            title={t('swarmManagement.aside.criticalTimingTitle')}
+          >
+            <p>{t('swarmManagement.aside.criticalTimingLead')}</p>
+            <p>{t('swarmManagement.aside.criticalTimingDetail')}</p>
+          </CalloutCard>
+        </div>
+      </PageAside>
+    </PageGrid>
+  );
+}

--- a/apps/frontend/src/pages/tools/pagden-planner.ts
+++ b/apps/frontend/src/pages/tools/pagden-planner.ts
@@ -1,0 +1,137 @@
+import { addDays, differenceInCalendarDays } from 'date-fns';
+
+export type PagdenCheckpointId =
+  | 'setup'
+  | 'queenCellCheck'
+  | 'secondQueenCellCheck'
+  | 'colonyReview';
+
+export interface PagdenCheckpointTemplate {
+  id: PagdenCheckpointId;
+  dayOffset: number;
+  titleKey: string;
+  summaryKey: string;
+  checklistKeys: string[];
+}
+
+export interface PagdenCheckpointPlan extends PagdenCheckpointTemplate {
+  date: Date;
+}
+
+export type PagdenWarningCode =
+  | 'lateQueenCellCheck'
+  | 'unsafeCheckpointSpacing'
+  | 'illogicalScheduleOrder';
+
+export interface PagdenWarning {
+  code: PagdenWarningCode;
+  checkpointIds: PagdenCheckpointId[];
+}
+
+export const PAGDEN_CHECKPOINTS: PagdenCheckpointTemplate[] = [
+  {
+    id: 'setup',
+    dayOffset: 0,
+    titleKey: 'swarmManagement.pagden.planner.checkpoints.setup.title',
+    summaryKey: 'swarmManagement.pagden.planner.checkpoints.setup.summary',
+    checklistKeys: [
+      'swarmManagement.pagden.planner.checkpoints.setup.checklist.0',
+      'swarmManagement.pagden.planner.checkpoints.setup.checklist.1',
+      'swarmManagement.pagden.planner.checkpoints.setup.checklist.2',
+    ],
+  },
+  {
+    id: 'queenCellCheck',
+    dayOffset: 7,
+    titleKey: 'swarmManagement.pagden.planner.checkpoints.queenCellCheck.title',
+    summaryKey:
+      'swarmManagement.pagden.planner.checkpoints.queenCellCheck.summary',
+    checklistKeys: [
+      'swarmManagement.pagden.planner.checkpoints.queenCellCheck.checklist.0',
+      'swarmManagement.pagden.planner.checkpoints.queenCellCheck.checklist.1',
+      'swarmManagement.pagden.planner.checkpoints.queenCellCheck.checklist.2',
+    ],
+  },
+  {
+    id: 'secondQueenCellCheck',
+    dayOffset: 14,
+    titleKey:
+      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.title',
+    summaryKey:
+      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.summary',
+    checklistKeys: [
+      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.checklist.0',
+      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.checklist.1',
+      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.checklist.2',
+    ],
+  },
+  {
+    id: 'colonyReview',
+    dayOffset: 21,
+    titleKey: 'swarmManagement.pagden.planner.checkpoints.colonyReview.title',
+    summaryKey:
+      'swarmManagement.pagden.planner.checkpoints.colonyReview.summary',
+    checklistKeys: [
+      'swarmManagement.pagden.planner.checkpoints.colonyReview.checklist.0',
+      'swarmManagement.pagden.planner.checkpoints.colonyReview.checklist.1',
+      'swarmManagement.pagden.planner.checkpoints.colonyReview.checklist.2',
+    ],
+  },
+];
+
+export const generatePagdenPlan = (startDate: Date): PagdenCheckpointPlan[] =>
+  PAGDEN_CHECKPOINTS.map(checkpoint => ({
+    ...checkpoint,
+    date: addDays(startDate, checkpoint.dayOffset),
+  }));
+
+export const getPagdenWarnings = (
+  checkpoints: Array<Pick<PagdenCheckpointPlan, 'id' | 'date'>>,
+): PagdenWarning[] => {
+  const warnings: PagdenWarning[] = [];
+
+  const setup = checkpoints.find(checkpoint => checkpoint.id === 'setup');
+  const queenCellCheck = checkpoints.find(
+    checkpoint => checkpoint.id === 'queenCellCheck',
+  );
+
+  if (setup && queenCellCheck) {
+    const queenCellGap = differenceInCalendarDays(
+      queenCellCheck.date,
+      setup.date,
+    );
+
+    if (queenCellGap > 8) {
+      warnings.push({
+        code: 'lateQueenCellCheck',
+        checkpointIds: ['setup', 'queenCellCheck'],
+      });
+    }
+  }
+
+  for (let index = 1; index < checkpoints.length; index += 1) {
+    const previousCheckpoint = checkpoints[index - 1];
+    const currentCheckpoint = checkpoints[index];
+    const gap = differenceInCalendarDays(
+      currentCheckpoint.date,
+      previousCheckpoint.date,
+    );
+
+    if (gap <= 0) {
+      warnings.push({
+        code: 'illogicalScheduleOrder',
+        checkpointIds: [previousCheckpoint.id, currentCheckpoint.id],
+      });
+      continue;
+    }
+
+    if (gap < 5 || gap > 10) {
+      warnings.push({
+        code: 'unsafeCheckpointSpacing',
+        checkpointIds: [previousCheckpoint.id, currentCheckpoint.id],
+      });
+    }
+  }
+
+  return warnings;
+};

--- a/apps/frontend/src/pages/tools/pagden-planner.ts
+++ b/apps/frontend/src/pages/tools/pagden-planner.ts
@@ -1,137 +1,14 @@
-import { addDays, differenceInCalendarDays } from 'date-fns';
+import {
+  buildCheckpoints,
+  buildGeneratePlan,
+  buildGetWarnings,
+} from './swarm-planner-factory';
 
-export type PagdenCheckpointId =
-  | 'setup'
-  | 'queenCellCheck'
-  | 'secondQueenCellCheck'
-  | 'colonyReview';
+export const PAGDEN_CHECKPOINTS = buildCheckpoints('swarmManagement.pagden');
 
-export interface PagdenCheckpointTemplate {
-  id: PagdenCheckpointId;
-  dayOffset: number;
-  titleKey: string;
-  summaryKey: string;
-  checklistKeys: string[];
-}
+export const generatePagdenPlan = buildGeneratePlan(PAGDEN_CHECKPOINTS);
 
-export interface PagdenCheckpointPlan extends PagdenCheckpointTemplate {
-  date: Date;
-}
+export const getPagdenWarnings = buildGetWarnings(PAGDEN_CHECKPOINTS);
 
-export type PagdenWarningCode =
-  | 'lateQueenCellCheck'
-  | 'unsafeCheckpointSpacing'
-  | 'illogicalScheduleOrder';
-
-export interface PagdenWarning {
-  code: PagdenWarningCode;
-  checkpointIds: PagdenCheckpointId[];
-}
-
-export const PAGDEN_CHECKPOINTS: PagdenCheckpointTemplate[] = [
-  {
-    id: 'setup',
-    dayOffset: 0,
-    titleKey: 'swarmManagement.pagden.planner.checkpoints.setup.title',
-    summaryKey: 'swarmManagement.pagden.planner.checkpoints.setup.summary',
-    checklistKeys: [
-      'swarmManagement.pagden.planner.checkpoints.setup.checklist.0',
-      'swarmManagement.pagden.planner.checkpoints.setup.checklist.1',
-      'swarmManagement.pagden.planner.checkpoints.setup.checklist.2',
-    ],
-  },
-  {
-    id: 'queenCellCheck',
-    dayOffset: 7,
-    titleKey: 'swarmManagement.pagden.planner.checkpoints.queenCellCheck.title',
-    summaryKey:
-      'swarmManagement.pagden.planner.checkpoints.queenCellCheck.summary',
-    checklistKeys: [
-      'swarmManagement.pagden.planner.checkpoints.queenCellCheck.checklist.0',
-      'swarmManagement.pagden.planner.checkpoints.queenCellCheck.checklist.1',
-      'swarmManagement.pagden.planner.checkpoints.queenCellCheck.checklist.2',
-    ],
-  },
-  {
-    id: 'secondQueenCellCheck',
-    dayOffset: 14,
-    titleKey:
-      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.title',
-    summaryKey:
-      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.summary',
-    checklistKeys: [
-      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.checklist.0',
-      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.checklist.1',
-      'swarmManagement.pagden.planner.checkpoints.secondQueenCellCheck.checklist.2',
-    ],
-  },
-  {
-    id: 'colonyReview',
-    dayOffset: 21,
-    titleKey: 'swarmManagement.pagden.planner.checkpoints.colonyReview.title',
-    summaryKey:
-      'swarmManagement.pagden.planner.checkpoints.colonyReview.summary',
-    checklistKeys: [
-      'swarmManagement.pagden.planner.checkpoints.colonyReview.checklist.0',
-      'swarmManagement.pagden.planner.checkpoints.colonyReview.checklist.1',
-      'swarmManagement.pagden.planner.checkpoints.colonyReview.checklist.2',
-    ],
-  },
-];
-
-export const generatePagdenPlan = (startDate: Date): PagdenCheckpointPlan[] =>
-  PAGDEN_CHECKPOINTS.map(checkpoint => ({
-    ...checkpoint,
-    date: addDays(startDate, checkpoint.dayOffset),
-  }));
-
-export const getPagdenWarnings = (
-  checkpoints: Array<Pick<PagdenCheckpointPlan, 'id' | 'date'>>,
-): PagdenWarning[] => {
-  const warnings: PagdenWarning[] = [];
-
-  const setup = checkpoints.find(checkpoint => checkpoint.id === 'setup');
-  const queenCellCheck = checkpoints.find(
-    checkpoint => checkpoint.id === 'queenCellCheck',
-  );
-
-  if (setup && queenCellCheck) {
-    const queenCellGap = differenceInCalendarDays(
-      queenCellCheck.date,
-      setup.date,
-    );
-
-    if (queenCellGap > 8) {
-      warnings.push({
-        code: 'lateQueenCellCheck',
-        checkpointIds: ['setup', 'queenCellCheck'],
-      });
-    }
-  }
-
-  for (let index = 1; index < checkpoints.length; index += 1) {
-    const previousCheckpoint = checkpoints[index - 1];
-    const currentCheckpoint = checkpoints[index];
-    const gap = differenceInCalendarDays(
-      currentCheckpoint.date,
-      previousCheckpoint.date,
-    );
-
-    if (gap <= 0) {
-      warnings.push({
-        code: 'illogicalScheduleOrder',
-        checkpointIds: [previousCheckpoint.id, currentCheckpoint.id],
-      });
-      continue;
-    }
-
-    if (gap < 5 || gap > 10) {
-      warnings.push({
-        code: 'unsafeCheckpointSpacing',
-        checkpointIds: [previousCheckpoint.id, currentCheckpoint.id],
-      });
-    }
-  }
-
-  return warnings;
-};
+// Re-export types consumed by the page wrapper and tests
+export type { SwarmCheckpointTemplate as PagdenCheckpointTemplate } from './swarm-planner-factory';

--- a/apps/frontend/src/pages/tools/pagden-planner.ts
+++ b/apps/frontend/src/pages/tools/pagden-planner.ts
@@ -12,3 +12,4 @@ export const getPagdenWarnings = buildGetWarnings(PAGDEN_CHECKPOINTS);
 
 // Re-export types consumed by the page wrapper and tests
 export type { SwarmCheckpointTemplate as PagdenCheckpointTemplate } from './swarm-planner-factory';
+export type { CheckpointPlan as PagdenCheckpointPlan } from './swarm-method-page-layout';

--- a/apps/frontend/src/pages/tools/swarm-management-overview-page.tsx
+++ b/apps/frontend/src/pages/tools/swarm-management-overview-page.tsx
@@ -1,4 +1,10 @@
-import { Beaker, Compass, Waypoints, AlertTriangle } from 'lucide-react';
+import {
+  Beaker,
+  Compass,
+  Waypoints,
+  AlertTriangle,
+  FlaskConical,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -36,7 +42,7 @@ export function SwarmManagementOverviewPage() {
         name: 'Honey Bee Swarm Management Methods',
         url: 'https://hivepal.app/tools/swarm-management',
         description:
-          'Reference guides for honey bee swarm-control methods, including the Demaree method, with prerequisites, step-by-step procedures, and follow-up inspection timing.',
+          'Reference guides for honey bee swarm-control methods, including the Demaree method, Pagden split, and artificial swarm technique, with prerequisites, step-by-step procedures, and follow-up inspection timing.',
         isAccessibleForFree: true,
         publisher: {
           '@type': 'Organization',
@@ -51,23 +57,24 @@ export function SwarmManagementOverviewPage() {
             description:
               'Reference workflow for the Demaree swarm-control method with an inspection planner.',
           },
+          {
+            '@type': 'WebPage',
+            name: 'Pagden Split',
+            url: 'https://hivepal.app/tools/swarm-management/pagden',
+            description:
+              'Reference workflow for the Pagden split swarm-control method with an inspection planner.',
+          },
+          {
+            '@type': 'WebPage',
+            name: 'Artificial Swarm',
+            url: 'https://hivepal.app/tools/swarm-management/artificial',
+            description:
+              'Reference workflow for the artificial swarm swarm-control method with an inspection planner.',
+          },
         ],
       },
     ],
   };
-
-  const placeholders = [
-    {
-      key: 'pagden',
-      title: t('swarmManagement.cards.pagden.title'),
-      description: t('swarmManagement.cards.pagden.description'),
-    },
-    {
-      key: 'artificialSwarm',
-      title: t('swarmManagement.cards.artificialSwarm.title'),
-      description: t('swarmManagement.cards.artificialSwarm.description'),
-    },
-  ];
 
   return (
     <PageGrid>
@@ -100,24 +107,41 @@ export function SwarmManagementOverviewPage() {
             }
           />
 
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {placeholders.map(method => (
-              <SwarmMethodCard
-                key={method.key}
-                title={method.title}
-                description={method.description}
-                cta={t('swarmManagement.cards.placeholderCta')}
-                icon={<Beaker className="h-5 w-5 text-muted-foreground" />}
-                badge={
-                  <Badge variant="secondary">
-                    {t('swarmManagement.cards.comingSoon')}
-                  </Badge>
-                }
-                className="opacity-70"
-                disabled
-              />
-            ))}
-          </div>
+          <SwarmMethodCard
+            title={t('swarmManagement.cards.pagden.title')}
+            description={t('swarmManagement.cards.pagden.description')}
+            detail={t('swarmManagement.cards.pagden.detail')}
+            cta={t('swarmManagement.cards.pagden.cta')}
+            icon={<Beaker className="h-5 w-5 text-primary" />}
+            badge={<Badge>{t('swarmManagement.cards.available')}</Badge>}
+            className="border-primary/30 bg-primary/5"
+            onClick={() => navigate(localize('/tools/swarm-management/pagden'))}
+          />
+
+          <SwarmMethodCard
+            title={t('swarmManagement.cards.artificialSwarm.title')}
+            description={t('swarmManagement.cards.artificialSwarm.description')}
+            detail={t('swarmManagement.cards.artificialSwarm.detail')}
+            cta={t('swarmManagement.cards.artificialSwarm.cta')}
+            icon={<FlaskConical className="h-5 w-5 text-primary" />}
+            badge={<Badge>{t('swarmManagement.cards.available')}</Badge>}
+            className="border-primary/30 bg-primary/5"
+            onClick={() =>
+              navigate(localize('/tools/swarm-management/artificial'))
+            }
+          />
+
+          <p className="text-sm text-muted-foreground">
+            {t('swarmManagement.cushmanCredit.text')}{' '}
+            <a
+              href="https://www.dave-cushman.net"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-foreground"
+            >
+              {t('swarmManagement.cushmanCredit.linkLabel')}
+            </a>
+          </p>
         </div>
       </MainContent>
 

--- a/apps/frontend/src/pages/tools/swarm-method-page-layout.tsx
+++ b/apps/frontend/src/pages/tools/swarm-method-page-layout.tsx
@@ -1,0 +1,697 @@
+import { useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CalendarClock,
+  ShieldAlert,
+  Waypoints,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { InspectionStatus, type HiveResponse } from 'shared-schemas';
+import { useCreateInspection, useHives } from '@/api/hooks';
+import { useAuth } from '@/context/auth-context';
+import {
+  MainContent,
+  PageAside,
+  PageGrid,
+} from '@/components/layout/page-grid-layout';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import { DatePickerPopover } from '@/components/common/date-picker-popover';
+import {
+  CalloutCard,
+  DotList,
+  ToolFaq,
+  ToolPageHeader,
+  type FaqItem,
+} from '@/components/tool-page';
+import { useLocalizedPath } from '@/hooks/use-language-navigation';
+import { cn } from '@/lib/utils';
+import { toInspectionDateISOString } from '@/utils/inspection-date';
+
+// ---------------------------------------------------------------------------
+// Generic types that all planner modules share
+// ---------------------------------------------------------------------------
+
+export interface CheckpointTemplate {
+  id: string;
+  dayOffset: number;
+  titleKey: string;
+  summaryKey: string;
+  checklistKeys: string[];
+}
+
+export interface CheckpointPlan extends CheckpointTemplate {
+  date: Date;
+}
+
+export type WarningCode =
+  | 'lateQueenCellCheck'
+  | 'unsafeCheckpointSpacing'
+  | 'illogicalScheduleOrder';
+
+export interface CheckpointWarning {
+  code: WarningCode;
+  checkpointIds: string[];
+}
+
+type EditableCheckpoint = CheckpointPlan & { notes: string };
+
+// ---------------------------------------------------------------------------
+// Method-detail section descriptor (same shape used in all three pages)
+// ---------------------------------------------------------------------------
+
+export interface MethodDetailSection {
+  id: string;
+  items: number[];
+  children: Record<number, number[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface SwarmMethodPageProps {
+  /** i18n namespace prefix, e.g. "swarmManagement.pagden" */
+  ns: string;
+  /** Shared planner namespace for generic UI strings, e.g. "swarmManagement.planner" */
+  plannerNs: string;
+  /** Planner-specific namespace for method-scoped date label/toast keys */
+  methodPlannerNs: string;
+  /** Number of prerequisites list items */
+  prerequisiteCount: number;
+  /** Number of pros/cons list items */
+  prosConsCount: number;
+  /** Sections for the method-detail card */
+  methodDetailSections: MethodDetailSection[];
+  /** Generate the plan from a start date */
+  generatePlan: (startDate: Date) => CheckpointPlan[];
+  /** Derive warnings from the current checkpoint list */
+  getWarnings: (checkpoints: CheckpointPlan[]) => CheckpointWarning[];
+  /** ToolMeta + structured data node (fully method-specific) */
+  meta: React.ReactNode;
+  /** Structured data for FAQPage (passed separately so it can be included in the page's own JSON-LD graph) */
+  faqI18nKey: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared warning colour map (all three methods use the same three codes)
+// ---------------------------------------------------------------------------
+
+const warningVariantClasses: Record<WarningCode, string> = {
+  lateQueenCellCheck: 'border-amber-300 bg-amber-50 dark:bg-amber-950/30',
+  unsafeCheckpointSpacing: 'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
+  illogicalScheduleOrder: 'border-red-300 bg-red-50 dark:bg-red-950/30',
+};
+
+// ---------------------------------------------------------------------------
+// Small internal components
+// ---------------------------------------------------------------------------
+
+function WarningSummary({
+  warning,
+}: Readonly<{ warning: CheckpointWarning }>) {
+  const { t } = useTranslation('common');
+  return (
+    <div
+      className={cn(
+        'rounded-lg border p-3',
+        warningVariantClasses[warning.code],
+      )}
+    >
+      <p className="font-medium">
+        {t(`swarmManagement.warnings.${warning.code}.title`)}
+      </p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {t(`swarmManagement.warnings.${warning.code}.description`)}
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main shared layout
+// ---------------------------------------------------------------------------
+
+export function SwarmMethodPageLayout({
+  ns,
+  plannerNs,
+  methodPlannerNs,
+  prerequisiteCount,
+  prosConsCount,
+  methodDetailSections,
+  generatePlan,
+  getWarnings,
+  meta,
+  faqI18nKey,
+}: Readonly<SwarmMethodPageProps>) {
+  const { t } = useTranslation('common');
+  const navigate = useNavigate();
+  const localize = useLocalizedPath();
+  const { isLoggedIn } = useAuth();
+  const { data: hives = [], isLoading: isLoadingHives } = useHives();
+  const { mutateAsync: createInspection, isPending: isSaving } =
+    useCreateInspection();
+
+  const [selectedHiveId, setSelectedHiveId] = useState<string>('');
+  const [startDate, setStartDate] = useState<Date | undefined>();
+  const [checkpoints, setCheckpoints] = useState<EditableCheckpoint[]>([]);
+
+  const warnings = useMemo(
+    () => getWarnings(checkpoints),
+    [checkpoints, getWarnings],
+  );
+
+  const selectedHive = hives.find(hive => hive.id === selectedHiveId);
+
+  const faqItems = t(faqI18nKey, { returnObjects: true }) as FaqItem[];
+
+  const buildCheckpointNotes = (checkpoint: CheckpointPlan) => {
+    const checklist = checkpoint.checklistKeys
+      .map(key => `- ${t(key)}`)
+      .join('\n');
+    return [
+      `${t(`${methodPlannerNs}.checkpointPrefix`)} ${t(checkpoint.titleKey)}`,
+      t(checkpoint.summaryKey),
+      '',
+      t(`${methodPlannerNs}.notesChecklistLabel`),
+      checklist,
+    ].join('\n');
+  };
+
+  const handleGeneratePlan = () => {
+    if (!startDate) return;
+    setCheckpoints(
+      generatePlan(startDate).map(checkpoint => ({
+        ...checkpoint,
+        notes: buildCheckpointNotes(checkpoint),
+      })),
+    );
+  };
+
+  const updateCheckpoint = (
+    checkpointId: string,
+    updates: Partial<EditableCheckpoint>,
+  ) => {
+    setCheckpoints(current =>
+      current.map(cp =>
+        cp.id === checkpointId ? { ...cp, ...updates } : cp,
+      ),
+    );
+  };
+
+  const getCheckpointWarnings = (checkpointId: string) =>
+    warnings.filter(w => w.checkpointIds.includes(checkpointId));
+
+  const handleSavePlan = async () => {
+    if (!selectedHiveId || checkpoints.length === 0) return;
+
+    const results = await Promise.allSettled(
+      checkpoints.map(cp =>
+        createInspection({
+          hiveId: selectedHiveId,
+          date: toInspectionDateISOString(cp.date, true),
+          isAllDay: true,
+          notes: cp.notes,
+          status: InspectionStatus.SCHEDULED,
+          actions: [],
+        }),
+      ),
+    );
+
+    const successCount = results.filter(r => r.status === 'fulfilled').length;
+    const failedCount = results.length - successCount;
+
+    if (successCount === checkpoints.length) {
+      toast.success(
+        t(`${methodPlannerNs}.savedSuccess`, { count: successCount }),
+      );
+      navigate(localize('/inspections/list/upcoming'));
+      return;
+    }
+
+    if (successCount > 0) {
+      toast.warning(
+        t(`${methodPlannerNs}.savedPartial`, { successCount, failedCount }),
+      );
+      navigate(localize('/inspections/list/upcoming'));
+      return;
+    }
+
+    if (failedCount > 0) {
+      toast.error(t(`${methodPlannerNs}.savedError`));
+    }
+  };
+
+  const handleCancel = () => {
+    setCheckpoints([]);
+    navigate(localize('/tools/swarm-management'));
+  };
+
+  const renderHiveSelect = () => {
+    if (isLoadingHives) return <Skeleton className="h-10 w-full" />;
+
+    if (hives.length === 0) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          {t(`${plannerNs}.noHives`)}
+        </p>
+      );
+    }
+
+    return (
+      <Select value={selectedHiveId} onValueChange={setSelectedHiveId}>
+        <SelectTrigger>
+          <SelectValue placeholder={t(`${plannerNs}.hivePlaceholder`)} />
+        </SelectTrigger>
+        <SelectContent>
+          {hives.map((hive: HiveResponse) => (
+            <SelectItem key={hive.id} value={hive.id}>
+              {hive.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  };
+
+  return (
+    <PageGrid>
+      {meta}
+
+      <MainContent>
+        <ToolPageHeader
+          title={t(`${ns}.title`)}
+          badge={
+            <Badge variant="outline">{t(`${ns}.badge`)}</Badge>
+          }
+          description={t(`${ns}.description`)}
+          intro={t(`${ns}.intro`)}
+          backLink={{
+            to: localize('/tools/swarm-management'),
+            label: t('swarmManagement.backToOverview'),
+          }}
+        />
+
+        <div className="space-y-4">
+          {/* Overview */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t(`${ns}.overviewTitle`)}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm text-muted-foreground">
+              <p>{t(`${ns}.overviewLead`)}</p>
+              <DotList
+                className="space-y-3"
+                items={[0, 1, 2].map(i => t(`${ns}.overviewPoints.${i}`))}
+              />
+            </CardContent>
+          </Card>
+
+          {/* Prerequisites */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t(`${ns}.prerequisitesTitle`)}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="list-disc space-y-3 pl-5 text-sm text-muted-foreground marker:text-primary/60">
+                {Array.from({ length: prerequisiteCount }, (_, i) => (
+                  <li key={i}>{t(`${ns}.prerequisites.${i}`)}</li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          {/* Why it works */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t(`${ns}.advantagesTitle`)}</CardTitle>
+              <CardDescription>
+                {t(`${ns}.advantagesDescription`)}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DotList
+                items={[0, 1, 2].map(i => t(`${ns}.advantages.${i}`))}
+              />
+            </CardContent>
+          </Card>
+
+          {/* Method detail */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t(`${ns}.stepsTitle`)}</CardTitle>
+              <CardDescription>{t(`${ns}.stepsDescription`)}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-6 text-sm text-muted-foreground">
+                {methodDetailSections.map(section => (
+                  <div key={section.id} className="space-y-3">
+                    <h3 className="font-semibold text-foreground">
+                      {t(`${ns}.methodDetail.${section.id}.title`)}
+                    </h3>
+                    <ul className="list-disc space-y-2 pl-5 marker:text-primary/60">
+                      {section.items.map(itemIndex => (
+                        <li key={itemIndex}>
+                          <span>
+                            {t(
+                              `${ns}.methodDetail.${section.id}.items.${itemIndex}.text`,
+                            )}
+                          </span>
+                          {(section.children[itemIndex] ?? []).length > 0 && (
+                            <ul className="list-[circle] space-y-2 pl-5 pt-2 marker:text-muted-foreground/60">
+                              {(section.children[itemIndex] ?? []).map(
+                                childIndex => (
+                                  <li key={childIndex}>
+                                    {t(
+                                      `${ns}.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
+                                    )}
+                                  </li>
+                                ),
+                              )}
+                            </ul>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Follow-up timing */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t(`${ns}.followUpTitle`)}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="overflow-hidden rounded-lg border">
+                <div className="grid grid-cols-[minmax(80px,auto)_1fr] border-b bg-muted/40 px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:px-4 sm:text-sm">
+                  <div>{t(`${ns}.followUpDayHeader`)}</div>
+                  <div>{t(`${ns}.followUpTaskHeader`)}</div>
+                </div>
+                {[0, 1, 2].map(index => (
+                  <div
+                    key={index}
+                    className="grid grid-cols-[minmax(80px,auto)_1fr] gap-3 border-b px-3 py-3 text-sm last:border-b-0 sm:px-4"
+                  >
+                    <div className="font-semibold text-foreground">
+                      {t(`${ns}.followUp.${index}.day`)}
+                    </div>
+                    <div className="text-muted-foreground">
+                      {t(`${ns}.followUp.${index}.task`)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-muted-foreground dark:bg-amber-950/30">
+                <p className="flex items-start gap-2 font-medium text-foreground">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                  {t('swarmManagement.aside.criticalTimingTitle')}
+                </p>
+                <p className="mt-2">
+                  {t('swarmManagement.aside.criticalTimingLead')}
+                </p>
+                <p className="mt-2">
+                  {t('swarmManagement.aside.criticalTimingDetail')}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Pros / cons */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t(`${ns}.prosConsTitle`)}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <div className="rounded-lg border border-emerald-200 bg-emerald-50/50 p-4 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+                  <p className="mb-3 text-sm font-semibold text-emerald-900 dark:text-emerald-200">
+                    {t(`${ns}.prosTitle`)}
+                  </p>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-emerald-600/60">
+                    {Array.from({ length: prosConsCount }, (_, i) => (
+                      <li key={i}>{t(`${ns}.pros.${i}`)}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="rounded-lg border border-rose-200 bg-rose-50/40 p-4 dark:border-rose-900/40 dark:bg-rose-950/20">
+                  <p className="mb-3 text-sm font-semibold text-rose-900 dark:text-rose-200">
+                    {t(`${ns}.consTitle`)}
+                  </p>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-muted-foreground marker:text-rose-600/60">
+                    {Array.from({ length: prosConsCount }, (_, i) => (
+                      <li key={i}>{t(`${ns}.cons.${i}`)}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Planner */}
+          <Card>
+            <CardHeader>
+              <CardTitle>{t(`${methodPlannerNs}.title`)}</CardTitle>
+              <CardDescription>
+                {t(`${methodPlannerNs}.description`)}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {!isLoggedIn ? (
+                <div className="rounded-lg border border-dashed bg-muted/20 p-6 text-center">
+                  <p className="text-base font-semibold text-foreground">
+                    {t(`${plannerNs}.signInTitle`)}
+                  </p>
+                  <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+                    {t(`${plannerNs}.signInDescription`)}
+                  </p>
+                  <div className="mt-4 flex flex-col items-center justify-center gap-2 sm:flex-row">
+                    <Button asChild>
+                      <Link to="/login">
+                        {t(`${plannerNs}.signInCta`)}
+                      </Link>
+                    </Button>
+                    <Button variant="outline" asChild>
+                      <Link to="/register">
+                        {t(`${plannerNs}.registerCta`)}
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">
+                        {t(`${plannerNs}.hiveLabel`)}
+                      </p>
+                      {renderHiveSelect()}
+                    </div>
+
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">
+                        {t(`${methodPlannerNs}.startDateLabel`)}
+                      </p>
+                      <DatePickerPopover
+                        date={startDate}
+                        onDateChange={setStartDate}
+                        placeholder={t(`${methodPlannerNs}.startDatePlaceholder`)}
+                      />
+                    </div>
+                  </div>
+
+                  <Button
+                    className="w-full sm:w-auto"
+                    onClick={handleGeneratePlan}
+                    disabled={!selectedHiveId || !startDate}
+                  >
+                    {t(`${plannerNs}.generate`)}
+                  </Button>
+
+                  {selectedHive && (
+                    <Alert>
+                      <Waypoints className="h-4 w-4" />
+                      <AlertTitle>
+                        {t(`${plannerNs}.selectedHive`)}
+                      </AlertTitle>
+                      <AlertDescription>{selectedHive.name}</AlertDescription>
+                    </Alert>
+                  )}
+
+                  {warnings.length > 0 && (
+                    <Alert className="border-amber-300 bg-amber-50 dark:bg-amber-950/30">
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertTitle>
+                        {t('swarmManagement.warnings.bannerTitle')}
+                      </AlertTitle>
+                      <AlertDescription className="mt-3 space-y-3">
+                        {warnings.map(warning => (
+                          <WarningSummary
+                            key={`${warning.code}-${warning.checkpointIds.join('-')}`}
+                            warning={warning}
+                          />
+                        ))}
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
+                  {checkpoints.length > 0 ? (
+                    <div className="space-y-4">
+                      {checkpoints.map(checkpoint => {
+                        const cpWarnings = getCheckpointWarnings(checkpoint.id);
+                        return (
+                          <Card key={checkpoint.id}>
+                            <CardHeader>
+                              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                <div className="min-w-0">
+                                  <CardTitle>
+                                    {t(checkpoint.titleKey)}
+                                  </CardTitle>
+                                  <CardDescription>
+                                    {t(`${plannerNs}.dayOffset`, {
+                                      count: checkpoint.dayOffset,
+                                    })}
+                                  </CardDescription>
+                                </div>
+                                <DatePickerPopover
+                                  date={checkpoint.date}
+                                  onDateChange={date => {
+                                    if (date)
+                                      updateCheckpoint(checkpoint.id, { date });
+                                  }}
+                                  align="end"
+                                  className="w-full sm:w-auto"
+                                />
+                              </div>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                              <p className="text-sm text-muted-foreground">
+                                {t(checkpoint.summaryKey)}
+                              </p>
+                              {cpWarnings.map(warning => (
+                                <Alert
+                                  key={`${checkpoint.id}-${warning.code}`}
+                                  className={warningVariantClasses[warning.code]}
+                                >
+                                  <ShieldAlert className="h-4 w-4" />
+                                  <AlertTitle>
+                                    {t(
+                                      `swarmManagement.warnings.${warning.code}.title`,
+                                    )}
+                                  </AlertTitle>
+                                  <AlertDescription>
+                                    {t(
+                                      `swarmManagement.warnings.${warning.code}.description`,
+                                    )}
+                                  </AlertDescription>
+                                </Alert>
+                              ))}
+                              <div className="space-y-2">
+                                <p className="text-sm font-medium">
+                                  {t(`${plannerNs}.notesLabel`)}
+                                </p>
+                                <Textarea
+                                  value={checkpoint.notes}
+                                  onChange={e =>
+                                    updateCheckpoint(checkpoint.id, {
+                                      notes: e.target.value,
+                                    })
+                                  }
+                                  rows={8}
+                                />
+                              </div>
+                            </CardContent>
+                          </Card>
+                        );
+                      })}
+
+                      <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                        <Button variant="outline" onClick={handleCancel}>
+                          {t('actions.cancel')}
+                        </Button>
+                        <Button onClick={handleSavePlan} disabled={isSaving}>
+                          {isSaving
+                            ? t(`${plannerNs}.saving`)
+                            : t(`${plannerNs}.save`)}
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+                      {t(`${plannerNs}.emptyState`)}
+                    </div>
+                  )}
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <ToolFaq title={t(`${ns}.faq.title`)} items={faqItems} />
+      </MainContent>
+
+      <PageAside>
+        <div className="space-y-4 md:sticky md:top-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <CalendarClock className="h-5 w-5 text-primary" />
+                {t(`${plannerNs}.atAGlanceTitle`)}
+              </CardTitle>
+              <CardDescription>
+                {t(`${plannerNs}.atAGlanceDescription`)}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ol className="space-y-3 text-sm">
+                {[0, 1, 2].map(i => (
+                  <li
+                    key={i}
+                    className="flex gap-3 border-b pb-3 last:border-b-0 last:pb-0"
+                  >
+                    <div className="min-w-[68px] font-semibold text-foreground">
+                      {t(`${ns}.followUp.${i}.day`)}
+                    </div>
+                    <div className="text-muted-foreground">
+                      {t(`${ns}.followUp.${i}.task`)}
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </CardContent>
+          </Card>
+
+          <CalloutCard
+            variant="amber"
+            icon={<AlertTriangle className="h-5 w-5" />}
+            title={t('swarmManagement.aside.criticalTimingTitle')}
+          >
+            <p>{t('swarmManagement.aside.criticalTimingLead')}</p>
+            <p>{t('swarmManagement.aside.criticalTimingDetail')}</p>
+          </CalloutCard>
+        </div>
+      </PageAside>
+    </PageGrid>
+  );
+}

--- a/apps/frontend/src/pages/tools/swarm-planner-factory.ts
+++ b/apps/frontend/src/pages/tools/swarm-planner-factory.ts
@@ -1,0 +1,108 @@
+import { addDays, differenceInCalendarDays } from 'date-fns';
+import type { CheckpointPlan, CheckpointWarning, WarningCode } from './swarm-method-page-layout';
+
+export type SwarmCheckpointId =
+  | 'setup'
+  | 'queenCellCheck'
+  | 'secondQueenCellCheck'
+  | 'colonyReview';
+
+export interface SwarmCheckpointTemplate {
+  id: SwarmCheckpointId;
+  dayOffset: number;
+  titleKey: string;
+  summaryKey: string;
+  checklistKeys: string[];
+}
+
+const CHECKPOINT_IDS: SwarmCheckpointId[] = [
+  'setup',
+  'queenCellCheck',
+  'secondQueenCellCheck',
+  'colonyReview',
+];
+
+const DAY_OFFSETS: Record<SwarmCheckpointId, number> = {
+  setup: 0,
+  queenCellCheck: 7,
+  secondQueenCellCheck: 14,
+  colonyReview: 21,
+};
+
+/**
+ * Build a checkpoint template array for any swarm-management method.
+ * Each checkpoint's i18n keys follow the pattern:
+ *   `{ns}.planner.checkpoints.{id}.title`  etc.
+ */
+export const buildCheckpoints = (ns: string): SwarmCheckpointTemplate[] =>
+  CHECKPOINT_IDS.map(id => ({
+    id,
+    dayOffset: DAY_OFFSETS[id],
+    titleKey: `${ns}.planner.checkpoints.${id}.title`,
+    summaryKey: `${ns}.planner.checkpoints.${id}.summary`,
+    checklistKeys: [0, 1, 2].map(
+      i => `${ns}.planner.checkpoints.${id}.checklist.${i}`,
+    ),
+  }));
+
+/**
+ * Generate a dated plan from a set of checkpoint templates.
+ */
+export const buildGeneratePlan =
+  (checkpoints: SwarmCheckpointTemplate[]) =>
+  (startDate: Date): CheckpointPlan[] =>
+    checkpoints.map(checkpoint => ({
+      ...checkpoint,
+      date: addDays(startDate, checkpoint.dayOffset),
+    }));
+
+/**
+ * Derive timing warnings from a list of scheduled checkpoints.
+ * Shared logic identical across all three swarm-management methods.
+ */
+export const buildGetWarnings =
+  (checkpoints: SwarmCheckpointTemplate[]) =>
+  (
+    scheduled: Array<Pick<CheckpointPlan, 'id' | 'date'>>,
+  ): CheckpointWarning[] => {
+    const warnings: CheckpointWarning[] = [];
+
+    // Use the first two checkpoint IDs from the template for the late-check warning.
+    const [firstId, secondId] = checkpoints.map(c => c.id);
+
+    const first = scheduled.find(c => c.id === firstId);
+    const second = scheduled.find(c => c.id === secondId);
+
+    if (first && second) {
+      const gap = differenceInCalendarDays(second.date, first.date);
+      if (gap > 8) {
+        warnings.push({
+          code: 'lateQueenCellCheck' as WarningCode,
+          checkpointIds: [firstId, secondId],
+        });
+      }
+    }
+
+    for (let i = 1; i < scheduled.length; i += 1) {
+      const prev = scheduled[i - 1];
+      const curr = scheduled[i];
+      const gap = differenceInCalendarDays(curr.date, prev.date);
+
+      if (gap <= 0) {
+        warnings.push({
+          code: 'illogicalScheduleOrder' as WarningCode,
+          checkpointIds: [prev.id, curr.id],
+        });
+        continue;
+      }
+
+      if (gap < 5 || gap > 10) {
+        warnings.push({
+          code: 'unsafeCheckpointSpacing' as WarningCode,
+          checkpointIds: [prev.id, curr.id],
+        });
+      }
+    }
+
+    return warnings;
+  };

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -18,7 +18,12 @@ import {
   InspectionListPage,
   ScheduleInspectionPage,
 } from '@/pages/inspection';
-import { CreateQueenPage, EditQueenPage, QueenDetailPage, QueenListPage } from '@/pages/queen';
+import {
+  CreateQueenPage,
+  EditQueenPage,
+  QueenDetailPage,
+  QueenListPage,
+} from '@/pages/queen';
 import { TodoListPage } from '@/pages/todo';
 import { ChangePasswordPage } from '@/pages/account';
 import GenericErrorPage from '@/pages/error-page.tsx';
@@ -170,6 +175,16 @@ const DemareeMethodPage = lazyWithRetry(() =>
     default: m.DemareeMethodPage,
   })),
 );
+const PagdenMethodPage = lazyWithRetry(() =>
+  import('@/pages/tools/pagden-method-page').then(m => ({
+    default: m.PagdenMethodPage,
+  })),
+);
+const ArtificialSwarmMethodPage = lazyWithRetry(() =>
+  import('@/pages/tools/artificial-swarm-method-page').then(m => ({
+    default: m.ArtificialSwarmMethodPage,
+  })),
+);
 const LiebefelderPage = lazyWithRetry(() =>
   import('@/pages/tools/liebefelder-page').then(m => ({
     default: m.LiebefelderPage,
@@ -263,6 +278,22 @@ function buildToolsChildren() {
       ),
     },
     {
+      path: 'swarm-management/pagden',
+      element: (
+        <LazyPage>
+          <PagdenMethodPage />
+        </LazyPage>
+      ),
+    },
+    {
+      path: 'swarm-management/artificial',
+      element: (
+        <LazyPage>
+          <ArtificialSwarmMethodPage />
+        </LazyPage>
+      ),
+    },
+    {
       path: 'liebefelder',
       element: (
         <LazyPage>
@@ -338,11 +369,19 @@ const router = createBrowserRouter([
       },
       {
         path: '/apiaries/create',
-        element: <EditableRoute redirectTo="/apiaries"><CreateApiaryPage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/apiaries">
+            <CreateApiaryPage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/apiaries/:id/edit',
-        element: <EditableRoute redirectTo="/apiaries"><EditApiaryPage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/apiaries">
+            <EditApiaryPage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/hives',
@@ -350,7 +389,11 @@ const router = createBrowserRouter([
       },
       {
         path: '/hives/create',
-        element: <EditableRoute redirectTo="/hives"><CreateHivePage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/hives">
+            <CreateHivePage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/hives/:id',
@@ -358,7 +401,11 @@ const router = createBrowserRouter([
       },
       {
         path: '/hives/:id/edit',
-        element: <EditableRoute redirectTo="/hives"><EditHivePage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/hives">
+            <EditHivePage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/hives/qr-codes/print',
@@ -370,15 +417,27 @@ const router = createBrowserRouter([
       },
       {
         path: '/hives/:hiveId/inspections/create',
-        element: <EditableRoute redirectTo="/inspections"><CreateInspectionPage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/inspections">
+            <CreateInspectionPage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/inspections/create',
-        element: <EditableRoute redirectTo="/inspections"><CreateInspectionPage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/inspections">
+            <CreateInspectionPage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/inspections/schedule',
-        element: <EditableRoute redirectTo="/inspections"><ScheduleInspectionPage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/inspections">
+            <ScheduleInspectionPage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/inspections',
@@ -390,7 +449,11 @@ const router = createBrowserRouter([
       },
       {
         path: '/inspections/:id/edit',
-        element: <EditableRoute redirectTo="/inspections"><EditInspectionPage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/inspections">
+            <EditInspectionPage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/inspections/:id',
@@ -422,15 +485,27 @@ const router = createBrowserRouter([
       },
       {
         path: '/queens/create',
-        element: <EditableRoute redirectTo="/queens"><CreateQueenPage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/queens">
+            <CreateQueenPage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/hives/:hiveId/queens/create',
-        element: <EditableRoute redirectTo="/queens"><CreateQueenPage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/queens">
+            <CreateQueenPage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/queens/:queenId/edit',
-        element: <EditableRoute redirectTo="/queens"><EditQueenPage /></EditableRoute>,
+        element: (
+          <EditableRoute redirectTo="/queens">
+            <EditQueenPage />
+          </EditableRoute>
+        ),
       },
       {
         path: '/queens',

--- a/apps/frontend/src/routes/public-route-config.tsx
+++ b/apps/frontend/src/routes/public-route-config.tsx
@@ -6,6 +6,8 @@ import { SyrupCalculatorPage } from '@/pages/tools/syrup-calculator-page';
 import { BroodTimelinePage } from '@/pages/tools/brood-timeline-page';
 import { SwarmManagementOverviewPage } from '@/pages/tools/swarm-management-overview-page';
 import { DemareeMethodPage } from '@/pages/tools/demaree-method-page';
+import { PagdenMethodPage } from '@/pages/tools/pagden-method-page';
+import { ArtificialSwarmMethodPage } from '@/pages/tools/artificial-swarm-method-page';
 import { LiebefelderPage } from '@/pages/tools/liebefelder-page';
 import { VarroaManagementPage } from '@/pages/tools/varroa-management-page';
 import { ReleasesPage } from '@/pages/releases';
@@ -23,6 +25,11 @@ const toolsChildren: RouteObject[] = [
   { path: 'brood-timeline', element: <BroodTimelinePage /> },
   { path: 'swarm-management', element: <SwarmManagementOverviewPage /> },
   { path: 'swarm-management/demaree', element: <DemareeMethodPage /> },
+  { path: 'swarm-management/pagden', element: <PagdenMethodPage /> },
+  {
+    path: 'swarm-management/artificial',
+    element: <ArtificialSwarmMethodPage />,
+  },
   { path: 'liebefelder', element: <LiebefelderPage /> },
   { path: 'varroa-management', element: <VarroaManagementPage /> },
 ];


### PR DESCRIPTION
Summary
Activates the two "coming soon" placeholder cards on the Swarm Management overview page by implementing full tool pages for the Pagden split and Artificial swarm methods. Both pages follow the established Demaree method pattern: an educational reference guide paired with an inspection planner that generates scheduled inspections at key follow-up dates.
What's changed
New pages
- /tools/swarm-management/pagden — Pagden split guide and planner. Covers the standard artificial swarm technique where the laying queen is moved to a new hive on the original stand, with the parent colony moved aside to raise a new queen. Includes method overview, prerequisites, step-by-step guide, pros/cons, FAQ, and a 4-checkpoint inspection planner (Day 0, 7, 14, 21).
- /tools/swarm-management/artificial — Artificial swarm guide and planner. Covers the variation where the queen is not moved — the parent colony moves aside and the new hive on the original stand is given one frame of brood with eggs or a queen cell. Useful when the queen cannot be found. Same guide and planner structure.
Updated: Swarm Management overview
- Both placeholder cards are now active and navigate to their respective pages.
- Card descriptions updated from placeholder text to accurate method summaries.
- Dave Cushman Beekeeping Website credited as a reference source with an external link.
- Structured data hasPart expanded to include both new pages.
i18n
- Full English copy added for both methods under swarmManagement.pagden.* and swarmManagement.artificialSwarm.*.
- All 8 non-English locales (de, fr, es, it, nl, da, sk, sr) receive the new keys with empty string values, ready for translation in Weblate.
Tests
- Unit tests for both planner modules (plan generation, date offsets, warning logic).
- i18n key validation tests confirming all new keys are present in the English locale and exist as empty strings in all non-English locales.
Key design decisions
- No new backend endpoints — both planners use the existing POST /api/inspections bulk-create pattern, identical to Demaree.
- Copy-adapt over generic component — three pages is below the threshold that would justify a new abstraction; each page is self-contained.
- Pagden vs Artificial Swarm differentiator — Pagden moves the queen to the new hive (queen found); Artificial Swarm leaves the queen in the parent colony and gives the new hive a brood frame with a queen cell (queen not required to be found).
Reference material
Method content based on the Dave Cushman Beekeeping Website (https://www.dave-cushman.net), specifically the Artificial Swarm, Method 1, and Method 2 pages.