### PR TITLE
feature inspections table: reusable column visibility + Notes/Actions columns + cleaner row actions

### DIFF
--- a/apps/e2e/tests/table-column-visibility.spec.ts
+++ b/apps/e2e/tests/table-column-visibility.spec.ts
@@ -43,6 +43,19 @@ const seedInspection = async (page: Page) => {
         date: new Date('2026-06-01T10:00:00.000Z').toISOString(),
         status: 'COMPLETED',
         notes: 'Colony looked strong and healthy with plenty of stores',
+        actions: [
+          {
+            type: 'FEEDING',
+            details: {
+              type: 'FEEDING',
+              feedType: 'Sugar syrup',
+              amount: 2,
+              unit: 'l',
+            },
+          },
+          { type: 'FRAME', details: { type: 'FRAME', quantity: -3 } },
+          { type: 'FRAME', details: { type: 'FRAME', quantity: 2 } },
+        ],
       }),
     });
   });
@@ -75,9 +88,7 @@ test('inspections table columns can be hidden and the choice persists', async ({
   await page.waitForURL(u => !u.pathname.startsWith('/register'), {
     timeout: 15000,
   });
-  await expect(page.getByTestId('apiary-switcher')).toBeVisible({
-    timeout: 15000,
-  });
+  await page.waitForLoadState('networkidle').catch(() => {});
 
   await seedInspection(page);
 
@@ -86,6 +97,19 @@ test('inspections table columns can be hidden and the choice persists', async ({
   const weatherHeader = page.getByRole('columnheader', { name: 'Weather' });
   await expect(weatherHeader).toBeVisible({ timeout: 15000 });
   await expect(page.getByRole('columnheader', { name: 'Hive' })).toBeVisible();
+
+  // --- The "Actions" column lists the performed actions (not a Details link) ---
+  await expect(
+    page.getByRole('columnheader', { name: 'Actions', exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText('Feeding', { exact: false }).first()).toBeVisible();
+  await expect(page.getByText('Frames', { exact: false }).first()).toBeVisible();
+  await expect(page.getByText('×2').first()).toBeVisible();
+
+  // --- Each row has leading View + Edit icon actions (the apiary owner can
+  // edit, so both are present). These open the detail / edit routes. ---
+  await expect(page.getByRole('button', { name: 'View' }).first()).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Edit' }).first()).toBeVisible();
 
   // --- Hide the Weather column via the Columns menu ---
   const SHOT_DIR =

--- a/apps/e2e/tests/table-column-visibility.spec.ts
+++ b/apps/e2e/tests/table-column-visibility.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from './fixtures';
+import { Page } from '@playwright/test';
+import { generateRandomString } from './utils';
+
+/**
+ * The inspections table lets the user choose which columns are visible, and the
+ * choice persists across reloads. This exercises the reusable column-visibility
+ * system (useColumnVisibility + ColumnVisibilityMenu + DataTable).
+ *
+ * Run with: `BASE_URL=... pnpm --filter e2e test table-column-visibility`.
+ */
+
+// Seed one hive + one completed inspection through the API from the
+// authenticated browser context, so the inspections table has a row to render.
+const seedInspection = async (page: Page) => {
+  return page.evaluate(async () => {
+    const apiariesRes = await fetch('/api/apiaries', {
+      credentials: 'include',
+    });
+    const apiaries = (await apiariesRes.json()) as {
+      apiaries: Array<{ id: string }>;
+    };
+    const apiaryId = apiaries.apiaries[0].id;
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-apiary-id': apiaryId,
+    };
+
+    const hiveRes = await fetch('/api/hives', {
+      method: 'POST',
+      credentials: 'include',
+      headers,
+      body: JSON.stringify({ name: 'Column Test Hive', apiaryId }),
+    });
+    const hive = (await hiveRes.json()) as { id: string };
+
+    await fetch('/api/inspections', {
+      method: 'POST',
+      credentials: 'include',
+      headers,
+      body: JSON.stringify({
+        hiveId: hive.id,
+        date: new Date('2026-06-01T10:00:00.000Z').toISOString(),
+        status: 'COMPLETED',
+      }),
+    });
+  });
+};
+
+test('inspections table columns can be hidden and the choice persists', async ({
+  page,
+}) => {
+  await page.route('**/*', route => {
+    const url = route.request().url();
+    if (!url.startsWith('http://localhost:5173')) return route.abort();
+    if (/\/api\/(weather|hivescale)/.test(url)) return route.abort();
+    return route.continue();
+  });
+
+  // --- Register a fresh user (auto-creates a default apiary) ---
+  const email = `columns-${Date.now()}@example.com`;
+  const password = generateRandomString();
+  await page.goto('/register', { waitUntil: 'commit' });
+  await page.getByLabel('email').fill(email);
+  await page
+    .getByRole('textbox', { name: 'Password', exact: true })
+    .fill(password);
+  await page.getByRole('textbox', { name: 'Confirm Password' }).fill(password);
+  await page.getByRole('textbox', { name: 'Display Name' }).fill('Columns');
+  await page
+    .getByRole('checkbox', { name: 'I agree to the Privacy Policy' })
+    .click();
+  await page.getByRole('button', { name: /register/i }).click();
+  await page.waitForURL(u => !u.pathname.startsWith('/register'), {
+    timeout: 15000,
+  });
+  await expect(page.getByTestId('apiary-switcher')).toBeVisible({
+    timeout: 15000,
+  });
+
+  await seedInspection(page);
+
+  // --- The inspections table shows the Weather column by default ---
+  await page.goto('/inspections', { waitUntil: 'commit' });
+  const weatherHeader = page.getByRole('columnheader', { name: 'Weather' });
+  await expect(weatherHeader).toBeVisible({ timeout: 15000 });
+  await expect(page.getByRole('columnheader', { name: 'Hive' })).toBeVisible();
+
+  // --- Hide the Weather column via the Columns menu ---
+  const SHOT_DIR =
+    process.env.SHOT_DIR ||
+    '/tmp/claude-0/-home-user/d4f56f04-fc33-515b-bc80-dc0a3231b16e/scratchpad';
+  await page.getByRole('button', { name: 'Columns', exact: true }).click();
+  await expect(
+    page.getByRole('menuitemcheckbox', { name: 'Weather' }),
+  ).toBeVisible();
+  await page.screenshot({
+    path: `${SHOT_DIR}/columns-01-menu-open.png`,
+    fullPage: true,
+  });
+  await page
+    .getByRole('menuitemcheckbox', { name: 'Weather' })
+    .click();
+  await page.keyboard.press('Escape');
+
+  await expect(weatherHeader).toHaveCount(0);
+  await page.screenshot({
+    path: `${SHOT_DIR}/columns-02-weather-hidden.png`,
+    fullPage: true,
+  });
+  // Other columns are unaffected.
+  await expect(page.getByRole('columnheader', { name: 'Hive' })).toBeVisible();
+
+  // Persisted to localStorage under the table's key.
+  const stored = await page.evaluate(() =>
+    localStorage.getItem('hive_pal_table_columns:inspections'),
+  );
+  expect(stored).toContain('"weather":false');
+
+  // --- The choice survives a reload ---
+  await page.reload({ waitUntil: 'commit' });
+  await expect(page.getByRole('columnheader', { name: 'Hive' })).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(
+    page.getByRole('columnheader', { name: 'Weather' }),
+  ).toHaveCount(0);
+
+  // --- Re-enabling it brings the column back ---
+  await page.getByRole('button', { name: 'Columns', exact: true }).click();
+  await page
+    .getByRole('menuitemcheckbox', { name: 'Weather' })
+    .click();
+  await page.keyboard.press('Escape');
+  await expect(
+    page.getByRole('columnheader', { name: 'Weather' }),
+  ).toBeVisible();
+});

--- a/apps/e2e/tests/table-column-visibility.spec.ts
+++ b/apps/e2e/tests/table-column-visibility.spec.ts
@@ -42,6 +42,7 @@ const seedInspection = async (page: Page) => {
         hiveId: hive.id,
         date: new Date('2026-06-01T10:00:00.000Z').toISOString(),
         status: 'COMPLETED',
+        notes: 'Colony looked strong and healthy with plenty of stores',
       }),
     });
   });
@@ -135,4 +136,23 @@ test('inspections table columns can be hidden and the choice persists', async ({
   await expect(
     page.getByRole('columnheader', { name: 'Weather' }),
   ).toBeVisible();
+
+  // --- The Notes column is off by default and can be enabled ---
+  await expect(
+    page.getByRole('columnheader', { name: 'Notes' }),
+  ).toHaveCount(0);
+  await page.getByRole('button', { name: 'Columns', exact: true }).click();
+  await page.getByRole('menuitemcheckbox', { name: 'Notes' }).click();
+  await page.keyboard.press('Escape');
+  await expect(
+    page.getByRole('columnheader', { name: 'Notes' }),
+  ).toBeVisible();
+  // The (abbreviated) note text is rendered in the row.
+  await expect(
+    page.getByText('Colony looked strong', { exact: false }),
+  ).toBeVisible();
+  await page.screenshot({
+    path: `${SHOT_DIR}/columns-03-notes-enabled.png`,
+    fullPage: true,
+  });
 });

--- a/apps/frontend/public/locales/de/common.json
+++ b/apps/frontend/public/locales/de/common.json
@@ -1,4 +1,14 @@
 {
+  "actionTypes": {
+    "feeding": "Fütterung",
+    "treatment": "Behandlung",
+    "frame": "Rähmchen",
+    "harvest": "Ernte",
+    "boxConfiguration": "Beutenkonfiguration",
+    "maintenance": "Wartung",
+    "note": "Notiz",
+    "other": "Sonstiges"
+  },
   "navigation": {
     "home": "Startseite",
     "dashboard": "Dashboard",

--- a/apps/frontend/public/locales/de/common.json
+++ b/apps/frontend/public/locales/de/common.json
@@ -1051,5 +1051,10 @@
         }
       }
     }
+  },
+  "table": {
+    "columns": "Spalten",
+    "toggleColumns": "Spalten ein-/ausblenden",
+    "resetColumns": "Auf Standard zurücksetzen"
   }
 }

--- a/apps/frontend/public/locales/de/inspection.json
+++ b/apps/frontend/public/locales/de/inspection.json
@@ -32,6 +32,7 @@
         "status": "Status",
         "queenSeen": "Königin gesehen",
         "notes": "Notizen",
+        "actions": "Aktionen",
         "temperature": "Temperatur",
         "weatherConditions": "Wetterbedingungen",
         "notRecorded": "Nicht erfasst",
@@ -99,6 +100,8 @@
     },
     "actions": {
         "details": "Details",
+        "view": "Ansehen",
+        "edit": "Bearbeiten",
         "createInspection": "Inspektion erstellen",
         "addInspection": "Inspektion hinzufügen",
         "scheduleInspection": "Inspektion planen",

--- a/apps/frontend/public/locales/de/inspection.json
+++ b/apps/frontend/public/locales/de/inspection.json
@@ -31,6 +31,7 @@
         "scoreStatus": "Bewertung/Status",
         "status": "Status",
         "queenSeen": "Königin gesehen",
+        "notes": "Notizen",
         "temperature": "Temperatur",
         "weatherConditions": "Wetterbedingungen",
         "notRecorded": "Nicht erfasst",

--- a/apps/frontend/public/locales/en/common.json
+++ b/apps/frontend/public/locales/en/common.json
@@ -1716,5 +1716,10 @@
         }
       }
     }
+  },
+  "table": {
+    "columns": "Columns",
+    "toggleColumns": "Toggle columns",
+    "resetColumns": "Reset to default"
   }
 }

--- a/apps/frontend/public/locales/en/common.json
+++ b/apps/frontend/public/locales/en/common.json
@@ -1,4 +1,14 @@
 {
+  "actionTypes": {
+    "feeding": "Feeding",
+    "treatment": "Treatment",
+    "frame": "Frames",
+    "harvest": "Harvest",
+    "boxConfiguration": "Box config",
+    "maintenance": "Maintenance",
+    "note": "Note",
+    "other": "Other"
+  },
   "navigation": {
     "home": "Home",
     "dashboard": "Dashboard",

--- a/apps/frontend/public/locales/en/inspection.json
+++ b/apps/frontend/public/locales/en/inspection.json
@@ -31,6 +31,7 @@
     "scoreStatus": "Score/Status",
     "status": "Status",
     "queenSeen": "Queen Seen",
+    "notes": "Notes",
     "temperature": "Temperature",
     "weatherConditions": "Weather Conditions",
     "notRecorded": "Not recorded",

--- a/apps/frontend/public/locales/en/inspection.json
+++ b/apps/frontend/public/locales/en/inspection.json
@@ -32,6 +32,7 @@
     "status": "Status",
     "queenSeen": "Queen Seen",
     "notes": "Notes",
+    "actions": "Actions",
     "temperature": "Temperature",
     "weatherConditions": "Weather Conditions",
     "notRecorded": "Not recorded",
@@ -119,6 +120,8 @@
   },
   "actions": {
     "details": "Details",
+    "view": "View",
+    "edit": "Edit",
     "createInspection": "Create Inspection",
     "addInspection": "Add Inspection",
     "mobileInspection": "Mobile Inspection",

--- a/apps/frontend/src/components/data-table/README.md
+++ b/apps/frontend/src/components/data-table/README.md
@@ -1,0 +1,77 @@
+# DataTable + column visibility
+
+A small, dependency-free system for tables with **user-toggleable, persisted
+columns**. Built on the shadcn table primitives — no `@tanstack/react-table`.
+
+Three pieces:
+
+- `DataTable` — renders rows from declarative `DataTableColumn<T>[]`.
+- `useColumnVisibility(tableId, columns)` — per-table visibility, persisted to
+  `localStorage` under `hive_pal_table_columns:<tableId>`.
+- `ColumnVisibilityMenu` — the "Columns" dropdown for a table's toolbar.
+
+## Adding it to a table
+
+```tsx
+import {
+  DataTable,
+  ColumnVisibilityMenu,
+  useColumnVisibility,
+  type DataTableColumn,
+} from '@/components/data-table';
+
+// 1. Describe the columns (memoise so visibility state stays stable).
+const columns = useMemo<DataTableColumn<Row>[]>(
+  () => [
+    { id: 'name', header: t('fields.name'), cell: row => row.name },
+    { id: 'date', header: t('fields.date'), cell: row => fmt(row.date) },
+    // Non-hideable columns (e.g. an actions column) set canHide: false.
+    {
+      id: 'actions',
+      header: '',
+      canHide: false,
+      cellClassName: 'text-right',
+      cell: row => <RowActions row={row} />,
+    },
+  ],
+  [t],
+);
+
+// 2. Wire up visibility (tableId must be unique & stable).
+const {
+  visibleColumns,
+  hideableColumns,
+  isColumnVisible,
+  setColumnVisible,
+  resetColumns,
+  isCustomised,
+} = useColumnVisibility('my-table', columns);
+
+// 3. Toolbar button + table.
+<ColumnVisibilityMenu
+  columns={hideableColumns}
+  isColumnVisible={isColumnVisible}
+  setColumnVisible={setColumnVisible}
+  resetColumns={resetColumns}
+  visibleCount={visibleColumns.length}
+  isCustomised={isCustomised}
+/>;
+
+<DataTable
+  columns={visibleColumns}
+  rows={rows}
+  rowKey={row => row.id}
+  emptyState={<EmptyState />}
+/>;
+```
+
+## Notes
+
+- **`canHide: false`** columns are always visible and never appear in the menu.
+- **`defaultHidden: true`** starts a column off until the user enables it.
+- The menu never lets the user hide the *last* visible column.
+- Unknown/removed column ids in the stored value are ignored; columns added
+  later show at their declared default — so persistence degrades gracefully as
+  a table's columns change over time.
+- The first adopter is `pages/inspection/inspection-list-page.tsx` (tableId
+  `inspections`).

--- a/apps/frontend/src/components/data-table/column-visibility-menu.tsx
+++ b/apps/frontend/src/components/data-table/column-visibility-menu.tsx
@@ -1,0 +1,88 @@
+import { SlidersHorizontal } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { columnMenuLabel, type DataTableColumn } from './types';
+
+interface ColumnVisibilityMenuProps<T> {
+  /** The columns the user may toggle (typically `hideableColumns` from the hook). */
+  columns: DataTableColumn<T>[];
+  isColumnVisible: (id: string) => boolean;
+  setColumnVisible: (id: string, visible: boolean) => void;
+  resetColumns: () => void;
+  /** Total number of currently-visible columns — used to keep at least one on. */
+  visibleCount: number;
+  /** Whether the user has diverged from the defaults (enables "Reset"). */
+  isCustomised?: boolean;
+  /** Optional trigger label; defaults to a translated "Columns". */
+  label?: string;
+  align?: 'start' | 'center' | 'end';
+}
+
+/**
+ * A reusable dropdown that toggles the visible columns of a {@link DataTable}.
+ * Drop it into any table's toolbar next to `useColumnVisibility`.
+ */
+export function ColumnVisibilityMenu<T>({
+  columns,
+  isColumnVisible,
+  setColumnVisible,
+  resetColumns,
+  visibleCount,
+  isCustomised = false,
+  label,
+  align = 'end',
+}: ColumnVisibilityMenuProps<T>) {
+  const { t } = useTranslation('common');
+  if (columns.length === 0) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <SlidersHorizontal className="h-4 w-4" />
+          {label ?? t('table.columns', { defaultValue: 'Columns' })}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className="w-52">
+        <DropdownMenuLabel>
+          {t('table.toggleColumns', { defaultValue: 'Toggle columns' })}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {columns.map(column => {
+          const visible = isColumnVisible(column.id);
+          // Never let the user hide the final visible column.
+          const isLastVisible = visible && visibleCount <= 1;
+          return (
+            <DropdownMenuCheckboxItem
+              key={column.id}
+              checked={visible}
+              disabled={isLastVisible}
+              // Keep the menu open so several columns can be toggled at once.
+              onSelect={event => event.preventDefault()}
+              onCheckedChange={checked => setColumnVisible(column.id, !!checked)}
+            >
+              {columnMenuLabel(column)}
+            </DropdownMenuCheckboxItem>
+          );
+        })}
+        {isCustomised && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => resetColumns()}>
+              {t('table.resetColumns', { defaultValue: 'Reset to default' })}
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/frontend/src/components/data-table/data-table.tsx
+++ b/apps/frontend/src/components/data-table/data-table.tsx
@@ -43,7 +43,7 @@ export function DataTable<T>({
   }
 
   return (
-    <Table>
+    <Table containerClassName="scroll-shadow-x">
       {caption && <TableCaption>{caption}</TableCaption>}
       <TableHeader>
         <TableRow>

--- a/apps/frontend/src/components/data-table/data-table.tsx
+++ b/apps/frontend/src/components/data-table/data-table.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+import type { DataTableColumn } from './types';
+
+interface DataTableProps<T> {
+  /**
+   * Columns to render, already filtered to the visible set (typically
+   * `visibleColumns` from `useColumnVisibility`).
+   */
+  columns: DataTableColumn<T>[];
+  rows: T[];
+  rowKey: (row: T, index: number) => string;
+  caption?: ReactNode;
+  /** Rendered instead of the table when there are no rows. */
+  emptyState?: ReactNode;
+  onRowClick?: (row: T) => void;
+}
+
+/**
+ * A thin, presentation-only table over the shadcn table primitives, driven by
+ * declarative {@link DataTableColumn} definitions. Combine with
+ * `useColumnVisibility` + `ColumnVisibilityMenu` for user-toggleable columns.
+ */
+export function DataTable<T>({
+  columns,
+  rows,
+  rowKey,
+  caption,
+  emptyState,
+  onRowClick,
+}: DataTableProps<T>) {
+  if (rows.length === 0) {
+    return emptyState ? <>{emptyState}</> : null;
+  }
+
+  return (
+    <Table>
+      {caption && <TableCaption>{caption}</TableCaption>}
+      <TableHeader>
+        <TableRow>
+          {columns.map(column => (
+            <TableHead key={column.id} className={column.headerClassName}>
+              {column.header}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row, index) => (
+          <TableRow
+            key={rowKey(row, index)}
+            onClick={onRowClick ? () => onRowClick(row) : undefined}
+            className={cn(onRowClick && 'cursor-pointer')}
+          >
+            {columns.map(column => (
+              <TableCell key={column.id} className={column.cellClassName}>
+                {column.cell(row, index, rows)}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/frontend/src/components/data-table/index.ts
+++ b/apps/frontend/src/components/data-table/index.ts
@@ -1,0 +1,6 @@
+export { DataTable } from './data-table';
+export { ColumnVisibilityMenu } from './column-visibility-menu';
+export { columnMenuLabel } from './types';
+export type { DataTableColumn, ColumnVisibility } from './types';
+export { useColumnVisibility } from '@/hooks/use-column-visibility';
+export type { UseColumnVisibilityResult } from '@/hooks/use-column-visibility';

--- a/apps/frontend/src/components/data-table/types.ts
+++ b/apps/frontend/src/components/data-table/types.ts
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+
+/**
+ * A declarative column definition shared by the generic {@link DataTable} and
+ * the column-visibility machinery. Any table that wants user-toggleable columns
+ * describes its columns as `DataTableColumn<T>[]` and renders them through the
+ * `DataTable` component together with `useColumnVisibility`.
+ */
+export interface DataTableColumn<T> {
+  /** Stable id — used as the React key and the localStorage visibility key. */
+  id: string;
+  /** Header cell content. */
+  header: ReactNode;
+  /** Renders a body cell for a row. Receives the row, its index and all rows. */
+  cell: (row: T, index: number, rows: T[]) => ReactNode;
+  /**
+   * Label shown in the column-visibility menu. Falls back to `header` when that
+   * is a plain string, otherwise to `id`.
+   */
+  menuLabel?: string;
+  /** Whether the user may hide this column. Defaults to `true`. */
+  canHide?: boolean;
+  /** Hidden until the user enables it (only meaningful when `canHide`). */
+  defaultHidden?: boolean;
+  /** Extra classes for the header cell. */
+  headerClassName?: string;
+  /** Extra classes for the body cells. */
+  cellClassName?: string;
+}
+
+/** Map of column id → whether it is currently visible. */
+export type ColumnVisibility = Record<string, boolean>;
+
+/** The label a column contributes to the visibility menu. */
+export const columnMenuLabel = <T>(column: DataTableColumn<T>): string =>
+  column.menuLabel ??
+  (typeof column.header === 'string' ? column.header : column.id);

--- a/apps/frontend/src/components/layout/page-grid-layout.tsx
+++ b/apps/frontend/src/components/layout/page-grid-layout.tsx
@@ -7,7 +7,11 @@ export const PageGrid: React.FC<PropsWithChildren> = ({ children }) => {
 };
 
 export const MainContent: React.FC<PropsWithChildren> = ({ children }) => {
-  return <div className={'md:col-span-2'}>{children}</div>;
+  // `min-w-0` lets this grid column shrink below its content's intrinsic width,
+  // so a wide child (e.g. a table with many/optional columns) scrolls inside its
+  // own `overflow-x-auto` container instead of pushing its last column off the
+  // edge / under the aside.
+  return <div className={'md:col-span-2 min-w-0'}>{children}</div>;
 };
 
 export const PageAside: React.FC<PropsWithChildren> = ({ children }) => {

--- a/apps/frontend/src/components/layout/page-grid-layout.tsx
+++ b/apps/frontend/src/components/layout/page-grid-layout.tsx
@@ -1,5 +1,7 @@
 import { PropsWithChildren } from 'react';
 
+// Page scaffold: a two-thirds MainContent beside a one-third PageAside on md+
+// screens, stacked into a single column on mobile.
 export const PageGrid: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <div className={'grid md:grid-cols-3 grid-cols-1 gap-4'}>{children}</div>
@@ -14,6 +16,7 @@ export const MainContent: React.FC<PropsWithChildren> = ({ children }) => {
   return <div className={'md:col-span-2 min-w-0'}>{children}</div>;
 };
 
+// The one-third aside column — page-level actions / secondary content.
 export const PageAside: React.FC<PropsWithChildren> = ({ children }) => {
   return <div className={'col-span-1'}>{children}</div>;
 };

--- a/apps/frontend/src/components/ui/table.tsx
+++ b/apps/frontend/src/components/ui/table.tsx
@@ -2,11 +2,15 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-function Table({ className, ...props }: React.ComponentProps<'table'>) {
+function Table({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<'table'> & { containerClassName?: string }) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className={cn('relative w-full overflow-x-auto', containerClassName)}
     >
       <table
         data-slot="table"

--- a/apps/frontend/src/components/ui/table.tsx
+++ b/apps/frontend/src/components/ui/table.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+// `containerClassName` styles the scroll wrapper (the element that actually
+// overflows horizontally) — e.g. to add a scroll-shadow hint. Optional and
+// additive, so existing callers are unaffected.
 function Table({
   className,
   containerClassName,

--- a/apps/frontend/src/hooks/use-column-visibility.ts
+++ b/apps/frontend/src/hooks/use-column-visibility.ts
@@ -1,0 +1,125 @@
+import { useCallback, useMemo, useState } from 'react';
+import type {
+  ColumnVisibility,
+  DataTableColumn,
+} from '@/components/data-table/types';
+
+const STORAGE_PREFIX = 'hive_pal_table_columns:';
+
+const readStored = (key: string): ColumnVisibility => {
+  try {
+    if (typeof localStorage === 'undefined') return {};
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as ColumnVisibility) : {};
+  } catch {
+    return {};
+  }
+};
+
+export interface UseColumnVisibilityResult<T> {
+  /** Effective visibility for every column id. */
+  visibility: ColumnVisibility;
+  isColumnVisible: (id: string) => boolean;
+  setColumnVisible: (id: string, visible: boolean) => void;
+  /** Clears the user's overrides, returning every column to its default. */
+  resetColumns: () => void;
+  /** Columns that are currently visible, in their declared order. */
+  visibleColumns: DataTableColumn<T>[];
+  /** Columns the user is allowed to toggle (for the visibility menu). */
+  hideableColumns: DataTableColumn<T>[];
+  /** True when the user has customised the visibility away from the defaults. */
+  isCustomised: boolean;
+}
+
+/**
+ * Persisted, per-table column visibility. Keyed by `tableId` in localStorage so
+ * a user's choice survives reloads and is scoped to that specific table.
+ *
+ * Columns with `canHide === false` are always visible. Unknown/removed columns
+ * in the stored value are ignored, and columns added later appear at their
+ * declared default — so the feature degrades gracefully as tables evolve.
+ *
+ * Pass a **stable** (memoised) `columns` array to avoid needless recomputation.
+ */
+export function useColumnVisibility<T>(
+  tableId: string,
+  columns: DataTableColumn<T>[],
+): UseColumnVisibilityResult<T> {
+  const storageKey = `${STORAGE_PREFIX}${tableId}`;
+  const [stored, setStored] = useState<ColumnVisibility>(() =>
+    readStored(storageKey),
+  );
+
+  const visibility = useMemo<ColumnVisibility>(() => {
+    const result: ColumnVisibility = {};
+    for (const column of columns) {
+      if (column.canHide === false) {
+        result[column.id] = true;
+        continue;
+      }
+      const userChoice = stored[column.id];
+      result[column.id] = userChoice ?? !column.defaultHidden;
+    }
+    return result;
+  }, [columns, stored]);
+
+  const persist = useCallback(
+    (next: ColumnVisibility) => {
+      setStored(next);
+      try {
+        if (typeof localStorage !== 'undefined') {
+          localStorage.setItem(storageKey, JSON.stringify(next));
+        }
+      } catch {
+        /* storage unavailable — keep the in-memory value */
+      }
+    },
+    [storageKey],
+  );
+
+  const setColumnVisible = useCallback(
+    (id: string, visible: boolean) => {
+      persist({ ...stored, [id]: visible });
+    },
+    [persist, stored],
+  );
+
+  const resetColumns = useCallback(() => {
+    setStored({});
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(storageKey);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [storageKey]);
+
+  const visibleColumns = useMemo(
+    () => columns.filter(column => visibility[column.id]),
+    [columns, visibility],
+  );
+  const hideableColumns = useMemo(
+    () => columns.filter(column => column.canHide !== false),
+    [columns],
+  );
+  const isCustomised = useMemo(
+    () => hideableColumns.some(column => stored[column.id] !== undefined),
+    [hideableColumns, stored],
+  );
+
+  const isColumnVisible = useCallback(
+    (id: string) => !!visibility[id],
+    [visibility],
+  );
+
+  return {
+    visibility,
+    isColumnVisible,
+    setColumnVisible,
+    resetColumns,
+    visibleColumns,
+    hideableColumns,
+    isCustomised,
+  };
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -203,4 +203,26 @@
     font-weight: 600;
     font-size: 0.6875rem;
   }
+  /*
+   * Pure-CSS horizontal scroll hint: a soft shadow fades in at whichever edge
+   * has more content to scroll to, and disappears once that edge is reached.
+   * The "cover" gradients use background-attachment:local so they scroll with
+   * the content and mask the shadow at the resting edge; the shadow gradients
+   * stay fixed to the scroll box. Only shows when the element actually
+   * overflows, so it's a no-op for tables that already fit.
+   */
+  .scroll-shadow-x {
+    background:
+      linear-gradient(to right, var(--background) 30%, transparent) 0 0,
+      linear-gradient(to left, var(--background) 30%, transparent) 100% 0,
+      linear-gradient(to right, rgba(0, 0, 0, 0.16), transparent) 0 0,
+      linear-gradient(to left, rgba(0, 0, 0, 0.16), transparent) 100% 0;
+    background-repeat: no-repeat;
+    background-size:
+      40px 100%,
+      40px 100%,
+      16px 100%,
+      16px 100%;
+    background-attachment: local, local, scroll, scroll;
+  }
 }

--- a/apps/frontend/src/pages/inspection/components/action-type-badges.tsx
+++ b/apps/frontend/src/pages/inspection/components/action-type-badges.tsx
@@ -1,3 +1,6 @@
+// Renders an inspection's beekeeping actions (feeding, treatment, frames, …) as
+// compact, colour-coded chips — one per distinct action type, deduplicated with
+// a ×count. Used in the inspections table's "Actions" column.
 import {
   Box,
   ClipboardCheck,

--- a/apps/frontend/src/pages/inspection/components/action-type-badges.tsx
+++ b/apps/frontend/src/pages/inspection/components/action-type-badges.tsx
@@ -1,0 +1,133 @@
+import {
+  Box,
+  ClipboardCheck,
+  Droplet,
+  Grid,
+  MessageSquare,
+  Pill,
+  Wrench,
+} from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { ActionResponse, ActionType } from 'shared-schemas';
+import { cn } from '@/lib/utils';
+
+type ActionVisual = {
+  Icon: React.ComponentType<{ className?: string }>;
+  tone: string;
+};
+
+const FALLBACK_VISUAL: ActionVisual = {
+  Icon: ClipboardCheck,
+  tone: 'bg-stone-100 text-stone-700 dark:bg-stone-800 dark:text-stone-300',
+};
+
+const FALLBACK_LABEL = { key: 'common:actionTypes.other', fallback: 'Other' };
+
+// Icon + colour tone per action type (mirrors the inspection detail actions
+// card). Partial so action types added to the enum later fall back gracefully
+// instead of breaking the build.
+const ACTION_TYPE_VISUAL: Partial<Record<ActionType, ActionVisual>> = {
+  [ActionType.FEEDING]: {
+    Icon: Droplet,
+    tone: 'bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300',
+  },
+  [ActionType.TREATMENT]: {
+    Icon: Pill,
+    tone: 'bg-purple-50 text-purple-700 dark:bg-purple-950/40 dark:text-purple-300',
+  },
+  [ActionType.FRAME]: {
+    Icon: Grid,
+    tone: 'bg-amber-50 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300',
+  },
+  [ActionType.HARVEST]: {
+    Icon: ClipboardCheck,
+    tone: 'bg-yellow-50 text-yellow-800 dark:bg-yellow-950/40 dark:text-yellow-300',
+  },
+  [ActionType.BOX_CONFIGURATION]: {
+    Icon: Box,
+    tone: 'bg-stone-100 text-stone-700 dark:bg-stone-800 dark:text-stone-300',
+  },
+  [ActionType.MAINTENANCE]: {
+    Icon: Wrench,
+    tone: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300',
+  },
+  [ActionType.NOTE]: {
+    Icon: MessageSquare,
+    tone: 'bg-stone-100 text-stone-700 dark:bg-stone-800 dark:text-stone-300',
+  },
+  [ActionType.OTHER]: {
+    Icon: ClipboardCheck,
+    tone: 'bg-stone-100 text-stone-700 dark:bg-stone-800 dark:text-stone-300',
+  },
+};
+
+const ACTION_TYPE_I18N: Partial<
+  Record<ActionType, { key: string; fallback: string }>
+> = {
+    [ActionType.FEEDING]: { key: 'common:actionTypes.feeding', fallback: 'Feeding' },
+    [ActionType.TREATMENT]: {
+      key: 'common:actionTypes.treatment',
+      fallback: 'Treatment',
+    },
+    [ActionType.FRAME]: { key: 'common:actionTypes.frame', fallback: 'Frames' },
+    [ActionType.HARVEST]: {
+      key: 'common:actionTypes.harvest',
+      fallback: 'Harvest',
+    },
+    [ActionType.BOX_CONFIGURATION]: {
+      key: 'common:actionTypes.boxConfiguration',
+      fallback: 'Box config',
+    },
+    [ActionType.MAINTENANCE]: {
+      key: 'common:actionTypes.maintenance',
+      fallback: 'Maintenance',
+    },
+    [ActionType.NOTE]: { key: 'common:actionTypes.note', fallback: 'Note' },
+    [ActionType.OTHER]: { key: 'common:actionTypes.other', fallback: 'Other' },
+  };
+
+/**
+ * Renders the actions recorded in an inspection as compact chips, one per
+ * distinct action type (with a ×count when a type occurs more than once).
+ * Shows a muted dash when there are no actions.
+ */
+export const ActionTypeBadges = ({
+  actions,
+}: {
+  actions: ActionResponse[];
+}) => {
+  const { t } = useTranslation('common');
+
+  if (!actions || actions.length === 0) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  // Count occurrences per type, preserving first-seen order.
+  const counts = new Map<ActionType, number>();
+  for (const action of actions) {
+    counts.set(action.type, (counts.get(action.type) ?? 0) + 1);
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {[...counts.entries()].map(([type, count]) => {
+        const visual = ACTION_TYPE_VISUAL[type] ?? FALLBACK_VISUAL;
+        const { Icon } = visual;
+        const label = ACTION_TYPE_I18N[type] ?? FALLBACK_LABEL;
+        return (
+          <span
+            key={type}
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs whitespace-nowrap',
+              visual.tone,
+            )}
+          >
+            <Icon className="h-3 w-3 shrink-0" />
+            {t(label.key, { defaultValue: label.fallback })}
+            {count > 1 && <span className="tabular-nums">×{count}</span>}
+          </span>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/frontend/src/pages/inspection/inspection-list-page.tsx
+++ b/apps/frontend/src/pages/inspection/inspection-list-page.tsx
@@ -597,6 +597,29 @@ const buildInspectionColumns = ({
         ),
     },
     {
+      id: 'notes',
+      header: t('inspection:fields.notes', { defaultValue: 'Notes' }),
+      menuLabel: t('inspection:fields.notes', { defaultValue: 'Notes' }),
+      // Off by default — the user enables it via the Columns menu. Abbreviated
+      // to a single truncated line; the full text shows on hover.
+      defaultHidden: true,
+      cellClassName: 'max-w-[16rem]',
+      cell: inspection => {
+        const notes = inspection.notes?.trim();
+        if (!notes) {
+          return <span className="text-muted-foreground">—</span>;
+        }
+        return (
+          <span
+            className="block truncate text-sm text-muted-foreground"
+            title={notes}
+          >
+            {notes}
+          </span>
+        );
+      },
+    },
+    {
       id: 'actions',
       header: t('common:actions.actions'),
       canHide: false,

--- a/apps/frontend/src/pages/inspection/inspection-list-page.tsx
+++ b/apps/frontend/src/pages/inspection/inspection-list-page.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApiary } from '@/hooks/use-apiary';
+import { useApiaryPermission } from '@/hooks/useApiaryPermission';
 import { useTranslation } from 'react-i18next';
 import { useHives, useInspections } from '@/api/hooks';
 import {
@@ -9,19 +10,21 @@ import {
   InspectionStatus,
 } from 'shared-schemas';
 import { InspectionActionSidebar } from './components';
+import { ActionTypeBadges } from './components/action-type-badges';
 import { ScheduledInspectionCard } from './components/scheduled-inspection-card';
 import { isFuture, isPast, isToday, parseISO } from 'date-fns';
 import {
   ActivityIcon,
   CalendarClockIcon,
   CalendarIcon,
-  ChevronRight,
   ClipboardCheckIcon,
   CloudIcon,
   CloudRainIcon,
   CrownIcon,
+  EyeIcon,
   HistoryIcon,
   InfoIcon,
+  PencilIcon,
   SearchIcon,
   SunIcon,
   ThermometerIcon,
@@ -76,6 +79,7 @@ export const InspectionListPage = () => {
 
   const navigate = useNavigate();
   const { activeApiary } = useApiary();
+  const { canEdit } = useApiaryPermission();
   const isSubjective = activeApiary?.settings?.inspectionType === 'subjective';
   const [searchTerm, setSearchTerm] = useState<string | undefined>('');
   const [selectedHiveId, setSelectedHiveId] = useState<string | undefined>(
@@ -105,8 +109,9 @@ export const InspectionListPage = () => {
         isSubjective,
         activeTab,
         navigate,
+        canEdit,
       }),
-    [t, hivesData, isSubjective, activeTab, navigate],
+    [t, hivesData, isSubjective, activeTab, navigate, canEdit],
   );
 
   // User-toggleable, persisted column visibility (shared across the tabs).
@@ -480,8 +485,9 @@ const renderStrengthCell = (
 
 /**
  * Declarative column set for the inspection tables. Every column carries a
- * stable `id` used for persisted visibility; `actions` cannot be hidden so a
- * row always has an affordance to open its detail page.
+ * stable `id` used for persisted visibility; the leading `rowActions` column
+ * cannot be hidden so a row always has an affordance to open (and, with edit
+ * permission, edit) the inspection.
  */
 const buildInspectionColumns = ({
   t,
@@ -489,12 +495,14 @@ const buildInspectionColumns = ({
   isSubjective,
   activeTab,
   navigate,
+  canEdit,
 }: {
   t: TFn;
   hives: HiveResponse[];
   isSubjective: boolean;
   activeTab: InspectionTab;
   navigate: (path: string) => void;
+  canEdit: boolean;
 }): DataTableColumn<InspectionResponse>[] => {
   const strengthHeader =
     activeTab === InspectionTab.UPCOMING || isSubjective
@@ -502,6 +510,43 @@ const buildInspectionColumns = ({
       : 'Strength';
 
   return [
+    {
+      // Leading row actions: open the inspection and (with edit permission) jump
+      // straight to its edit form. Kept on the left so it stays visible even
+      // when a wide table scrolls horizontally, and non-hideable so every row
+      // always has these affordances. Icon-only with accessible labels.
+      id: 'rowActions',
+      header: <span className="sr-only">{t('inspection:actions.view')}</span>,
+      menuLabel: t('inspection:actions.view'),
+      canHide: false,
+      cellClassName: 'w-0 whitespace-nowrap',
+      cell: inspection => (
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label={t('inspection:actions.view')}
+            title={t('inspection:actions.view')}
+            onClick={() => navigate(`/inspections/${inspection.id}`)}
+          >
+            <EyeIcon className="h-4 w-4" />
+          </Button>
+          {canEdit && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              aria-label={t('inspection:actions.edit')}
+              title={t('inspection:actions.edit')}
+              onClick={() => navigate(`/inspections/${inspection.id}/edit`)}
+            >
+              <PencilIcon className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      ),
+    },
     {
       id: 'dateTime',
       header: t('inspection:fields.dateTime'),
@@ -620,21 +665,13 @@ const buildInspectionColumns = ({
       },
     },
     {
+      // The beekeeping actions recorded in the inspection (feeding, treatment,
+      // frames, …), shown as compact chips. This is what "Actions" means here.
       id: 'actions',
-      header: t('common:actions.actions'),
-      canHide: false,
-      headerClassName: 'text-right',
-      cellClassName: 'text-right',
+      header: t('inspection:fields.actions', { defaultValue: 'Actions' }),
+      menuLabel: t('inspection:fields.actions', { defaultValue: 'Actions' }),
       cell: inspection => (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate(`/inspections/${inspection.id}`)}
-          className="flex items-center"
-        >
-          {t('inspection:actions.details')}{' '}
-          <ChevronRight className="ml-1 h-4 w-4" />
-        </Button>
+        <ActionTypeBadges actions={inspection.actions ?? []} />
       ),
     },
   ];

--- a/apps/frontend/src/pages/inspection/inspection-list-page.tsx
+++ b/apps/frontend/src/pages/inspection/inspection-list-page.tsx
@@ -48,19 +48,18 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import {
+  DataTable,
+  ColumnVisibilityMenu,
+  useColumnVisibility,
+  type DataTableColumn,
+} from '@/components/data-table';
+
+type TFn = (key: string, options?: Record<string, unknown>) => string;
 
 // Define tab enum for cleaner code
 enum InspectionTab {
@@ -95,6 +94,30 @@ export const InspectionListPage = () => {
   );
 
   const { data: hivesData, isLoading: isLoadingHives } = useHives();
+
+  // Declarative columns for the inspection tables. Kept stable per relevant
+  // input so `useColumnVisibility` doesn't churn.
+  const columns = useMemo(
+    () =>
+      buildInspectionColumns({
+        t,
+        hives: hivesData ?? [],
+        isSubjective,
+        activeTab,
+        navigate,
+      }),
+    [t, hivesData, isSubjective, activeTab, navigate],
+  );
+
+  // User-toggleable, persisted column visibility (shared across the tabs).
+  const {
+    visibleColumns,
+    hideableColumns,
+    isColumnVisible,
+    setColumnVisible,
+    resetColumns,
+    isCustomised,
+  } = useColumnVisibility('inspections', columns);
 
   // Handle tab changes
   const handleTabChange = (value: string) => {
@@ -147,6 +170,14 @@ export const InspectionListPage = () => {
   if (isLoadingInspections || isLoadingHives) {
     return <div>{t('common:status.loading')}</div>;
   }
+
+  const emptyState = (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <p className="text-muted-foreground mb-4">
+        {t('inspection:list.noInspections')}
+      </p>
+    </div>
+  );
 
   return (
     <PageGrid>
@@ -211,31 +242,37 @@ export const InspectionListPage = () => {
                   </SelectContent>
                 </Select>
               </div>
+
+              {/* Choose which table columns are visible (persisted per user). */}
+              <ColumnVisibilityMenu
+                columns={hideableColumns}
+                isColumnVisible={isColumnVisible}
+                setColumnVisible={setColumnVisible}
+                resetColumns={resetColumns}
+                visibleCount={visibleColumns.length}
+                isCustomised={isCustomised}
+              />
             </div>
           </div>
 
           <TabsContent value={InspectionTab.ALL}>
-            {renderInspectionsTable(
-              sortedInspections,
-              t('inspection:list.allInspections'),
-              navigate,
-              hivesData,
-              InspectionTab.ALL,
-              t,
-              isSubjective,
-            )}
+            <DataTable
+              columns={visibleColumns}
+              rows={sortedInspections}
+              rowKey={inspection => inspection.id}
+              caption={t('inspection:list.allInspections')}
+              emptyState={emptyState}
+            />
           </TabsContent>
 
           <TabsContent value={InspectionTab.RECENT}>
-            {renderInspectionsTable(
-              sortedInspections,
-              t('inspection:list.recentInspections'),
-              navigate,
-              hivesData,
-              InspectionTab.RECENT,
-              t,
-              isSubjective,
-            )}
+            <DataTable
+              columns={visibleColumns}
+              rows={sortedInspections}
+              rowKey={inspection => inspection.id}
+              caption={t('inspection:list.recentInspections')}
+              emptyState={emptyState}
+            />
           </TabsContent>
 
           <TabsContent value={InspectionTab.UPCOMING}>
@@ -243,9 +280,8 @@ export const InspectionListPage = () => {
               sortedInspections,
               hivesData,
               t,
-              navigate,
               refetchInspections,
-              isSubjective,
+              visibleColumns,
             )}
           </TabsContent>
         </Tabs>
@@ -262,8 +298,6 @@ export const InspectionListPage = () => {
     </PageGrid>
   );
 };
-
-
 
 const getHiveName = (
   hiveId: string,
@@ -311,7 +345,10 @@ const getStatusBadge = (
 /**
  * Renders the weather cell content: temperature and weather icon
  */
-const renderWeatherCell = (inspection: InspectionResponse, t: (key: string) => string) => {
+const renderWeatherCell = (
+  inspection: InspectionResponse,
+  t: (key: string) => string,
+) => {
   return (
     <div className="flex items-center gap-2">
       {inspection.temperature && (
@@ -362,13 +399,18 @@ const renderStrengthCell = (
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="ghost" size="sm" className="flex items-center gap-1 p-0 h-auto">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex items-center gap-1 p-0 h-auto"
+        >
           {strength == null ? (
             <span className="text-muted-foreground text-sm">—</span>
           ) : (
             <>
               <span className="font-medium tabular-nums">
-                {strength}{totalFrames != null ? `/${totalFrames}` : ''}
+                {strength}
+                {totalFrames != null ? `/${totalFrames}` : ''}
               </span>
               <TrendIndicator delta={strengthDelta} iconSize="h-3 w-3" />
             </>
@@ -386,79 +428,86 @@ const renderStrengthCell = (
                 if (frameCounts[i] === 0) return null;
                 return (
                   <div key={f.key} className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full shrink-0" style={{ backgroundColor: f.color }} />
+                    <span
+                      className="h-2 w-2 rounded-full shrink-0"
+                      style={{ backgroundColor: f.color }}
+                    />
                     <span className="text-sm flex-1">{f.label}</span>
-                    <span className="text-sm font-medium tabular-nums">{framePcts[i]}%</span>
+                    <span className="text-sm font-medium tabular-nums">
+                      {framePcts[i]}%
+                    </span>
                   </div>
                 );
               })}
             </div>
           ) : (
-            <p className="text-xs text-muted-foreground">No frame data recorded</p>
+            <p className="text-xs text-muted-foreground">
+              No frame data recorded
+            </p>
           )}
 
           {obs?.queenCells != null && obs.queenCells > 0 && (
             <div className="flex items-center gap-2 pt-2 border-t">
               <CrownIcon className="h-3.5 w-3.5 text-rose-500 shrink-0" />
               <span className="text-sm flex-1">Queen Cells</span>
-              <span className="text-sm font-medium tabular-nums">{obs.queenCells}</span>
+              <span className="text-sm font-medium tabular-nums">
+                {obs.queenCells}
+              </span>
             </div>
           )}
 
-          {inspection.score?.warnings && inspection.score.warnings.length > 0 && (
-            <div className="pt-2 border-t">
-              <h5 className="text-sm font-medium text-amber-500 flex items-center gap-1 mb-1">
-                <ActivityIcon className="h-3 w-3" />
-                {t('inspection:scores.warnings')}
-              </h5>
-              <ul className="text-xs space-y-1">
-                {inspection.score.warnings.map(warning => (
-                  <li key={warning} className="text-muted-foreground">{warning}</li>
-                ))}
-              </ul>
-            </div>
-          )}
+          {inspection.score?.warnings &&
+            inspection.score.warnings.length > 0 && (
+              <div className="pt-2 border-t">
+                <h5 className="text-sm font-medium text-amber-500 flex items-center gap-1 mb-1">
+                  <ActivityIcon className="h-3 w-3" />
+                  {t('inspection:scores.warnings')}
+                </h5>
+                <ul className="text-xs space-y-1">
+                  {inspection.score.warnings.map(warning => (
+                    <li key={warning} className="text-muted-foreground">
+                      {warning}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
         </div>
       </PopoverContent>
     </Popover>
   );
 };
 
-const InspectionTableRow = ({
-  inspection,
-  index,
-  inspections,
-  hives,
-  activeTab,
+/**
+ * Declarative column set for the inspection tables. Every column carries a
+ * stable `id` used for persisted visibility; `actions` cannot be hidden so a
+ * row always has an affordance to open its detail page.
+ */
+const buildInspectionColumns = ({
   t,
+  hives,
   isSubjective,
+  activeTab,
   navigate,
 }: {
-  inspection: InspectionResponse;
-  index: number;
-  inspections: InspectionResponse[];
+  t: TFn;
   hives: HiveResponse[];
-  activeTab: InspectionTab;
-  t: (key: string, options?: Record<string, unknown>) => string;
   isSubjective: boolean;
+  activeTab: InspectionTab;
   navigate: (path: string) => void;
-}) => {
-  const prevInspection = inspections
-    .slice(index + 1)
-    .find(candidate => candidate.hiveId === inspection.hiveId);
-  const obs = inspection.observations;
-  const strength    = obs?.strength ?? null;
-  const totalFrames = obs?.totalFrames ?? null;
-  const prevStrength = prevInspection?.observations?.strength ?? null;
-  const strengthDelta = strength != null && prevStrength != null ? strength - prevStrength : null;
+}): DataTableColumn<InspectionResponse>[] => {
+  const strengthHeader =
+    activeTab === InspectionTab.UPCOMING || isSubjective
+      ? t('inspection:fields.status')
+      : 'Strength';
 
-  const frameCounts = FRAME_FIELDS.map(f => (obs?.[f.obsKey] as number | null | undefined) ?? 0);
-  const frameTotal  = frameCounts.reduce((a, b) => a + b, 0);
-  const framePcts   = frameTotal > 0 ? largestRemainder(frameCounts, frameTotal) : null;
-
-  return (
-    <TableRow key={inspection.id}>
-      <TableCell className="font-medium">
+  return [
+    {
+      id: 'dateTime',
+      header: t('inspection:fields.dateTime'),
+      menuLabel: t('inspection:fields.dateTime'),
+      cellClassName: 'font-medium',
+      cell: inspection => (
         <div className="flex items-center gap-2">
           <CalendarIcon className="h-4 w-4 text-muted-foreground" />
           {new Date(inspection.date).toLocaleDateString('en-US', {
@@ -474,13 +523,43 @@ const InspectionTableRow = ({
             })}
           </span>
         </div>
-      </TableCell>
-      <TableCell>{getHiveName(inspection.hiveId, hives, t)}</TableCell>
-      <TableCell>
-        {renderWeatherCell(inspection, t)}
-      </TableCell>
-      <TableCell>
-        {renderStrengthCell(
+      ),
+    },
+    {
+      id: 'hive',
+      header: t('inspection:fields.hive'),
+      cell: inspection => getHiveName(inspection.hiveId, hives, t),
+    },
+    {
+      id: 'weather',
+      header: t('inspection:fields.weather'),
+      cell: inspection => renderWeatherCell(inspection, t),
+    },
+    {
+      id: 'strength',
+      header: strengthHeader,
+      menuLabel: t('inspection:fields.strength', { defaultValue: 'Strength' }),
+      cell: (inspection, index, rows) => {
+        const prevInspection = rows
+          .slice(index + 1)
+          .find(candidate => candidate.hiveId === inspection.hiveId);
+        const obs = inspection.observations;
+        const strength = obs?.strength ?? null;
+        const totalFrames = obs?.totalFrames ?? null;
+        const prevStrength = prevInspection?.observations?.strength ?? null;
+        const strengthDelta =
+          strength != null && prevStrength != null
+            ? strength - prevStrength
+            : null;
+
+        const frameCounts = FRAME_FIELDS.map(
+          f => (obs?.[f.obsKey] as number | null | undefined) ?? 0,
+        );
+        const frameTotal = frameCounts.reduce((a, b) => a + b, 0);
+        const framePcts =
+          frameTotal > 0 ? largestRemainder(frameCounts, frameTotal) : null;
+
+        return renderStrengthCell(
           inspection,
           activeTab,
           isSubjective,
@@ -492,10 +571,14 @@ const InspectionTableRow = ({
           framePcts,
           obs,
           t,
-        )}
-      </TableCell>
-      <TableCell>
-        {inspection.observations?.queenSeen === null ? (
+        );
+      },
+    },
+    {
+      id: 'queenSeen',
+      header: t('inspection:fields.queenSeen'),
+      cell: inspection =>
+        inspection.observations?.queenSeen === null ? (
           <span className="text-muted-foreground italic">
             {t('inspection:fields.notRecorded')}
           </span>
@@ -511,9 +594,15 @@ const InspectionTableRow = ({
               ? t('inspection:fields.yes')
               : t('inspection:fields.no')}
           </span>
-        )}
-      </TableCell>
-      <TableCell className="text-right">
+        ),
+    },
+    {
+      id: 'actions',
+      header: t('common:actions.actions'),
+      canHide: false,
+      headerClassName: 'text-right',
+      cellClassName: 'text-right',
+      cell: inspection => (
         <Button
           variant="ghost"
           size="sm"
@@ -523,72 +612,17 @@ const InspectionTableRow = ({
           {t('inspection:actions.details')}{' '}
           <ChevronRight className="ml-1 h-4 w-4" />
         </Button>
-      </TableCell>
-    </TableRow>
-  );
-};
-
-const renderInspectionsTable = (
-  inspections: InspectionResponse[],
-  caption: string,
-  navigate: (path: string) => void,
-  hives: HiveResponse[] = [],
-  activeTab: InspectionTab = InspectionTab.ALL,
-  t: (key: string, options?: Record<string, unknown>) => string,
-  isSubjective: boolean = false,
-) => {
-
-  return inspections.length > 0 ? (
-    <Table>
-      <TableCaption>{caption}</TableCaption>
-      <TableHeader>
-        <TableRow>
-          <TableHead>{t('inspection:fields.dateTime')}</TableHead>
-          <TableHead>{t('inspection:fields.hive')}</TableHead>
-          <TableHead>{t('inspection:fields.weather')}</TableHead>
-          <TableHead>
-            {activeTab === InspectionTab.UPCOMING || isSubjective
-              ? t('inspection:fields.status')
-              : 'Strength'}
-          </TableHead>
-          <TableHead>{t('inspection:fields.queenSeen')}</TableHead>
-          <TableHead className="text-right">
-            {t('common:actions.actions')}
-          </TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {inspections.map((inspection, index) => (
-          <InspectionTableRow
-            key={inspection.id}
-            inspection={inspection}
-            index={index}
-            inspections={inspections}
-            hives={hives}
-            activeTab={activeTab}
-            t={t}
-            isSubjective={isSubjective}
-            navigate={navigate}
-          />
-        ))}
-      </TableBody>
-    </Table>
-  ) : (
-    <div className="flex flex-col items-center justify-center py-12 text-center">
-      <p className="text-muted-foreground mb-4">
-        {t('inspection:list.noInspections')}
-      </p>
-    </div>
-  );
+      ),
+    },
+  ];
 };
 
 const renderUpcomingInspections = (
   inspections: InspectionResponse[],
   hives: HiveResponse[] = [],
-  t: (key: string, options?: Record<string, unknown>) => string,
-  navigate: (path: string) => void,
+  t: TFn,
   refetchInspections: () => void,
-  isSubjective: boolean = false,
+  columns: DataTableColumn<InspectionResponse>[],
 ) => {
   // Filter only scheduled inspections for cards
   const scheduledInspections = inspections.filter(
@@ -610,6 +644,12 @@ const renderUpcomingInspections = (
       upcoming.push(inspection);
     }
   }
+
+  const otherInspections = inspections.filter(
+    i =>
+      i.status !== InspectionStatus.SCHEDULED &&
+      i.status !== InspectionStatus.COMPLETED,
+  );
 
   return (
     <div className="space-y-6">
@@ -674,29 +714,18 @@ const renderUpcomingInspections = (
       )}
 
       {/* Show non-scheduled, non-completed inspections in a table below */}
-      {inspections.some(
-        i =>
-          i.status !== InspectionStatus.SCHEDULED &&
-          i.status !== InspectionStatus.COMPLETED,
-      ) && (
+      {otherInspections.length > 0 && (
         <div>
           <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
             <HistoryIcon className="h-5 w-5" />
             {t('inspection:scheduled.otherUpcomingInspections')}
           </h3>
-          {renderInspectionsTable(
-            inspections.filter(
-              i =>
-                i.status !== InspectionStatus.SCHEDULED &&
-                i.status !== InspectionStatus.COMPLETED,
-            ),
-            'Cancelled inspections',
-            navigate,
-            hives,
-            InspectionTab.UPCOMING,
-            t,
-            isSubjective,
-          )}
+          <DataTable
+            columns={columns}
+            rows={otherInspections}
+            rowKey={inspection => inspection.id}
+            caption="Cancelled inspections"
+          />
         </div>
       )}
 

--- a/apps/frontend/src/pages/inspection/inspection-list-page.tsx
+++ b/apps/frontend/src/pages/inspection/inspection-list-page.tsx
@@ -578,7 +578,7 @@ const buildInspectionColumns = ({
       cell: inspection => {
         const name = getHiveName(inspection.hiveId, hives, t);
         return (
-          <span className="block max-w-[9rem] truncate" title={name}>
+          <span className="block max-w-[7rem] truncate" title={name}>
             {name}
           </span>
         );

--- a/apps/frontend/src/pages/inspection/inspection-list-page.tsx
+++ b/apps/frontend/src/pages/inspection/inspection-list-page.tsx
@@ -573,7 +573,16 @@ const buildInspectionColumns = ({
     {
       id: 'hive',
       header: t('inspection:fields.hive'),
-      cell: inspection => getHiveName(inspection.hiveId, hives, t),
+      // Cap the width so long hive names don't stretch the column; the full
+      // name stays available on hover.
+      cell: inspection => {
+        const name = getHiveName(inspection.hiveId, hives, t);
+        return (
+          <span className="block max-w-[9rem] truncate" title={name}>
+            {name}
+          </span>
+        );
+      },
     },
     {
       id: 'weather',
@@ -648,7 +657,7 @@ const buildInspectionColumns = ({
       // Off by default — the user enables it via the Columns menu. Abbreviated
       // to a single truncated line; the full text shows on hover.
       defaultHidden: true,
-      cellClassName: 'max-w-[16rem]',
+      cellClassName: 'max-w-[12rem]',
       cell: inspection => {
         const notes = inspection.notes?.trim();
         if (!notes) {


### PR DESCRIPTION

Closes #199 

## What
Improves the Inspections table:
1. **User-toggleable, persisted columns**, built as a small reusable mechanism.
2. A new optional **Notes** column.
3. The **"Actions"** column now lists the actions performed in each inspection
   (feeding, frames, treatment, …) instead of just a navigation button.
4. **Leading row actions** — a compact **View** / **Edit** icon column — plus
   compaction so the table stops scrolling sideways when it doesn't need to, and a
   subtle hint for when it does.

## Why
See #199 . Beekeepers want to tailor which columns a table shows, to see
an inspection's notes in the list, to actually see the *actions* in the column
labelled "Actions", and to open/edit a row without hunting for a control.

## How
A small, **dependency-free** system built on the existing shadcn table primitives
(no `@tanstack/react-table`):

- **`DataTable<T>`** — renders rows from declarative `DataTableColumn<T>[]`.
- **`useColumnVisibility(tableId, columns)`** — per-table visibility persisted to
  `localStorage` under `hive_pal_table_columns:<tableId>`. Columns with
  `canHide: false` stay visible; unknown/removed ids in the stored value are
  ignored and columns added later appear at their declared default, so it degrades
  gracefully as a table's columns evolve.
- **`ColumnVisibilityMenu`** — the "Columns" toolbar dropdown; never hides the last
  visible column and offers "Reset to default" once customised.
- `apps/frontend/src/components/data-table/README.md` documents how any other table
  adopts it in ~3 steps.

**Inspections table**
- Refactored to declare its columns as `DataTableColumn[]` and render through
  `DataTable` + `ColumnVisibilityMenu` (tableId `inspections`); the Upcoming tab's
  fallback table shares the same column set / visibility.
- New **Notes** column, off by default: one truncated line, full text on hover. No
  backend change — the inspection list already returns `notes`.
- New **`ActionTypeBadges`** component: renders `inspection.actions[]` as compact,
  colour-coded chips (icon + label per action type, `×N` when a type repeats, muted
  dash when empty). The action-type → icon/label maps are
  `Partial<Record<ActionType, …>>` with a graceful fallback, so a new `ActionType`
  value won't break the build (it renders with the neutral "other" styling).
- **Leading row actions**: a non-hideable icon column with **View** (opens the
  inspection) and, with edit permission (`useApiaryPermission().canEdit`), **Edit**
  (jumps straight to the edit form). Kept on the *left* so the affordance stays
  visible even when a wide table scrolls, and so "Actions" is unambiguously the
  beekeeping-actions column.

**Compaction & scroll hint**
- The Hive column caps its width and truncates long names (full name on hover); the
  Notes column is narrowed. Together these let the table fit its container in the
  common case instead of overflowing.
- New reusable `.scroll-shadow-x` utility, applied to `DataTable` via a new optional
  `containerClassName` on the shadcn `Table` primitive: a pure-CSS, theme-aware
  shadow fades in at whichever edge still has content to scroll to, and is a no-op
  when the table already fits. This makes horizontal scrolling discoverable in
  browsers with overlay scrollbars (e.g. Firefox).

**Layout** — added `min-w-0` to `MainContent` (the 2/3 grid column). Without it a
CSS grid child keeps its content's intrinsic width, so a wide table couldn't shrink
and pushed its last column off the edge / under the aside. With `min-w-0`, the table
scrolls **horizontally** inside its own `overflow-x-auto` container and every column
stays reachable.

**i18n** — `table.columns` / `table.toggleColumns` / `table.resetColumns` and a new
`actionTypes.*` block (common); `fields.actions` / `fields.notes` and
`actions.view` / `actions.edit` (inspection); for `en` and `de`.

## Tests
- Playwright spec `apps/e2e/tests/table-column-visibility.spec.ts`: hides a column →
  it disappears → persists across reload → re-enable; the Notes column is off by
  default, can be enabled, and renders the abbreviated text; the Actions column
  shows the performed actions (e.g. "Feeding", "Frames", "×2"); and each row exposes
  leading **View** + **Edit** actions.
- `pnpm --filter frontend typecheck` is clean.

## Screenshots
| Row actions + Actions column | Columns menu |
| --- | --- |
| <img width="3840" height="2000" alt="pr01overview" src="https://github.com/user-attachments/assets/e6d9ac23-bb05-40ac-b334-4d9f7e49ba0a" />| <img width="3840" height="2000" alt="pr02columnsmenu" src="https://github.com/user-attachments/assets/3bef71a4-f6a7-4ea2-9086-949dc0db86f6" /> |

| Notes column | Horizontal-scroll hint |
| --- | --- |
 |<img width="3840" height="2000" alt="pr03notescolumn" src="https://github.com/user-attachments/assets/0bd042f9-5340-47b4-aa80-22c87e6d30fd" />| <img width="2360" height="2000" alt="pr04scrollhint" src="https://github.com/user-attachments/assets/09880fca-fbd9-4850-8c53-f208fc3ad97f" />|

## Notes for reviewers
- No new dependency; purely on top of the existing shadcn primitives. The only
  change to a shared primitive is an additive, optional `containerClassName` prop on
  `Table`.
- Persistence is localStorage-only (per browser). Server-side per-user prefs could
  be a follow-up.
- Enables easy follow-ups: adopt the menu in Hives / Queens / Harvests, and later
  add column reordering / resizing.
- Happy to split this into separate PRs (columns mechanism / Notes / Actions / row
  actions) if you'd prefer smaller reviews.
