### PR TITLE
Feature: faster inspection date/time entry (remember last time + "Now" button)

### DIFF
--- a/apps/frontend/public/locales/de/inspection.json
+++ b/apps/frontend/public/locales/de/inspection.json
@@ -214,6 +214,7 @@
         "inspectionDate": "Inspektionsdatum",
         "pickDate": "Datum auswählen",
         "allDay": "All day",
+        "now": "Jetzt",
         "specificTime": "Set specific time",
         "futureScheduled": "Diese Inspektion ist für die Zukunft geplant",
         "futureScheduledDescription": "Sie planen eine Inspektion für ein zukünftiges Datum.",

--- a/apps/frontend/public/locales/en/inspection.json
+++ b/apps/frontend/public/locales/en/inspection.json
@@ -237,6 +237,7 @@
     "inspectionDate": "Inspection date",
     "pickDate": "Pick a date",
     "allDay": "All day",
+    "now": "Now",
     "specificTime": "Set specific time",
     "futureScheduled": "This inspection is scheduled for the future",
     "futureScheduledDescription": "You are scheduling an inspection for a future date.",

--- a/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
@@ -513,6 +513,19 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
                         form.setValue('isAllDay', checked)
                       }
                     />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8"
+                      onClick={() => {
+                        // Set the inspection to the current date and time.
+                        form.setValue('isAllDay', false);
+                        field.onChange(new Date());
+                      }}
+                    >
+                      {t('inspection:form.now', { defaultValue: 'Now' })}
+                    </Button>
                   </div>
 
                   {isInFuture && (

--- a/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
@@ -48,6 +48,10 @@ import { PhotosSection, PendingPhoto } from './photos-section';
 import { ScorePreviewSection } from './score-preview';
 import { AiMergeBanner } from '@/pages/inspection/components/inspection-form/ai-merge-banner';
 import { InspectionDateTimePicker } from '@/components/inspection-date-time-picker';
+import {
+  getDefaultInspectionDateTime,
+  saveLastInspectionTimePreference,
+} from '@/utils/inspection-time-preference';
 import { FrameCountSection } from './frame-counts';
 import { uploadPendingPhotos } from './upload-pending-photos';
 import { uploadPendingRecordings } from './upload-pending-recordings';
@@ -125,13 +129,22 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
     enabled: !!inspectionId,
   });
 
+  // For a brand-new inspection, seed the date/time and all-day flag from the
+  // user's last-used choice (persisted in localStorage). Computed once on mount.
+  // Editing an existing inspection keeps that inspection's own stored values.
+  const [newInspectionDefaults] = useState(() =>
+    inspectionId ? null : getDefaultInspectionDateTime(),
+  );
+
   const form = useForm<InspectionFormData>({
     resolver: zodResolver(inspectionSchema),
     defaultValues: {
       hiveId,
       ...inspection,
-      date: inspection?.date ? new Date(inspection.date) : new Date(),
-      isAllDay: inspection?.isAllDay ?? true,
+      date: inspection?.date
+        ? new Date(inspection.date)
+        : (newInspectionDefaults?.date ?? new Date()),
+      isAllDay: inspection?.isAllDay ?? newInspectionDefaults?.isAllDay ?? true,
       // Cast: RHF types defaultValues as DeepPartial, which makes the action
       // discriminant (`type`) optional and breaks discriminated-union narrowing.
       // The mapping below produces correctly-shaped action objects at runtime.
@@ -356,6 +369,8 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
       onSubmitSuccess(formattedData);
       return;
     }
+    // Remember this time-of-day choice so the next new inspection defaults to it.
+    saveLastInspectionTimePreference(data.date, data.isAllDay ?? true);
     const status = fromScheduled ? InspectionStatus.COMPLETED : undefined;
     // Return the promise so RHF's isSubmitting stays true until the save
     // resolves — otherwise the save button re-enables before the request
@@ -375,6 +390,8 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
       onSubmitSuccess(formattedData);
       return;
     }
+    // Remember this time-of-day choice so the next new inspection defaults to it.
+    saveLastInspectionTimePreference(data.date, data.isAllDay ?? true);
     await onSubmit(formattedData, InspectionStatus.COMPLETED);
   });
 

--- a/apps/frontend/src/utils/inspection-time-preference.ts
+++ b/apps/frontend/src/utils/inspection-time-preference.ts
@@ -1,0 +1,90 @@
+/**
+ * Remembers the time-of-day the user last chose for an inspection, so a new
+ * inspection can default to that instead of always falling back to "all day".
+ *
+ * This is a lightweight, per-device UX convenience persisted in localStorage —
+ * no API or schema changes required.
+ */
+
+const STORAGE_KEY = 'hivepal:lastInspectionTime';
+
+export interface LastInspectionTimePreference {
+  isAllDay: boolean;
+  hours: number;
+  minutes: number;
+}
+
+/**
+ * Read the last-used inspection time preference, or null if none has been
+ * stored yet (or the stored value is unreadable).
+ */
+export function getLastInspectionTimePreference(): LastInspectionTimePreference | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<LastInspectionTimePreference>;
+    if (
+      typeof parsed.isAllDay !== 'boolean' ||
+      typeof parsed.hours !== 'number' ||
+      typeof parsed.minutes !== 'number' ||
+      parsed.hours < 0 ||
+      parsed.hours > 23 ||
+      parsed.minutes < 0 ||
+      parsed.minutes > 59
+    ) {
+      return null;
+    }
+    return {
+      isAllDay: parsed.isAllDay,
+      hours: parsed.hours,
+      minutes: parsed.minutes,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the time-of-day / all-day choice from a saved inspection so the next
+ * new inspection can reuse it as its default.
+ */
+export function saveLastInspectionTimePreference(
+  date: Date,
+  isAllDay: boolean,
+): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const value: LastInspectionTimePreference = {
+      isAllDay,
+      hours: date.getHours(),
+      minutes: date.getMinutes(),
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // localStorage may be unavailable (private mode, quota) — ignore silently.
+  }
+}
+
+/**
+ * Build the default date for a brand-new inspection, seeding the time-of-day
+ * from the last-used preference when available. Returns both the date and the
+ * matching all-day flag so the form can initialise consistently.
+ */
+export function getDefaultInspectionDateTime(now: Date = new Date()): {
+  date: Date;
+  isAllDay: boolean;
+} {
+  const pref = getLastInspectionTimePreference();
+  if (!pref) {
+    // No history yet — preserve the previous default (all day).
+    return { date: now, isAllDay: true };
+  }
+  const date = new Date(now);
+  if (pref.isAllDay) {
+    date.setHours(0, 0, 0, 0);
+    return { date, isAllDay: true };
+  }
+  date.setHours(pref.hours, pref.minutes, 0, 0);
+  return { date, isAllDay: false };
+}


### PR DESCRIPTION
Closes #208

### Summary
Two small quality-of-life improvements to the new-inspection date/time entry:
1. **Remember the last used time** — a new inspection defaults its date/time and
   all-day state to the user's last saved choice, instead of always defaulting to
   *All day*.
2. **A "Now" button** next to the date/time that sets the inspection to the
   current date and time (and turns *All day* off) in one click.

### Why
Beekeepers who record the real time had to turn off *All day* and re-enter the
time on **every** new inspection; many inspect at similar times (e.g. after
work). (See the issue for the related *All day = 00:00 UTC → shows as 02:00 AM*
oddity.)

### Changes
- New util `inspection-time-preference.ts` (`localStorage` key
  `hivepal:lastInspectionTime`) — reads/writes `{ isAllDay, hours, minutes }`.
- The inspection form seeds new-inspection defaults from it and persists the
  choice on save. **Editing an existing inspection is unaffected.**
- A "Now" button next to the date/time row sets the current date+time and turns
  *All day* off; `en`/`de` labels added.
- Frontend-only — no API or schema changes.

### Testing
- `pnpm typecheck` passes.
- Manually verified end-to-end: create at 17:00 → next new inspection shows
  *All day* off with 17:00 pre-filled; survives reload; all-day choice likewise
  restored; the "Now" button sets the current date/time and turns *All day* off.

### Acceptance criteria
All items in the linked issue are met.