### PR TITLE
Fix: hive edit form failed silently — dead save button

### DIFF
--- a/apps/frontend/public/locales/de/hive.json
+++ b/apps/frontend/public/locales/de/hive.json
@@ -142,7 +142,8 @@
     "hivePlaceholder": "Bienenstock 01",
     "notesPlaceholder": "Guter Bienenstock",
     "pickDate": "Datum auswählen",
-    "submit": "Absenden"
+    "submit": "Absenden",
+    "validationError": "Speichern nicht möglich — bitte prüfen: {{fields}}"
   },
   "weather": {
     "forecast": "Wettervorhersage"
@@ -158,7 +159,7 @@
     "noHivesInApiary": "Noch keine Bienenstöcke in diesem Bienenstand vorhanden.",
     "dragToOrganize": "Fügen Sie Bienenstöcke hinzu und ziehen Sie sie in das Raster oben, um Ihren Bienenstand zu organisieren."
   },
-  "equipment":{
+  "equipment": {
     "currentHives": "Aktuelle Bienenstöcke",
     "targetHives": "Soll-Bienenstöcke",
     "itemsNeeded": "Benötigte Artikel",
@@ -170,7 +171,7 @@
     "saveAllChanges": "Alle Änderungen speichern",
     "equipmentPlanningOverview": "Übersicht über die Ausstattungsplanung",
     "trackCurrentEquipment": "Behalte den Überblick über deinen aktuellen Bestand und plane deine saisonalen Erweiterungen",
-    "table":{
+    "table": {
       "title": "Ausstattung",
       "addEquipment": "Ausstattung hinzufügen",
       "equipmentName": "Ausstattungsname",

--- a/apps/frontend/public/locales/de/hive.json
+++ b/apps/frontend/public/locales/de/hive.json
@@ -23,7 +23,8 @@
   },
   "edit": {
     "title": "Bienenstock bearbeiten",
-    "success": "Bienenstock erfolgreich aktualisiert"
+    "success": "Bienenstock erfolgreich aktualisiert",
+    "error": "Bienenstock konnte nicht gespeichert werden. Bitte erneut versuchen."
   },
   "delete": {
     "confirm": "Möchten Sie diesen Bienenstock wirklich löschen?",

--- a/apps/frontend/public/locales/en/hive.json
+++ b/apps/frontend/public/locales/en/hive.json
@@ -23,7 +23,8 @@
   },
   "edit": {
     "title": "Edit Hive",
-    "success": "Hive updated successfully"
+    "success": "Hive updated successfully",
+    "error": "Failed to save the hive. Please try again."
   },
   "delete": {
     "confirm": "Are you sure you want to delete this hive?",

--- a/apps/frontend/public/locales/en/hive.json
+++ b/apps/frontend/public/locales/en/hive.json
@@ -142,7 +142,8 @@
     "hivePlaceholder": "hive 01",
     "notesPlaceholder": "Good hive",
     "pickDate": "Pick a date",
-    "submit": "Submit"
+    "submit": "Submit",
+    "validationError": "Cannot save — please check: {{fields}}"
   },
   "settings": {
     "title": "Hive Settings",
@@ -198,7 +199,7 @@
     "saveAllChanges": "Save All Changes",
     "equipmentPlanningOverview": "Equipment Planning Overview",
     "trackCurrentEquipment": "Track your current equipment and plan for seasonal expansion",
-    "table":{
+    "table": {
       "title": "Equipment",
       "addEquipment": "Add Equipment",
       "equipmentName": "Equipment Name",
@@ -222,7 +223,7 @@
   },
   "llmPrompt": {
     "title": "LLM Prompt for {{hiveName}}",
-    "description":"Copy this prompt and paste it into your preferred AI assistant for a\nhive health assessment. You can edit the text before copying.",
+    "description": "Copy this prompt and paste it into your preferred AI assistant for a\nhive health assessment. You can edit the text before copying.",
     "charactersLength": "{{length}} characters",
     "promptCopied": "Copied",
     "promptCopyToClipboard": "Copy to clipboard",

--- a/apps/frontend/src/pages/hive/components/hive-form.spec.tsx
+++ b/apps/frontend/src/pages/hive/components/hive-form.spec.tsx
@@ -1,20 +1,19 @@
 import { test, expect } from '@playwright/experimental-ct-react';
 import { MemoryRouter } from 'react-router-dom';
+import { Toaster } from 'sonner';
 import { HiveForm } from './hive-form';
 import type { Page } from '@playwright/test';
 
 const APIARY_ID = '11111111-1111-4111-8111-111111111111';
 const HIVE_ID = '22222222-2222-4222-8222-222222222222';
 
-// Regression test for the silently-dead save button: a hive whose status is
-// outside ACTIVE/INACTIVE (here UNKNOWN) used to fail the form's local zod
-// schema on an unrendered field, so submitting sent no request and showed no
-// error.
-async function mockApi(page: Page, requests: string[]) {
+// Regression tests for the silently-dead save button: validation failures on
+// unrendered form fields (e.g. a hive status outside ACTIVE/INACTIVE) used to
+// abort the submit with no request and no visible error.
+async function mockApi(page: Page, requests: string[], settings: unknown) {
   await page.route('**/api/**', async (route) => {
     const url = new URL(route.request().url());
-    const key = `${route.request().method()} ${url.pathname}`;
-    requests.push(key);
+    requests.push(`${route.request().method()} ${url.pathname}`);
     if (url.pathname === '/api/apiaries') {
       return route.fulfill({
         json: {
@@ -45,14 +44,11 @@ async function mockApi(page: Page, requests: string[]) {
           status: 'UNKNOWN',
           installationDate: '2025-04-12T10:00:00.000Z',
           updatedAt: '2026-07-14T09:00:00.000Z',
-          settings: {},
+          settings,
           boxes: [],
           alerts: [],
           hiveScore: null,
           activeQueen: null,
-          parentHiveId: null,
-          parentHive: null,
-          offspring: [],
         },
       });
     }
@@ -65,7 +61,7 @@ test('saving a hive with a non-ACTIVE status sends the update', async ({
   page,
 }) => {
   const requests: string[] = [];
-  await mockApi(page, requests);
+  await mockApi(page, requests, {});
 
   await mount(
     <MemoryRouter>
@@ -82,6 +78,39 @@ test('saving a hive with a non-ACTIVE status sends the update', async ({
 
   // The update request actually goes out (used to be silently swallowed).
   await expect
-    .poll(() => requests.filter((r) => r === `PATCH /api/hives/${HIVE_ID}`))
+    .poll(() =>
+      requests.filter((r) => r === `PATCH /api/hives/${HIVE_ID}`),
+    )
     .toHaveLength(1);
+});
+
+test('a validation failure on a hidden field shows a named error', async ({
+  mount,
+  page,
+}) => {
+  const requests: string[] = [];
+  // amountKg 0 violates the settings schema on a field that is not rendered —
+  // previously this made the save button silently dead.
+  await mockApi(page, requests, {
+    autumnFeeding: { startMonth: 8, endMonth: 10, amountKg: 0 },
+  });
+
+  await mount(
+    <MemoryRouter>
+      <>
+        <HiveForm hiveId={HIVE_ID} />
+        <Toaster />
+      </>
+    </MemoryRouter>,
+  );
+  await expect(page.getByPlaceholder('hive 01')).toHaveValue('Volk 7');
+
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+  // Instead of a silent no-op, the user sees which field is at fault…
+  await expect(page.getByText('Cannot save — please check')).toBeVisible();
+  // …and no update was sent.
+  expect(
+    requests.filter((r) => r === `PATCH /api/hives/${HIVE_ID}`),
+  ).toHaveLength(0);
 });

--- a/apps/frontend/src/pages/hive/components/hive-form.spec.tsx
+++ b/apps/frontend/src/pages/hive/components/hive-form.spec.tsx
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import { MemoryRouter } from 'react-router-dom';
+import { HiveForm } from './hive-form';
+import type { Page } from '@playwright/test';
+
+const APIARY_ID = '11111111-1111-4111-8111-111111111111';
+const HIVE_ID = '22222222-2222-4222-8222-222222222222';
+
+// Regression test for the silently-dead save button: a hive whose status is
+// outside ACTIVE/INACTIVE (here UNKNOWN) used to fail the form's local zod
+// schema on an unrendered field, so submitting sent no request and showed no
+// error.
+async function mockApi(page: Page, requests: string[]) {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const key = `${route.request().method()} ${url.pathname}`;
+    requests.push(key);
+    if (url.pathname === '/api/apiaries') {
+      return route.fulfill({
+        json: {
+          apiaries: [
+            { id: APIARY_ID, name: 'Home Apiary', role: 'OWNER', settings: {} },
+          ],
+          pendingMemberships: 0,
+        },
+      });
+    }
+    if (url.pathname === `/api/hives/${HIVE_ID}`) {
+      if (route.request().method() === 'PATCH') {
+        return route.fulfill({
+          json: {
+            id: HIVE_ID,
+            name: 'Volk 7',
+            apiaryId: APIARY_ID,
+            status: 'UNKNOWN',
+            updatedAt: '2026-07-21T12:00:00.000Z',
+          },
+        });
+      }
+      return route.fulfill({
+        json: {
+          id: HIVE_ID,
+          name: 'Volk 7',
+          apiaryId: APIARY_ID,
+          status: 'UNKNOWN',
+          installationDate: '2025-04-12T10:00:00.000Z',
+          updatedAt: '2026-07-14T09:00:00.000Z',
+          settings: {},
+          boxes: [],
+          alerts: [],
+          hiveScore: null,
+          activeQueen: null,
+          parentHiveId: null,
+          parentHive: null,
+          offspring: [],
+        },
+      });
+    }
+    return route.fulfill({ json: [] });
+  });
+}
+
+test('saving a hive with a non-ACTIVE status sends the update', async ({
+  mount,
+  page,
+}) => {
+  const requests: string[] = [];
+  await mockApi(page, requests);
+
+  await mount(
+    <MemoryRouter>
+      <HiveForm hiveId={HIVE_ID} />
+    </MemoryRouter>,
+  );
+
+  // Wait for the hive to load into the form.
+  await expect(page.getByPlaceholder('hive 01')).toHaveValue('Volk 7');
+
+  // The submit button is labeled "Save" (not the page title).
+  const save = page.getByRole('button', { name: 'Save', exact: true });
+  await save.click();
+
+  // The update request actually goes out (used to be silently swallowed).
+  await expect
+    .poll(() => requests.filter((r) => r === `PATCH /api/hives/${HIVE_ID}`))
+    .toHaveLength(1);
+});

--- a/apps/frontend/src/pages/hive/components/hive-form.tsx
+++ b/apps/frontend/src/pages/hive/components/hive-form.tsx
@@ -168,21 +168,35 @@ export const HiveForm: React.FC<HiveFormProps> = ({
     if (onSubmitOverride) {
       return onSubmitOverride(finalData as HiveFormData);
     } else if (isEditMode) {
-      await updateHive({
-        id: hiveId,
-        data: {
-          ...finalData,
+      try {
+        await updateHive({
           id: hiveId,
-          status: data.status as HiveStatusEnum,
-          installationDate: data.installationDate.toISOString(),
-        },
-      });
-      // The hive update endpoint ignores boxes; persist box/frame changes
-      // through the dedicated boxes endpoint.
-      if (finalData.boxes && finalData.boxes.length > 0) {
-        await updateHiveBoxes({ id: hiveId, boxes: finalData.boxes });
+          data: {
+            ...finalData,
+            id: hiveId,
+            status: data.status as HiveStatusEnum,
+            installationDate: data.installationDate.toISOString(),
+          },
+        });
+        // The hive update endpoint ignores boxes; persist box/frame changes
+        // through the dedicated boxes endpoint.
+        if (finalData.boxes && finalData.boxes.length > 0) {
+          await updateHiveBoxes({ id: hiveId, boxes: finalData.boxes });
+        }
+        toast.success(
+          t('hive:edit.success', {
+            defaultValue: 'Hive updated successfully',
+          }),
+        );
+        navigate(`/hives/${hiveId}`);
+      } catch {
+        // A failed request must never look like a dead button.
+        toast.error(
+          t('hive:edit.error', {
+            defaultValue: 'Failed to save the hive. Please try again.',
+          }),
+        );
       }
-      navigate(`/hives/${hiveId}`);
     } else {
       createHive({
         ...finalData,

--- a/apps/frontend/src/pages/hive/components/hive-form.tsx
+++ b/apps/frontend/src/pages/hive/components/hive-form.tsx
@@ -47,9 +47,12 @@ import {
 import {
   boxSchema,
   hiveSettingsSchema,
+  hiveStatusSchema,
   HiveStatus as HiveStatusEnum,
   findFrameSizeForVariant,
 } from 'shared-schemas';
+import { toast } from 'sonner';
+import type { FieldErrors } from 'react-hook-form';
 import {
   BoxBuilder,
   BoxBuilderRef,
@@ -69,7 +72,10 @@ const hiveSchema = z.object({
   name: z.string(),
   notes: z.string().optional(),
   apiaryId: z.string(),
-  status: z.enum(['ACTIVE', 'INACTIVE']).optional(),
+  // Must accept every real HiveStatus: in edit mode the form is reset with the
+  // hive's actual status (not rendered as a field), and a narrower enum makes
+  // submit fail invisibly for e.g. UNKNOWN/DEAD/SOLD/ARCHIVED hives.
+  status: hiveStatusSchema.optional(),
   installationDate: z.date(),
   settings: hiveSettingsSchema,
   boxes: boxSchema.optional(),
@@ -127,7 +133,7 @@ export const HiveForm: React.FC<HiveFormProps> = ({
         name: existingHive.name,
         notes: existingHive.notes || '',
         apiaryId: existingHive.apiaryId || '',
-        status: existingHive.status as 'ACTIVE' | 'INACTIVE',
+        status: existingHive.status,
         installationDate: existingHive.installationDate
           ? typeof existingHive.installationDate === 'string'
             ? parseISO(existingHive.installationDate)
@@ -192,9 +198,24 @@ export const HiveForm: React.FC<HiveFormProps> = ({
     }
   }, [activeApiaryId, form, isEditMode]);
 
+  // Validation failures on fields that aren't rendered (e.g. status, settings)
+  // would otherwise be invisible — the submit would just silently do nothing.
+  const onInvalid = (errors: FieldErrors<HiveFormData>) => {
+    const fields = Object.keys(errors).join(', ');
+    toast.error(
+      t('hive:form.validationError', {
+        defaultValue: 'Cannot save — please check: {{fields}}',
+        fields,
+      }),
+    );
+  };
+
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+      <form
+        onSubmit={form.handleSubmit(onSubmit, onInvalid)}
+        className="space-y-4"
+      >
         <FormField
           control={form.control}
           name="name"
@@ -467,7 +488,9 @@ export const HiveForm: React.FC<HiveFormProps> = ({
           type="submit"
           data-umami-event={isEditMode ? 'Hive Edit' : 'Hive Create'}
         >
-          {isEditMode ? t('hive:edit.title') : t('hive:form.submit')}
+          {isEditMode
+            ? t('common:actions.save', { defaultValue: 'Save' })
+            : t('hive:form.submit')}
         </Button>
       </form>
     </Form>


### PR DESCRIPTION
Resolves #210 

## Summary

The Edit Hive form could dead-end silently in two ways (full analysis in the
linked issue): a Zod validation failure on a form field that is never rendered
(most commonly a hive status outside `ACTIVE`/`INACTIVE`), and server-side
failures swallowed by uncaught `await`s in the submit handler. In both cases
the submit produced no request feedback, no error, and no navigation.

This PR fixes the status validation and — more importantly — turns every
remaining failure mode into a **visible, named error**, so this class of bug
cannot be silent again.

## Changes

Frontend only, two commits, four files (`hive-form.tsx`, its component spec,
`en`/`de` locale files):

- **Validate `status` against the real enum** — the form schema now uses
  `hiveStatusSchema` from `shared-schemas` instead of a hardcoded two-value
  enum, so hives in any status can be edited.
- **Surface validation failures** — an `onInvalid` handler on `handleSubmit`
  shows a toast naming the failing field(s) (e.g.
  *"Cannot save — please check: settings"*). Any future schema/form mismatch
  becomes visible instead of a dead button.
- **Visible outcomes for server errors** — the edit-mode mutations are wrapped
  in `try/catch` with success/error toasts.
- **Button label** — "Save" (`common:actions.save`) in edit mode instead of
  reusing the "Edit Hive" page title.
- New i18n keys (`hive:form.validationError`, `hive:edit.error`) in English
  and German.

No backend changes — `updateHiveSchema` already accepted every status.

## Screenshots

**The edit form with an actionable "Save" button:**
<img width="860" height="900" alt="prfixform" src="https://github.com/user-attachments/assets/01f7a999-c2f9-4c50-a6ca-d8149e9037ee" />


**A validation failure on a hidden field is now a visible, named error instead
of a dead button (here: a stored feeding amount of 0):**
<img width="860" height="900" alt="prfixtoast" src="https://github.com/user-attachments/assets/4220e71a-c095-4c9d-b053-86f5e1fdd74e" />

## Testing

Playwright component tests mount the real form against a mocked API:

- a hive with status `UNKNOWN` saves — the update request is actually issued
  (used to be silently swallowed);
- a validation failure on an unrendered field (stored feeding amount of 0)
  shows the named error toast and sends no request.

`tsc -b` and ESLint clean.
