### PR TITLE
Fix: render boxes at proportional real-world heights (Dadant honey/feeder)

### DIFF
--- a/apps/frontend/src/components/hive-minimap/hive-minimap.tsx
+++ b/apps/frontend/src/components/hive-minimap/hive-minimap.tsx
@@ -65,7 +65,7 @@ const MinimapHive = ({ hive, onClick, isHighlighted }: MinimapHiveProps) => {
         {sortedBoxes.length > 0 ? (
           <div className="flex flex-col items-center space-y-[2px]">
             {sortedBoxes.map((box, index) => {
-              const height = getBoxHeight(box.variant);
+              const height = getBoxHeight(box.variant, 'minimap', box.type);
               const defaultColor = '#CD853F';
 
               return (
@@ -73,7 +73,6 @@ const MinimapHive = ({ hive, onClick, isHighlighted }: MinimapHiveProps) => {
                   key={box.id || index}
                   className={cn(
                     'relative rounded-sm border border-gray-400/60 hover:shadow-sm transition-shadow',
-                    height,
                     index === 0 && 'rounded-t-sm',
                     index === sortedBoxes.length - 1 && 'rounded-b-sm',
                   )}
@@ -81,6 +80,7 @@ const MinimapHive = ({ hive, onClick, isHighlighted }: MinimapHiveProps) => {
                     backgroundColor: box.color || defaultColor,
                     borderColor: 'rgba(0, 0, 0, 0.3)',
                     width: '85px',
+                    height: `${height}px`,
                   }}
                 >
                   {/* Box type indicator */}
@@ -91,7 +91,7 @@ const MinimapHive = ({ hive, onClick, isHighlighted }: MinimapHiveProps) => {
                   </div>
 
                   {/* Frame count for larger boxes */}
-                  {height === 'h-15' && (
+                  {height >= 28 && (
                     <div className="absolute bottom-0.5 left-1 flex items-center gap-0.5">
                       <Package className="h-2 w-2 text-white/80" />
                       <span className="text-white/90 text-[9px]">

--- a/apps/frontend/src/pages/apiaries/components/hives-layout/hive-card.tsx
+++ b/apps/frontend/src/pages/apiaries/components/hives-layout/hive-card.tsx
@@ -72,7 +72,7 @@ export const HiveCard = ({
         <div className="px-2 ">
           <div className="flex flex-col items-center space-y-0.5">
              {sortedBoxes.map((box, index) => {
-               const height = getBoxHeight(box.variant, 'hive-card');
+               const height = getBoxHeight(box.variant, 'hive-card', box.type);
                const defaultColor = '#CD853F';
 
               return (
@@ -80,11 +80,11 @@ export const HiveCard = ({
                   key={box.id || index}
                   className={cn(
                     'relative w-full rounded-sm border border-gray-400/60',
-                    height,
                     index === 0 && 'rounded-t-sm',
                     index === sortedBoxes.length - 1 && 'rounded-b-sm',
                   )}
                   style={{
+                    height: `${height}px`,
                     backgroundColor: box.color || defaultColor,
                     borderColor: 'rgba(0, 0, 0, 0.3)',
                   }}
@@ -97,7 +97,7 @@ export const HiveCard = ({
                   </div>
 
                   {/* Frame count for larger boxes */}
-                  {(height === 'h-12' || height === 'h-10') && (
+                  {height >= 28 && (
                     <div className="absolute bottom-0.5 left-1 flex items-center gap-0.5">
                       <Package className="h-2.5 w-2.5 text-white/80" />
                       <span className="text-white/90 text-xs">

--- a/apps/frontend/src/pages/hive/hive-detail-page/box-configurator/BoxItem.tsx
+++ b/apps/frontend/src/pages/hive/hive-detail-page/box-configurator/BoxItem.tsx
@@ -30,7 +30,7 @@ export const BoxItem = ({
   isEditing,
   frameSizeName,
 }: BoxItemProps) => {
-  const height = getBoxHeight(box.variant, 'detail');
+  const height = getBoxHeight(box.variant, 'detail', box.type);
   const defaultColor = '#CD853F'; // Default wood color
 
   const getBoxTypeBadgeClass = (type: string) => {
@@ -46,11 +46,11 @@ export const BoxItem = ({
     <div
       className={cn(
         'relative w-64 rounded border-2 cursor-pointer transition-all',
-        height,
         isSelected && isEditing ? 'ring-2 ring-primary ring-offset-2' : '',
         isEditing ? 'hover:shadow-lg' : '',
       )}
       style={{
+        height: `${height}px`,
         backgroundColor: box.color || defaultColor,
         borderColor: 'rgba(0, 0, 0, 0.2)',
       }}
@@ -81,8 +81,8 @@ export const BoxItem = ({
         </span>
       </div>
 
-      {/* Frame size name */}
-      {frameSizeName && (
+      {/* Frame size name (hidden on short boxes to avoid overlapping badge/frame count) */}
+      {frameSizeName && height >= 56 && (
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
           <span
             className="text-white/70 text-xs font-medium"

--- a/apps/frontend/src/utils/box-display.ts
+++ b/apps/frontend/src/utils/box-display.ts
@@ -5,83 +5,119 @@
  * box type labels. Ensures consistent box rendering across all components.
  */
 
-import { BoxVariantEnum } from 'shared-schemas';
+import { BoxVariantEnum, BoxTypeEnum } from 'shared-schemas';
 
 /**
  * Display context for box height calculation
  * - 'hive-card': Compact hive card grid view
- * - 'minimap': Very compact minimap display (includes medium variant support)
+ * - 'minimap': Very compact minimap display
  * - 'detail': Large detail/configurator view
  */
 type BoxHeightContext = 'hive-card' | 'minimap' | 'detail';
 
 /**
- * Maps BoxVariantEnum values to Tailwind height classes for consistent box rendering.
+ * Approximate real-world external box (Zarge) heights in millimetres, keyed by
+ * variant. Boxes are rendered proportionally to these values so the stack
+ * matches reality (e.g. a shallow super is drawn clearly shorter than a deep).
  *
- * Different contexts use different height scales:
- * - hive-card: Compact (h-8 to h-12)
- * - minimap: Very compact with medium support (h-8 to h-15)
- * - detail: Large (h-20 to h-28)
+ * Sources: common commercial dimensions (Langstroth deep 9⅝"/medium 6⅝"/
+ * shallow 5¹¹⁄₁₆", Dadant brood ~300 mm, National deep/shallow).
+ */
+const VARIANT_HEIGHT_MM: Record<BoxVariantEnum, number> = {
+  [BoxVariantEnum.LANGSTROTH_DEEP]: 240,
+  [BoxVariantEnum.LANGSTROTH_MEDIUM]: 170,
+  [BoxVariantEnum.LANGSTROTH_SHALLOW]: 145,
+  [BoxVariantEnum.B_DEEP]: 225,
+  [BoxVariantEnum.B_SHALLOW]: 150,
+  [BoxVariantEnum.NATIONAL_DEEP]: 225,
+  [BoxVariantEnum.NATIONAL_SHALLOW]: 150,
+  [BoxVariantEnum.DADANT]: 300,
+  [BoxVariantEnum.WARRE]: 210,
+  [BoxVariantEnum.TOP_BAR]: 300,
+  [BoxVariantEnum.CUSTOM]: 240,
+};
+
+/**
+ * Real-world box heights in millimetres by box type. Used for hive systems
+ * whose single variant does not encode physical size — most importantly
+ * Dadant, where the same `DADANT` variant covers a full-height brood box, a
+ * ~half-height honey super and a ~third-height feeder — and as a fallback when
+ * a box has no variant set.
+ */
+const TYPE_HEIGHT_MM: Record<string, number> = {
+  [BoxTypeEnum.BROOD]: 300,
+  [BoxTypeEnum.HONEY]: 150,
+  [BoxTypeEnum.FEEDER]: 100,
+};
+
+/**
+ * Variants that map to a single physical box size in their enum value, so the
+ * box *type* must decide the rendered height instead of the variant. Dadant is
+ * the key case: brood/honey/feeder all share the `DADANT` variant but differ a
+ * lot in real height.
+ */
+const TYPE_DRIVEN_VARIANTS: BoxVariantEnum[] = [BoxVariantEnum.DADANT];
+
+/**
+ * Per-context rendering: `scale` converts millimetres to pixels (anchored so a
+ * ~300 mm brood box roughly matches the previous largest size in each context),
+ * `min` guarantees a legible minimum so tiny boxes still render a usable bar.
+ */
+const CONTEXT_RENDER: Record<BoxHeightContext, { scale: number; min: number }> =
+  {
+    detail: { scale: 112 / 300, min: 34 },
+    'hive-card': { scale: 48 / 300, min: 16 },
+    minimap: { scale: 40 / 300, min: 13 },
+  };
+
+/**
+ * Resolve the approximate real-world height (mm) of a box from its variant and
+ * type. Type-driven variants (Dadant) and variant-less boxes are resolved by
+ * type; everything else uses the variant's physical height.
+ */
+function resolveHeightMm(variant?: BoxVariantEnum, type?: string): number {
+  if (
+    variant &&
+    TYPE_DRIVEN_VARIANTS.includes(variant) &&
+    type &&
+    TYPE_HEIGHT_MM[type] != null
+  ) {
+    return TYPE_HEIGHT_MM[type];
+  }
+  if (variant && VARIANT_HEIGHT_MM[variant] != null) {
+    return VARIANT_HEIGHT_MM[variant];
+  }
+  if (type && TYPE_HEIGHT_MM[type] != null) {
+    return TYPE_HEIGHT_MM[type];
+  }
+  return VARIANT_HEIGHT_MM[BoxVariantEnum.LANGSTROTH_DEEP];
+}
+
+/**
+ * Calculate the rendered box height in **pixels**, proportional to the box's
+ * real-world height, for a given display context. Because Dadant honey/feeder
+ * boxes share one variant, the box `type` is needed to draw them at the correct
+ * (shorter) height.
  *
  * @param variant - The box variant enum value
- * @param context - The display context determining height scale
- * @returns A Tailwind CSS height class string (e.g., 'h-12')
+ * @param context - The display context determining the pixel scale
+ * @param type - The box type (BROOD/HONEY/FEEDER); required for correct Dadant
+ *   heights and used as a fallback when no variant is set
+ * @returns Height in pixels (number)
  *
  * @example
- * // Hive card view
- * const height = getBoxHeight(BoxVariantEnum.LANGSTROTH_DEEP, 'hive-card');
- * // Returns: 'h-12'
- *
- * // Minimap view
- * const height = getBoxHeight(BoxVariantEnum.LANGSTROTH_DEEP, 'minimap');
- * // Returns: 'h-15'
- *
- * // Detail view
- * const height = getBoxHeight(BoxVariantEnum.LANGSTROTH_DEEP, 'detail');
- * // Returns: 'h-28'
+ * getBoxHeight(BoxVariantEnum.DADANT, 'detail', BoxTypeEnum.BROOD); // 112
+ * getBoxHeight(BoxVariantEnum.DADANT, 'detail', BoxTypeEnum.HONEY); //  56
+ * getBoxHeight(BoxVariantEnum.DADANT, 'detail', BoxTypeEnum.FEEDER); // 37
  */
 export function getBoxHeight(
   variant?: BoxVariantEnum,
   context: BoxHeightContext = 'minimap',
-): string {
-  const deepVariants = [
-    BoxVariantEnum.LANGSTROTH_DEEP,
-    BoxVariantEnum.B_DEEP,
-    BoxVariantEnum.NATIONAL_DEEP,
-    BoxVariantEnum.DADANT,
-  ];
-
-  const mediumVariants = [BoxVariantEnum.LANGSTROTH_MEDIUM];
-
-  const shallowVariants = [
-    BoxVariantEnum.LANGSTROTH_SHALLOW,
-    BoxVariantEnum.B_SHALLOW,
-    BoxVariantEnum.NATIONAL_SHALLOW,
-  ];
-
-  // Hive card context: compact display in grid
-  if (context === 'hive-card') {
-    if (!variant) return 'h-8';
-    if (deepVariants.includes(variant)) return 'h-12';
-    if (shallowVariants.includes(variant)) return 'h-8';
-    return 'h-10'; // Default for WARRE, TOP_BAR, CUSTOM
-  }
-
-  // Detail context: large display for box configurator
-  if (context === 'detail') {
-    if (!variant) return 'h-20';
-    if (deepVariants.includes(variant)) return 'h-28';
-    if (mediumVariants.includes(variant)) return 'h-24';
-    if (shallowVariants.includes(variant)) return 'h-20';
-    return 'h-24'; // Default for WARRE, TOP_BAR, CUSTOM
-  }
-
-  // Minimap context (default): very compact display with medium support
-  if (!variant) return 'h-10';
-  if (deepVariants.includes(variant)) return 'h-15';
-  if (mediumVariants.includes(variant)) return 'h-12';
-  if (shallowVariants.includes(variant)) return 'h-10';
-  return 'h-8'; // Default for WARRE, TOP_BAR, CUSTOM
+  type?: string,
+): number {
+  const mm = resolveHeightMm(variant, type);
+  const { scale, min } = CONTEXT_RENDER[context];
+  return Math.round(Math.max(min, mm * scale));
 }
 
 /**

--- a/apps/frontend/src/utils/box-display.ts
+++ b/apps/frontend/src/utils/box-display.ts
@@ -110,6 +110,18 @@ function resolveHeightMm(variant?: BoxVariantEnum, type?: string): number {
  * getBoxHeight(BoxVariantEnum.DADANT, 'detail', BoxTypeEnum.HONEY); //  56
  * getBoxHeight(BoxVariantEnum.DADANT, 'detail', BoxTypeEnum.FEEDER); // 37
  */
+/**
+ * Real-world box height in millimetres for a given variant/type — the same
+ * table that drives the rendered stack, exposed for other proportional
+ * visualizations (e.g. the hive header gradient).
+ */
+export function getBoxHeightMm(
+  variant?: BoxVariantEnum,
+  type?: string,
+): number {
+  return resolveHeightMm(variant, type);
+}
+
 export function getBoxHeight(
   variant?: BoxVariantEnum,
   context: BoxHeightContext = 'minimap',

--- a/apps/frontend/src/utils/box-gradient.ts
+++ b/apps/frontend/src/utils/box-gradient.ts
@@ -1,23 +1,43 @@
+import { BoxVariantEnum } from 'shared-schemas';
+import { getBoxHeightMm } from './box-display';
+
+const MUTED_GRADIENT =
+  'linear-gradient(to bottom, hsl(var(--muted)), hsl(var(--muted)))';
+
 export function buildBoxGradient(
-  boxes?: { position: number; color?: string }[],
+  boxes?: {
+    position: number;
+    color?: string;
+    variant?: BoxVariantEnum | null;
+    type?: string;
+  }[],
 ): string {
   if (!boxes || boxes.length === 0) {
-    return 'linear-gradient(to bottom, hsl(var(--muted)), hsl(var(--muted)))';
+    return MUTED_GRADIENT;
   }
   // Sort descending by position so highest position (top box) is first in the gradient
   const sorted = [...boxes].sort((a, b) => b.position - a.position);
-  const colors = sorted.map(b => b.color).filter((c): c is string => !!c);
-  if (colors.length === 0) {
-    return 'linear-gradient(to bottom, hsl(var(--muted)), hsl(var(--muted)))';
+  const colored = sorted.filter(b => !!b.color);
+  if (colored.length === 0) {
+    return MUTED_GRADIENT;
   }
-  if (colors.length === 1) {
-    return colors[0];
+  if (colored.length === 1) {
+    return colored[0].color as string;
   }
-  // Hard stops — each color occupies an equal band with no blending
-  const step = 100 / colors.length;
-  const stops = colors.flatMap((color, i) => [
-    `${color} ${(i * step).toFixed(1)}%`,
-    `${color} ${((i + 1) * step).toFixed(1)}%`,
-  ]);
+  // Hard stops with no blending, each band weighted by the box's real-world
+  // height so the preview mirrors the actual stack (e.g. a Dadant feeder is a
+  // third of a brood box, not an equal share).
+  const weights = colored.map(b =>
+    getBoxHeightMm(b.variant ?? undefined, b.type),
+  );
+  const total = weights.reduce((sum, w) => sum + w, 0);
+  let acc = 0;
+  const stops: string[] = [];
+  colored.forEach((b, i) => {
+    const start = ((acc / total) * 100).toFixed(1);
+    acc += weights[i];
+    const end = ((acc / total) * 100).toFixed(1);
+    stops.push(`${b.color} ${start}%`, `${b.color} ${end}%`);
+  });
   return `linear-gradient(to bottom, ${stops.join(', ')})`;
 }


### PR DESCRIPTION
Resolves #202 

## Summary

In the hive visualizations (Box Configuration, apiary hive card, minimap),
box height was derived **solely from the box variant**. Langstroth/National
encode deep/medium/shallow as separate variants, so their supers happened to
differ — but **Dadant has a single `DADANT` variant**, so brood, honey and
feeder boxes were all drawn at the **same height**, even though a real Dadant
honey super is ~half and a feeder ~a third the height of a brood box.

This PR makes `getBoxHeight()` return **proportional pixel heights derived
from a central table of real-world box heights (mm)**, and resolves
single-variant systems (Dadant) by **box type**. Langstroth/National heights
are now proportional too. No DB/schema change — height stays derived at render
time, not stored.

## Changes

- `apps/frontend/src/utils/box-display.ts` — `getBoxHeight()` is now mm-based,
  type-aware, with a per-context pixel scale (`detail`, `hive-card`,
  `minimap`). Single source of truth: a table of researched real box heights.
  Resolution order: variant height if the variant encodes size
  (Langstroth/National deep/medium/shallow), otherwise by type
  (`BROOD` = full, `HONEY` = half, `FEEDER` = third).
- `BoxItem.tsx` (Box Configuration), `hive-card.tsx` (apiary layout),
  `hive-minimap.tsx` — apply the height via inline style instead of fixed
  Tailwind height classes, pass `box.type`, and switch the frame-count /
  label display to a height threshold (removes the non-standard `h-15` hack).
  The center frame-size label is hidden on short boxes to avoid overlap.
- `box-gradient.ts` — the hive header's photo-placeholder gradient previously
  split its color bands evenly per box (a strict three-way split for a
  three-box Dadant hive); its bands are now weighted by the same mm table via
  a new `getBoxHeightMm()` helper.

## Real-world heights used (mm)

| Box                          | Height (mm) | Ratio to brood |
| ---------------------------- | ----------- | -------------- |
| Dadant brood                 | ~300–320    | 1.00           |
| Dadant honey super (half)    | ~150–172    | ~0.50          |
| Dadant feeder                | ~73–100     | ~0.25–0.33     |
| Langstroth deep              | ~240        | 0.80           |
| Langstroth medium            | ~170        | 0.57           |
| Langstroth shallow           | ~145        | 0.48           |
| National (BS) deep                | ~225        | 0.75           |
| National (BS) shallow             | ~150        | 0.50           |

## Screenshots

A Dadant hive with brood box + honey super + feeder, Box Configuration view.

**Before — all three boxes render at the same height:**
<img width="1100" height="900" alt="boxheightbefore(1)" src="https://github.com/user-attachments/assets/7b3aa2e7-6f0a-43fe-9112-482aa84c0cae" />


**After — honey ≈ half, feeder ≈ a third of the brood box:**
<img width="1100" height="900" alt="boxheightafter(1)" src="https://github.com/user-attachments/assets/0761a169-9d18-4585-8450-902938b4fdec" />


## Notes

- Purely a frontend rendering change; no API, schema, or data migration.
- Langstroth/National users see slightly adjusted (now truly proportional)
  heights; Dadant users see the actual fix.
