### PR TITLE
Add "All apiaries" mode: cross-apiary reads, single-apiary writes

### DIFF
--- a/apps/backend/src/common/apiary-scope.ts
+++ b/apps/backend/src/common/apiary-scope.ts
@@ -1,0 +1,10 @@
+import { Prisma } from '@/prisma/client';
+
+/**
+ * Prisma `ApiaryWhereInput` that matches every apiary a user can access
+ * (owned or an active membership). Used to scope cross-apiary "view all"
+ * queries to the current user's apiaries.
+ */
+export const apiaryAccessWhere = (userId: string): Prisma.ApiaryWhereInput => ({
+  OR: [{ userId }, { members: { some: { userId, status: 'ACTIVE' } } }],
+});

--- a/apps/backend/src/common/index.ts
+++ b/apps/backend/src/common/index.ts
@@ -1,2 +1,3 @@
 export * from './decorators/zod-validation.decorator';
 export * from './pipes/zod-validation.pipe';
+export * from './apiary-scope';

--- a/apps/backend/src/guards/allow-all-apiaries.decorator.ts
+++ b/apps/backend/src/guards/allow-all-apiaries.decorator.ts
@@ -1,0 +1,19 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Metadata key marking a route handler as supporting the cross-apiary
+ * "view all" mode (x-apiary-id: all).
+ */
+export const ALLOW_ALL_APIARIES_KEY = 'allowAllApiaries';
+
+/**
+ * Marks a GET route handler as safe to run in the cross-apiary "view all" mode.
+ *
+ * By default the ApiaryContextGuard rejects `x-apiary-id: all`, because most
+ * services filter by a single `apiaryId` and would otherwise run unscoped
+ * queries (leaking other users' data). Only handlers whose service explicitly
+ * scopes the query to the user's apiaries when no single apiary is set should
+ * opt in with this decorator.
+ */
+export const AllowAllApiaries = () =>
+  SetMetadata(ALLOW_ALL_APIARIES_KEY, true);

--- a/apps/backend/src/guards/allow-all-apiaries.decorator.ts
+++ b/apps/backend/src/guards/allow-all-apiaries.decorator.ts
@@ -15,5 +15,4 @@ export const ALLOW_ALL_APIARIES_KEY = 'allowAllApiaries';
  * scopes the query to the user's apiaries when no single apiary is set should
  * opt in with this decorator.
  */
-export const AllowAllApiaries = () =>
-  SetMetadata(ALLOW_ALL_APIARIES_KEY, true);
+export const AllowAllApiaries = () => SetMetadata(ALLOW_ALL_APIARIES_KEY, true);

--- a/apps/backend/src/guards/apiary-context.guard.spec.ts
+++ b/apps/backend/src/guards/apiary-context.guard.spec.ts
@@ -1,5 +1,6 @@
 import type { Mock } from 'vitest';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Reflector } from '@nestjs/core';
 import {
   BadRequestException,
   ForbiddenException,
@@ -11,6 +12,7 @@ import { PrismaService } from '../prisma/prisma.service';
 describe('ApiaryContextGuard', () => {
   let guard: ApiaryContextGuard;
   let prisma: { apiary: { findFirst: Mock } };
+  let reflector: { getAllAndOverride: Mock };
 
   beforeEach(async () => {
     prisma = {
@@ -18,11 +20,16 @@ describe('ApiaryContextGuard', () => {
         findFirst: vi.fn(),
       },
     };
+    // Default: handlers do NOT opt into the all-apiaries mode.
+    reflector = {
+      getAllAndOverride: vi.fn().mockReturnValue(false),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ApiaryContextGuard,
         { provide: PrismaService, useValue: prisma },
+        { provide: Reflector, useValue: reflector },
       ],
     }).compile();
 
@@ -33,13 +40,16 @@ describe('ApiaryContextGuard', () => {
     headers?: Record<string, string>;
     query?: Record<string, string>;
     user?: { id: string } | undefined;
+    method?: string;
   }) {
     const request = {
+      method: overrides.method ?? 'GET',
       headers: overrides.headers ?? {},
       query: overrides.query ?? {},
       user: overrides.user,
       apiaryId: undefined as string | undefined,
       apiaryRole: undefined as string | undefined,
+      allApiaries: undefined as boolean | undefined,
     };
 
     return {
@@ -47,6 +57,8 @@ describe('ApiaryContextGuard', () => {
         switchToHttp: () => ({
           getRequest: () => request,
         }),
+        getHandler: () => () => undefined,
+        getClass: () => class {},
       } as unknown as Parameters<typeof guard.canActivate>[0],
       request,
     };
@@ -171,5 +183,53 @@ describe('ApiaryContextGuard', () => {
     await expect(guard.canActivate(context)).rejects.toThrow(
       ForbiddenException,
     );
+  });
+
+  describe('all-apiaries ("view all") mode', () => {
+    it('enables all-apiaries scope for a GET handler that opts in', async () => {
+      reflector.getAllAndOverride.mockReturnValue(true);
+
+      const { context, request } = createMockContext({
+        headers: { 'x-apiary-id': 'all' },
+        user: { id: 'user-1' },
+        method: 'GET',
+      });
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(request.allApiaries).toBe(true);
+      expect(request.apiaryId).toBeUndefined();
+      // Must not hit the single-apiary lookup.
+      expect(prisma.apiary.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('rejects "all" on a handler that does not opt in', async () => {
+      reflector.getAllAndOverride.mockReturnValue(false);
+
+      const { context } = createMockContext({
+        headers: { 'x-apiary-id': 'all' },
+        user: { id: 'user-1' },
+        method: 'GET',
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects "all" for a write (non-GET) request even when opted in', async () => {
+      reflector.getAllAndOverride.mockReturnValue(true);
+
+      const { context } = createMockContext({
+        headers: { 'x-apiary-id': 'all' },
+        user: { id: 'user-1' },
+        method: 'POST',
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
   });
 });

--- a/apps/backend/src/guards/apiary-context.guard.ts
+++ b/apps/backend/src/guards/apiary-context.guard.ts
@@ -6,19 +6,33 @@ import {
   ForbiddenException,
   BadRequestException,
 } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { PrismaService } from '../prisma/prisma.service';
 import { ApiaryRole } from '@/prisma/client';
+import { ALLOW_ALL_APIARIES_KEY } from './allow-all-apiaries.decorator';
+
+/**
+ * Reserved `x-apiary-id` value that selects the cross-apiary "view all" mode.
+ * In this mode no single apiary is chosen; read queries span every apiary the
+ * user has access to. Only safe (GET) requests may use it.
+ */
+export const ALL_APIARIES = 'all';
 
 @Injectable()
 export class ApiaryContextGuard implements CanActivate {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private reflector: Reflector,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request: {
+      method: string;
       headers: Record<string, string>;
       query: Record<string, string>;
-      apiaryId: string;
-      apiaryRole: ApiaryRole;
+      apiaryId?: string;
+      apiaryRole?: ApiaryRole;
+      allApiaries?: boolean;
       user?: { id: string };
     } = context.switchToHttp().getRequest();
 
@@ -33,6 +47,32 @@ export class ApiaryContextGuard implements CanActivate {
     // If user is not authenticated, we can't proceed
     if (!request.user?.id) {
       throw new ForbiddenException('User is not authenticated');
+    }
+
+    // "all" selects the cross-apiary read mode. It scopes queries to every
+    // apiary the user has access to and is only allowed on GET handlers that
+    // explicitly opt in via @AllowAllApiaries — otherwise a service that
+    // filters by a single apiaryId would run an unscoped query.
+    if (apiaryId === ALL_APIARIES) {
+      const allowAll = this.reflector.getAllAndOverride<boolean>(
+        ALLOW_ALL_APIARIES_KEY,
+        [context.getHandler(), context.getClass()],
+      );
+      if (!allowAll) {
+        throw new BadRequestException(
+          'This endpoint does not support the "all apiaries" view; ' +
+            'select a specific apiary.',
+        );
+      }
+      if (request.method.toUpperCase() !== 'GET') {
+        throw new BadRequestException(
+          'A specific apiary is required for write operations ' +
+            '(x-apiary-id must not be "all")',
+        );
+      }
+      request.allApiaries = true;
+      request.apiaryId = undefined;
+      return true;
     }
 
     // Find the apiary and check if user is owner or active member

--- a/apps/backend/src/hives/hive.controller.ts
+++ b/apps/backend/src/hives/hive.controller.ts
@@ -85,16 +85,18 @@ export class HiveController {
   }
 
   @Get(':id')
+  @AllowAllApiaries()
   findOne(
     @Param('id') id: string,
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<HiveDetailResponse> {
     this.logger.log(
-      `Getting hive details for ID: ${id} in apiary: ${req.apiaryId}`,
+      `Getting hive details for ID: ${id} in apiary: ${req.apiaryId ?? 'ALL'}`,
     );
     return this.hiveService.findOne(id, {
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
     });
   }
 

--- a/apps/backend/src/hives/hive.controller.ts
+++ b/apps/backend/src/hives/hive.controller.ts
@@ -18,7 +18,11 @@ import { HiveService } from './hive.service';
 import { ApiConsumes, ApiTags } from '@nestjs/swagger';
 import { ApiaryContextGuard } from '../guards/apiary-context.guard';
 import { ApiaryPermissionGuard } from '../guards/apiary-permission.guard';
-import { RequestWithApiary } from '../interface/request-with.apiary';
+import { AllowAllApiaries } from '../guards/allow-all-apiaries.decorator';
+import {
+  RequestWithApiary,
+  RequestWithApiaryScope,
+} from '../interface/request-with.apiary';
 import { CustomLoggerService } from '../logger/logger.service';
 import { ZodValidation } from '../common';
 import {
@@ -63,17 +67,19 @@ export class HiveController {
   }
 
   @Get()
+  @AllowAllApiaries()
   @ZodValidation(hiveFilterSchema)
   findAll(
     @Query() query: HiveFilter,
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<HiveResponse[]> {
     this.logger.log(
-      `Getting all hives for apiary: ${req.apiaryId} and user: ${req.user.id}`,
+      `Getting all hives for apiary: ${req.apiaryId ?? 'ALL'} and user: ${req.user.id}`,
     );
     return this.hiveService.findAll({
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
       ...query,
     });
   }

--- a/apps/backend/src/hives/hive.service.ts
+++ b/apps/backend/src/hives/hive.service.ts
@@ -14,6 +14,7 @@ import {
   ApiaryUserFilter,
   ApiaryScopeFilter,
 } from '../interface/request-with.apiary';
+import { apiaryAccessWhere } from '../common';
 import { CustomLoggerService } from '../logger/logger.service';
 import { Box as PrismaBox } from '@/prisma/client';
 import { HiveCreatedEvent, HiveUpdatedEvent } from '../events/hive.events';
@@ -349,17 +350,18 @@ export class HiveService {
 
   async findOne(
     id: string,
-    filter: ApiaryUserFilter,
+    filter: ApiaryScopeFilter,
   ): Promise<HiveDetailResponse> {
     this.logger.log(
-      `Finding hive with ID: ${id} for apiary ${filter.apiaryId} and user ${filter.userId}`,
+      `Finding hive with ID: ${id} for apiary ${filter.apiaryId ?? 'ALL'} and user ${filter.userId}`,
     );
     const hive = await this.prisma.hive.findFirst({
       where: {
         id,
-        apiary: {
-          id: filter.apiaryId,
-        },
+        // Single apiary, or any apiary the user can access in view-all mode.
+        apiary: filter.apiaryId
+          ? { id: filter.apiaryId }
+          : apiaryAccessWhere(filter.userId),
       },
       include: {
         apiary: { select: { settings: true } },

--- a/apps/backend/src/hives/hive.service.ts
+++ b/apps/backend/src/hives/hive.service.ts
@@ -10,7 +10,10 @@ import { InspectionsService } from '../inspections/inspections.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { PrometheusService } from '../health/prometheus/prometheus.service';
 import { FileUploadService } from '../storage/file-upload.service';
-import { ApiaryUserFilter } from '../interface/request-with.apiary';
+import {
+  ApiaryUserFilter,
+  ApiaryScopeFilter,
+} from '../interface/request-with.apiary';
 import { CustomLoggerService } from '../logger/logger.service';
 import { Box as PrismaBox } from '@/prisma/client';
 import { HiveCreatedEvent, HiveUpdatedEvent } from '../events/hive.events';
@@ -177,10 +180,10 @@ export class HiveService {
   }
 
   async findAll(
-    filter: ApiaryUserFilter & HiveFilter,
+    filter: ApiaryScopeFilter & HiveFilter,
   ): Promise<HiveResponse[]> {
     this.logger.log(
-      `Finding all hives for apiary ${filter.apiaryId} and user ${filter.userId}`,
+      `Finding all hives for apiary ${filter.apiaryId ?? 'ALL'} and user ${filter.userId}`,
     );
 
     const includeConfig = {

--- a/apps/backend/src/inspections/inspections.controller.ts
+++ b/apps/backend/src/inspections/inspections.controller.ts
@@ -78,16 +78,18 @@ export class InspectionsController {
   }
 
   @Get(':id')
+  @AllowAllApiaries()
   async findOne(
     @Param('id') id: string,
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<InspectionResponse | null> {
     this.logger.log(
-      `Finding inspection with ID ${id} in apiary ${req.apiaryId}`,
+      `Finding inspection with ID ${id} in apiary ${req.apiaryId ?? 'ALL'}`,
     );
     return this.inspectionsService.findOne(id, {
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
     });
   }
 

--- a/apps/backend/src/inspections/inspections.controller.ts
+++ b/apps/backend/src/inspections/inspections.controller.ts
@@ -14,7 +14,11 @@ import {
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ApiaryContextGuard } from '../guards/apiary-context.guard';
 import { ApiaryPermissionGuard } from '../guards/apiary-permission.guard';
-import { RequestWithApiary } from '../interface/request-with.apiary';
+import { AllowAllApiaries } from '../guards/allow-all-apiaries.decorator';
+import {
+  RequestWithApiary,
+  RequestWithApiaryScope,
+} from '../interface/request-with.apiary';
 import { InspectionsService } from './inspections.service';
 import { CustomLoggerService } from '../logger/logger.service';
 import {
@@ -56,18 +60,20 @@ export class InspectionsController {
   }
 
   @Get()
+  @AllowAllApiaries()
   @ZodValidation(inspectionFilterSchema)
   async findAll(
     @Query() query: InspectionFilter,
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<InspectionResponse[]> {
     this.logger.log(
-      `Finding inspections for apiary ${req.apiaryId}${query.hiveId ? `, hive ${query.hiveId}` : ''}`,
+      `Finding inspections for apiary ${req.apiaryId ?? 'ALL'}${query.hiveId ? `, hive ${query.hiveId}` : ''}`,
     );
     return this.inspectionsService.findAll({
       ...query,
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
     });
   }
 
@@ -121,24 +127,32 @@ export class InspectionsController {
   }
 
   @Get('status/overdue')
+  @AllowAllApiaries()
   async findOverdue(
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<InspectionResponse[]> {
-    this.logger.log(`Finding overdue inspections for apiary ${req.apiaryId}`);
+    this.logger.log(
+      `Finding overdue inspections for apiary ${req.apiaryId ?? 'ALL'}`,
+    );
     return this.inspectionsService.findOverdueInspections({
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
     });
   }
 
   @Get('status/due-today')
+  @AllowAllApiaries()
   async findDueToday(
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<InspectionResponse[]> {
-    this.logger.log(`Finding due today inspections for apiary ${req.apiaryId}`);
+    this.logger.log(
+      `Finding due today inspections for apiary ${req.apiaryId ?? 'ALL'}`,
+    );
     return this.inspectionsService.findDueTodayInspections({
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
     });
   }
 }

--- a/apps/backend/src/inspections/inspections.service.ts
+++ b/apps/backend/src/inspections/inspections.service.ts
@@ -9,7 +9,10 @@ import { PrismaService } from '../prisma/prisma.service';
 import { Observation, Prisma } from '@/prisma/client';
 import { MetricsService } from '../metrics/metrics.service';
 import { PrometheusService } from '../health/prometheus/prometheus.service';
-import { ApiaryUserFilter } from '../interface/request-with.apiary';
+import {
+  ApiaryUserFilter,
+  ApiaryScopeFilter,
+} from '../interface/request-with.apiary';
 import { ActionsService } from '../actions/actions.service';
 import { CustomLoggerService } from '../logger/logger.service';
 import { InspectionCreatedEvent } from '../events/hive.events';
@@ -334,7 +337,7 @@ export class InspectionsService {
   }
 
   async findAll(
-    filter: InspectionFilter & Partial<ApiaryUserFilter>,
+    filter: InspectionFilter & ApiaryScopeFilter,
   ): Promise<InspectionResponse[]> {
     await this.inspectionStatusUpdater.checkAndUpdateInspectionStatuses();
 
@@ -579,7 +582,7 @@ export class InspectionsService {
   }
 
   async findOverdueInspections(
-    filter: Partial<ApiaryUserFilter>,
+    filter: ApiaryScopeFilter,
   ): Promise<InspectionResponse[]> {
     await this.inspectionStatusUpdater.checkAndUpdateInspectionStatuses();
 
@@ -600,7 +603,7 @@ export class InspectionsService {
   }
 
   async findDueTodayInspections(
-    filter: Partial<ApiaryUserFilter>,
+    filter: ApiaryScopeFilter,
   ): Promise<InspectionResponse[]> {
     await this.inspectionStatusUpdater.checkAndUpdateInspectionStatuses();
 
@@ -727,15 +730,39 @@ export class InspectionsService {
       : {};
   }
 
-  private getApiaryFilter(filter: Partial<ApiaryUserFilter>) {
-    if (!filter.apiaryId || !filter.userId) return {};
-    return {
-      hive: {
-        apiary: {
-          id: filter.apiaryId,
+  private getApiaryFilter(
+    filter: ApiaryScopeFilter,
+  ): Prisma.InspectionWhereInput {
+    // Single-apiary view: scope to the selected apiary.
+    if (filter.apiaryId) {
+      return {
+        hive: {
+          apiary: {
+            id: filter.apiaryId,
+          },
         },
-      },
-    };
+      };
+    }
+    // Cross-apiary "view all" mode: scope to every apiary the user owns or is
+    // an active member of. Never fall through to an unscoped query, which
+    // would leak other users' inspections.
+    if (filter.allApiaries && filter.userId) {
+      return {
+        hive: {
+          apiary: {
+            OR: [
+              { userId: filter.userId },
+              {
+                members: {
+                  some: { userId: filter.userId, status: 'ACTIVE' },
+                },
+              },
+            ],
+          },
+        },
+      };
+    }
+    return {};
   }
 
   private mapInspectionsToDto(

--- a/apps/backend/src/inspections/inspections.service.ts
+++ b/apps/backend/src/inspections/inspections.service.ts
@@ -13,6 +13,7 @@ import {
   ApiaryUserFilter,
   ApiaryScopeFilter,
 } from '../interface/request-with.apiary';
+import { apiaryAccessWhere } from '../common';
 import { ActionsService } from '../actions/actions.service';
 import { CustomLoggerService } from '../logger/logger.service';
 import { InspectionCreatedEvent } from '../events/hive.events';
@@ -367,15 +368,15 @@ export class InspectionsService {
 
   async findOne(
     id: string,
-    filter: ApiaryUserFilter,
+    filter: ApiaryScopeFilter,
   ): Promise<InspectionResponse | null> {
     const inspection = await this.prisma.inspection.findFirst({
       where: {
         id,
         hive: {
-          apiary: {
-            id: filter.apiaryId,
-          },
+          apiary: filter.apiaryId
+            ? { id: filter.apiaryId }
+            : apiaryAccessWhere(filter.userId),
         },
       },
       include: INSPECTION_INCLUDE,

--- a/apps/backend/src/interface/request-with.apiary.ts
+++ b/apps/backend/src/interface/request-with.apiary.ts
@@ -9,7 +9,34 @@ export interface RequestWithApiary extends Request {
   };
 }
 
+/**
+ * Request type for read endpoints that support the "all apiaries" view mode.
+ * When the client sends `x-apiary-id: all`, the ApiaryContextGuard leaves
+ * `apiaryId` undefined and sets `allApiaries` to true, so the query is scoped
+ * to every apiary the user owns or is an active member of.
+ */
+export interface RequestWithApiaryScope extends Request {
+  apiaryId?: string;
+  apiaryRole?: ApiaryRole;
+  allApiaries?: boolean;
+  user: {
+    id: string;
+  };
+}
+
 export interface ApiaryUserFilter {
   apiaryId: string;
   userId: string;
+}
+
+/**
+ * Filter for read queries that may span all of a user's apiaries.
+ * Either `apiaryId` is set (single apiary) or `allApiaries` is true (every
+ * apiary the user has access to). `userId` is always required so the query
+ * stays scoped to the current user.
+ */
+export interface ApiaryScopeFilter {
+  apiaryId?: string;
+  userId: string;
+  allApiaries?: boolean;
 }

--- a/apps/backend/src/queens/queens.controller.ts
+++ b/apps/backend/src/queens/queens.controller.ts
@@ -64,15 +64,17 @@ export class QueensController {
   }
 
   @Get('hive/:hiveId/history')
+  @AllowAllApiaries()
   @ApiOkResponse({ type: Object, isArray: true })
   getHiveHistory(
     @Param('hiveId') hiveId: string,
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<QueenResponse[]> {
     this.logger.log(`Getting queen history for hive ${hiveId}`);
     return this.queensService.getHiveQueenHistory(hiveId, {
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
     });
   }
 
@@ -96,15 +98,17 @@ export class QueensController {
   }
 
   @Get(':id/history')
+  @AllowAllApiaries()
   @ApiOkResponse({ type: Object })
   getHistory(
     @Param('id') id: string,
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<QueenDetail> {
     this.logger.log(`Getting history for queen ${id}`);
     return this.queensService.getQueenHistory(id, {
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
     });
   }
 
@@ -124,15 +128,19 @@ export class QueensController {
   }
 
   @Get(':id')
+  @AllowAllApiaries()
   @ApiOkResponse({ type: Object })
   findOne(
     @Param('id') id: string,
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<QueenResponse> {
-    this.logger.log(`Finding queen with ID ${id} in apiary ${req.apiaryId}`);
+    this.logger.log(
+      `Finding queen with ID ${id} in apiary ${req.apiaryId ?? 'ALL'}`,
+    );
     return this.queensService.findOne(id, {
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
     });
   }
 

--- a/apps/backend/src/queens/queens.controller.ts
+++ b/apps/backend/src/queens/queens.controller.ts
@@ -17,7 +17,11 @@ import { QueensService } from './queens.service';
 import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { ApiaryContextGuard } from '../guards/apiary-context.guard';
 import { ApiaryPermissionGuard } from '../guards/apiary-permission.guard';
-import { RequestWithApiary } from '../interface/request-with.apiary';
+import { AllowAllApiaries } from '../guards/allow-all-apiaries.decorator';
+import {
+  RequestWithApiary,
+  RequestWithApiaryScope,
+} from '../interface/request-with.apiary';
 import { CustomLoggerService } from '../logger/logger.service';
 import { ZodValidation } from '../common';
 import {
@@ -73,15 +77,20 @@ export class QueensController {
   }
 
   @Get()
+  @AllowAllApiaries()
   @ApiOkResponse({ type: Object, isArray: true })
   findAll(
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
     @Query('status') status?: string,
     @Query('hiveId') hiveId?: string,
   ): Promise<QueenResponse[]> {
-    this.logger.log(`Finding all queens in apiary ${req.apiaryId}`);
+    this.logger.log(`Finding all queens in apiary ${req.apiaryId ?? 'ALL'}`);
     return this.queensService.findAll(
-      { apiaryId: req.apiaryId, userId: req.user.id },
+      {
+        apiaryId: req.apiaryId,
+        userId: req.user.id,
+        allApiaries: req.allApiaries,
+      },
       { status, hiveId },
     );
   }

--- a/apps/backend/src/queens/queens.service.ts
+++ b/apps/backend/src/queens/queens.service.ts
@@ -1,7 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { PrometheusService } from '../health/prometheus/prometheus.service';
-import { ApiaryUserFilter } from '../interface/request-with.apiary';
+import {
+  ApiaryUserFilter,
+  ApiaryScopeFilter,
+} from '../interface/request-with.apiary';
+import { apiaryAccessWhere } from '../common';
 import {
   CreateQueen,
   QueenResponse,
@@ -99,10 +103,14 @@ export class QueensService {
   }
 
   async findAll(
-    filter: ApiaryUserFilter,
+    filter: ApiaryScopeFilter,
     params?: { status?: string; hiveId?: string },
   ): Promise<QueenResponse[]> {
-    const apiaryFilter = { hive: { apiary: { id: filter.apiaryId } } };
+    // Single apiary, or every apiary the user can access in view-all mode.
+    const apiaryWhere = filter.apiaryId
+      ? { id: filter.apiaryId }
+      : apiaryAccessWhere(filter.userId);
+    const apiaryFilter = { hive: { apiary: apiaryWhere } };
 
     let where: Record<string, unknown>;
     if (params?.hiveId) {
@@ -118,8 +126,8 @@ export class QueensService {
             movements: {
               some: {
                 OR: [
-                  { fromHive: { apiary: { id: filter.apiaryId } } },
-                  { toHive: { apiary: { id: filter.apiaryId } } },
+                  { fromHive: { apiary: apiaryWhere } },
+                  { toHive: { apiary: apiaryWhere } },
                 ],
               },
             },

--- a/apps/backend/src/queens/queens.service.ts
+++ b/apps/backend/src/queens/queens.service.ts
@@ -147,9 +147,16 @@ export class QueensService {
     return queens.map((queen) => this.mapQueenToResponse(queen));
   }
 
-  async findOne(id: string, filter: ApiaryUserFilter): Promise<QueenResponse> {
+  async findOne(id: string, filter: ApiaryScopeFilter): Promise<QueenResponse> {
     const queen = await this.prisma.queen.findFirst({
-      where: { id, hive: { apiary: { id: filter.apiaryId } } },
+      where: {
+        id,
+        hive: {
+          apiary: filter.apiaryId
+            ? { id: filter.apiaryId }
+            : apiaryAccessWhere(filter.userId),
+        },
+      },
       include: { hive: { select: { name: true } } },
     });
     if (!queen) throw new NotFoundException(`Queen with ID ${id} not found`);
@@ -288,19 +295,22 @@ export class QueensService {
 
   async getQueenHistory(
     queenId: string,
-    filter: ApiaryUserFilter,
+    filter: ApiaryScopeFilter,
   ): Promise<QueenDetail> {
+    const apiaryWhere = filter.apiaryId
+      ? { id: filter.apiaryId }
+      : apiaryAccessWhere(filter.userId);
     const queen = await this.prisma.queen.findFirst({
       where: {
         id: queenId,
         OR: [
-          { hive: { apiary: { id: filter.apiaryId } } },
+          { hive: { apiary: apiaryWhere } },
           {
             movements: {
               some: {
                 OR: [
-                  { fromHive: { apiary: { id: filter.apiaryId } } },
-                  { toHive: { apiary: { id: filter.apiaryId } } },
+                  { fromHive: { apiary: apiaryWhere } },
+                  { toHive: { apiary: apiaryWhere } },
                 ],
               },
             },
@@ -350,10 +360,15 @@ export class QueensService {
 
   async getHiveQueenHistory(
     hiveId: string,
-    filter: ApiaryUserFilter,
+    filter: ApiaryScopeFilter,
   ): Promise<QueenResponse[]> {
     const hive = await this.prisma.hive.findFirst({
-      where: { id: hiveId, apiary: { id: filter.apiaryId } },
+      where: {
+        id: hiveId,
+        apiary: filter.apiaryId
+          ? { id: filter.apiaryId }
+          : apiaryAccessWhere(filter.userId),
+      },
     });
     if (!hive) throw new NotFoundException(`Hive with ID ${hiveId} not found`);
 

--- a/apps/backend/src/todos/todos.controller.ts
+++ b/apps/backend/src/todos/todos.controller.ts
@@ -81,15 +81,19 @@ export class TodosController {
   }
 
   @Get(':id')
+  @AllowAllApiaries()
   @ApiOkResponse({ type: Object })
   findOne(
     @Param('id') id: string,
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
   ): Promise<TodoResponse> {
-    this.logger.log(`Finding todo with ID ${id} in apiary ${req.apiaryId}`);
+    this.logger.log(
+      `Finding todo with ID ${id} in apiary ${req.apiaryId ?? 'ALL'}`,
+    );
     return this.todosService.findOne(id, {
       apiaryId: req.apiaryId,
       userId: req.user.id,
+      allApiaries: req.allApiaries,
     });
   }
 

--- a/apps/backend/src/todos/todos.controller.ts
+++ b/apps/backend/src/todos/todos.controller.ts
@@ -17,7 +17,11 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { TodosService } from './todos.service';
 import { ApiaryContextGuard } from '../guards/apiary-context.guard';
 import { ApiaryPermissionGuard } from '../guards/apiary-permission.guard';
-import { RequestWithApiary } from '../interface/request-with.apiary';
+import { AllowAllApiaries } from '../guards/allow-all-apiaries.decorator';
+import {
+  RequestWithApiary,
+  RequestWithApiaryScope,
+} from '../interface/request-with.apiary';
 import { CustomLoggerService } from '../logger/logger.service';
 import { ZodValidation } from '../common';
 import {
@@ -55,15 +59,20 @@ export class TodosController {
   }
 
   @Get()
+  @AllowAllApiaries()
   @ApiOkResponse({ type: Object, isArray: true })
   findAll(
-    @Req() req: RequestWithApiary,
+    @Req() req: RequestWithApiaryScope,
     @Query('completed') completed?: string,
     @Query('hiveId') hiveId?: string,
   ): Promise<TodoResponse[]> {
-    this.logger.log(`Finding all todos in apiary ${req.apiaryId}`);
+    this.logger.log(`Finding all todos in apiary ${req.apiaryId ?? 'ALL'}`);
     return this.todosService.findAll(
-      { apiaryId: req.apiaryId, userId: req.user.id },
+      {
+        apiaryId: req.apiaryId,
+        userId: req.user.id,
+        allApiaries: req.allApiaries,
+      },
       {
         completed: completed === undefined ? undefined : completed === 'true',
         hiveId,

--- a/apps/backend/src/todos/todos.service.ts
+++ b/apps/backend/src/todos/todos.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { ApiaryUserFilter } from '../interface/request-with.apiary';
+import {
+  ApiaryUserFilter,
+  ApiaryScopeFilter,
+} from '../interface/request-with.apiary';
+import { apiaryAccessWhere } from '../common';
 import { CreateTodo, UpdateTodo, TodoResponse } from 'shared-schemas';
 
 @Injectable()
@@ -69,12 +73,14 @@ export class TodosService {
   }
 
   async findAll(
-    filter: ApiaryUserFilter,
+    filter: ApiaryScopeFilter,
     params?: { completed?: boolean; hiveId?: string },
   ): Promise<TodoResponse[]> {
     const todos = await this.prisma.todo.findMany({
       where: {
-        apiaryId: filter.apiaryId,
+        ...(filter.apiaryId
+          ? { apiaryId: filter.apiaryId }
+          : { apiary: apiaryAccessWhere(filter.userId) }),
         ...(params?.completed !== undefined && { completed: params.completed }),
         ...(params?.hiveId && { hiveId: params.hiveId }),
       },

--- a/apps/backend/src/todos/todos.service.ts
+++ b/apps/backend/src/todos/todos.service.ts
@@ -94,9 +94,14 @@ export class TodosService {
     return todos.map((todo) => this.mapTodoToResponse(todo));
   }
 
-  async findOne(id: string, filter: ApiaryUserFilter): Promise<TodoResponse> {
+  async findOne(id: string, filter: ApiaryScopeFilter): Promise<TodoResponse> {
     const todo = await this.prisma.todo.findFirst({
-      where: { id, apiaryId: filter.apiaryId },
+      where: {
+        id,
+        ...(filter.apiaryId
+          ? { apiaryId: filter.apiaryId }
+          : { apiary: apiaryAccessWhere(filter.userId) }),
+      },
       include: { hive: { select: { name: true } } },
     });
     if (!todo) throw new NotFoundException(`Todo with ID ${id} not found`);

--- a/apps/e2e/tests/view-all-apiaries.spec.ts
+++ b/apps/e2e/tests/view-all-apiaries.spec.ts
@@ -143,5 +143,11 @@ test.describe('View all apiaries', () => {
     await expect(
       page.getByText(apiaryB, { exact: true }).first(),
     ).toBeVisible();
+
+    // --- Opening a hive that lives in a non-active apiary must work in
+    // view-all mode (regression: detail reads previously 400'd on `all`). ---
+    await page.getByText(hiveB).first().click();
+    await expect(page).toHaveURL(/\/hives\/[0-9a-f-]+$/);
+    await expect(page.getByText(hiveB).first()).toBeVisible();
   });
 });

--- a/apps/e2e/tests/view-all-apiaries.spec.ts
+++ b/apps/e2e/tests/view-all-apiaries.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from './fixtures';
+import { ApiaryFormPage, HiveFormPage } from 'page-objects';
+import { generateRandomString } from './utils';
+
+/**
+ * End-to-end coverage for the cross-apiary "view all" mode.
+ *
+ * A fresh user is registered (which starts the onboarding wizard), creates a
+ * first apiary + hive through onboarding, then a second apiary + hive. We then
+ * verify that:
+ *   - selecting a single apiary filters the dashboard to that apiary's hive,
+ *   - "All apiaries" shows hives from every apiary, grouped under each apiary,
+ *   - the /hives list shows every hive across apiaries (flat list).
+ *
+ * Requires a running stack (frontend + backend + database), e.g. the preview
+ * environment. Run with: `BASE_URL=... pnpm --filter e2e test view-all-apiaries`.
+ */
+test.describe('View all apiaries', () => {
+  test('disabling the apiary filter shows hives from every apiary', async ({
+    page,
+    onboardingPage,
+  }) => {
+    const suffix = Date.now().toString().slice(-5);
+    const apiaryA = `Meadow Alpha ${suffix}`;
+    const apiaryB = `Ridge Bravo ${suffix}`;
+    const hiveA = `Hive Anna ${suffix}`;
+    const hiveB = `Hive Boris ${suffix}`;
+
+    // --- Register a brand-new user (lands on the onboarding welcome screen) ---
+    await page.goto('/login');
+    const email = `viewall-${Date.now()}@example.com`;
+    const password = generateRandomString();
+
+    await page.getByRole('link', { name: 'Sign Up' }).click();
+    await page.getByLabel('email').fill(email);
+    await page
+      .getByRole('textbox', { name: 'Password', exact: true })
+      .fill(password);
+    await page
+      .getByRole('textbox', { name: 'Confirm Password' })
+      .fill(password);
+    await page.getByRole('textbox', { name: 'Display Name' }).fill('View All');
+    await page
+      .getByRole('checkbox', { name: 'I agree to the Privacy Policy' })
+      .click();
+    await page.getByRole('button', { name: /register/i }).click();
+
+    // --- Onboarding: create the first apiary + hive ---
+    await onboardingPage.completeOnboarding({
+      apiaryName: apiaryA,
+      hiveName: hiveA,
+    });
+    await expect(page).toHaveURL('/');
+
+    // --- Create a second apiary ---
+    const apiaryForm = new ApiaryFormPage(page);
+    await page.goto('/apiaries/create');
+    await apiaryForm.fillApiaryForm({ name: apiaryB });
+    await apiaryForm.submitForm();
+
+    // --- Create a hive in the second apiary ---
+    const hiveForm = new HiveFormPage(page);
+    await page.goto('/hives/create');
+    await hiveForm.fillHiveForm({ name: hiveB, apiaryName: apiaryB });
+    await hiveForm.submitForm();
+
+    // --- Select the first apiary: dashboard is filtered to it ---
+    await page.goto('/');
+    await page.getByTestId('apiary-switcher').click();
+    await page.getByRole('menuitem', { name: new RegExp(apiaryA) }).click();
+
+    await expect(page.getByText(hiveA)).toBeVisible();
+    await expect(page.getByText(hiveB)).toHaveCount(0);
+
+    // --- Switch to "All apiaries": both apiaries' hives are shown, grouped ---
+    await page.getByTestId('apiary-switcher').click();
+    await page.getByTestId('apiary-switcher-all').click();
+
+    // Both apiary group headings are present.
+    await expect(page.getByText(apiaryA, { exact: true })).toBeVisible();
+    await expect(page.getByText(apiaryB, { exact: true })).toBeVisible();
+    // Both hives are visible on the dashboard.
+    await expect(page.getByText(hiveA)).toBeVisible();
+    await expect(page.getByText(hiveB)).toBeVisible();
+
+    // --- The /hives list shows every hive across apiaries (flat list) ---
+    await page.goto('/hives');
+    await expect(page.getByText(hiveA)).toBeVisible();
+    await expect(page.getByText(hiveB)).toBeVisible();
+  });
+});

--- a/apps/e2e/tests/view-all-apiaries.spec.ts
+++ b/apps/e2e/tests/view-all-apiaries.spec.ts
@@ -19,14 +19,41 @@ import { generateRandomString } from './utils';
  * environment. Run with: `BASE_URL=... pnpm --filter e2e test view-all-apiaries`.
  */
 
+// Open the switcher dropdown and click an item. Background query refetches can
+// briefly re-render the menu, so wait for the item to settle before clicking
+// and retry once if it gets detached mid-click.
+const clickSwitcherItem = async (
+  page: Page,
+  item: ReturnType<Page['locator']>,
+) => {
+  // Let any in-flight query refetches settle first — selecting an apiary
+  // invalidates all queries, and the resulting re-render can detach the
+  // freshly-opened dropdown mid-click.
+  await page.waitForLoadState('networkidle').catch(() => {});
+  for (let attempt = 0; attempt < 5; attempt++) {
+    await page.getByTestId('apiary-switcher').click();
+    try {
+      await item.click({ timeout: 3000 });
+      return;
+    } catch {
+      // menu closed / re-rendered — dismiss, settle, and retry
+      await page.keyboard.press('Escape').catch(() => {});
+      await page.waitForLoadState('networkidle').catch(() => {});
+      await page.waitForTimeout(300);
+    }
+  }
+  throw new Error('Could not click switcher item');
+};
+
 const selectApiary = async (page: Page, name: string) => {
-  await page.getByTestId('apiary-switcher').click();
-  await page.getByRole('menuitem', { name: new RegExp(name) }).click();
+  await clickSwitcherItem(
+    page,
+    page.getByRole('menuitem', { name: new RegExp(name) }),
+  );
 };
 
 const selectAllApiaries = async (page: Page) => {
-  await page.getByTestId('apiary-switcher').click();
-  await page.getByTestId('apiary-switcher-all').click();
+  await clickSwitcherItem(page, page.getByTestId('apiary-switcher-all'));
 };
 
 test.describe('View all apiaries', () => {
@@ -39,11 +66,21 @@ test.describe('View all apiaries', () => {
     const hiveA = `Hive Anna ${suffix}`;
     const hiveB = `Hive Boris ${suffix}`;
 
+    // Abort external analytics and slow third-party-backed endpoints (weather,
+    // hive-scale) so they don't hold browser connections open and starve the
+    // session/list requests this test depends on.
+    await page.route('**/*', route => {
+      const url = route.request().url();
+      if (!url.startsWith('http://localhost:5173')) return route.abort();
+      if (/\/api\/(weather|hivescale)/.test(url)) return route.abort();
+      return route.continue();
+    });
+
     // --- Register a brand-new user (auto-creates "My Apiary") ---
     const email = `viewall-${Date.now()}@example.com`;
     const password = generateRandomString();
 
-    await page.goto('/register', { waitUntil: 'domcontentloaded' });
+    await page.goto('/register', { waitUntil: 'commit' });
     await page.getByLabel('email').fill(email);
     await page
       .getByRole('textbox', { name: 'Password', exact: true })
@@ -63,7 +100,7 @@ test.describe('View all apiaries', () => {
     });
 
     // The app shell (with the apiary switcher) is available on any app route.
-    await page.goto('/hives', { waitUntil: 'domcontentloaded' });
+    await page.goto('/hives', { waitUntil: 'commit' });
     await expect(page.getByTestId('apiary-switcher')).toBeVisible({
       timeout: 15000,
     });
@@ -72,36 +109,39 @@ test.describe('View all apiaries', () => {
     const apiaryForm = new ApiaryFormPage(page);
 
     // --- Add a hive to the default apiary (active by default) ---
-    await page.goto('/hives/create', { waitUntil: 'domcontentloaded' });
+    await page.goto('/hives/create', { waitUntil: 'commit' });
     await hiveForm.fillHiveForm({ name: hiveA });
     await hiveForm.submitForm();
 
     // --- Create a second apiary and make it the active one ---
-    await page.goto('/apiaries/create', { waitUntil: 'domcontentloaded' });
+    await page.goto('/apiaries/create', { waitUntil: 'commit' });
     await apiaryForm.fillApiaryForm({ name: apiaryB });
     await apiaryForm.submitForm();
     await selectApiary(page, apiaryB);
 
     // --- Add a hive to the second apiary (now active) ---
-    await page.goto('/hives/create', { waitUntil: 'domcontentloaded' });
+    await page.goto('/hives/create', { waitUntil: 'commit' });
     await hiveForm.fillHiveForm({ name: hiveB });
     await hiveForm.submitForm();
 
     // --- Single apiary selected: /hives is filtered to that apiary ---
-    await page.goto('/hives', { waitUntil: 'domcontentloaded' });
+    // (a hive name may render in both a card and a table row, so match .first())
+    await page.goto('/hives', { waitUntil: 'commit' });
     await selectApiary(page, apiaryA);
-    await expect(page.getByText(hiveA)).toBeVisible();
+    await expect(page.getByText(hiveA).first()).toBeVisible();
     await expect(page.getByText(hiveB)).toHaveCount(0);
 
     // --- "All apiaries": /hives shows every hive across apiaries (flat list) ---
     await selectAllApiaries(page);
-    await expect(page.getByText(hiveA)).toBeVisible();
-    await expect(page.getByText(hiveB)).toBeVisible();
+    await expect(page.getByText(hiveA).first()).toBeVisible();
+    await expect(page.getByText(hiveB).first()).toBeVisible();
 
     // --- Dashboard groups hives under each apiary in view-all mode ---
     await page.getByRole('button', { name: 'Dashboard' }).click();
-    await expect(page.getByText(hiveA)).toBeVisible();
-    await expect(page.getByText(hiveB)).toBeVisible();
-    await expect(page.getByText(apiaryB, { exact: true })).toBeVisible();
+    await expect(page.getByText(hiveA).first()).toBeVisible();
+    await expect(page.getByText(hiveB).first()).toBeVisible();
+    await expect(
+      page.getByText(apiaryB, { exact: true }).first(),
+    ).toBeVisible();
   });
 });

--- a/apps/e2e/tests/view-all-apiaries.spec.ts
+++ b/apps/e2e/tests/view-all-apiaries.spec.ts
@@ -1,37 +1,49 @@
 import { test, expect } from './fixtures';
+import { Page } from '@playwright/test';
 import { ApiaryFormPage, HiveFormPage } from 'page-objects';
 import { generateRandomString } from './utils';
 
 /**
  * End-to-end coverage for the cross-apiary "view all" mode.
  *
- * A fresh user is registered (which starts the onboarding wizard), creates a
- * first apiary + hive through onboarding, then a second apiary + hive. We then
- * verify that:
- *   - selecting a single apiary filters the dashboard to that apiary's hive,
- *   - "All apiaries" shows hives from every apiary, grouped under each apiary,
- *   - the /hives list shows every hive across apiaries (flat list).
+ * A fresh user is registered (a default "My Apiary" is auto-created). We add a
+ * hive to that apiary, create a second apiary with its own hive, then verify:
+ *   - selecting a single apiary filters the hive list to that apiary,
+ *   - "All apiaries" shows hives from every apiary (flat /hives list),
+ *   - the dashboard groups hives under each apiary in view-all mode.
+ *
+ * The active apiary is chosen through the switcher before creating each hive, so
+ * the hive form defaults to it (no dependency on the apiary <select> control).
  *
  * Requires a running stack (frontend + backend + database), e.g. the preview
  * environment. Run with: `BASE_URL=... pnpm --filter e2e test view-all-apiaries`.
  */
+
+const selectApiary = async (page: Page, name: string) => {
+  await page.getByTestId('apiary-switcher').click();
+  await page.getByRole('menuitem', { name: new RegExp(name) }).click();
+};
+
+const selectAllApiaries = async (page: Page) => {
+  await page.getByTestId('apiary-switcher').click();
+  await page.getByTestId('apiary-switcher-all').click();
+};
+
 test.describe('View all apiaries', () => {
   test('disabling the apiary filter shows hives from every apiary', async ({
     page,
-    onboardingPage,
   }) => {
     const suffix = Date.now().toString().slice(-5);
-    const apiaryA = `Meadow Alpha ${suffix}`;
+    const apiaryA = 'My Apiary'; // auto-created default apiary
     const apiaryB = `Ridge Bravo ${suffix}`;
     const hiveA = `Hive Anna ${suffix}`;
     const hiveB = `Hive Boris ${suffix}`;
 
-    // --- Register a brand-new user (lands on the onboarding welcome screen) ---
-    await page.goto('/login');
+    // --- Register a brand-new user (auto-creates "My Apiary") ---
     const email = `viewall-${Date.now()}@example.com`;
     const password = generateRandomString();
 
-    await page.getByRole('link', { name: 'Sign Up' }).click();
+    await page.goto('/register', { waitUntil: 'domcontentloaded' });
     await page.getByLabel('email').fill(email);
     await page
       .getByRole('textbox', { name: 'Password', exact: true })
@@ -45,47 +57,51 @@ test.describe('View all apiaries', () => {
       .click();
     await page.getByRole('button', { name: /register/i }).click();
 
-    // --- Onboarding: create the first apiary + hive ---
-    await onboardingPage.completeOnboarding({
-      apiaryName: apiaryA,
-      hiveName: hiveA,
+    // Wait for registration to complete (session cookie set + navigation away).
+    await page.waitForURL(url => !url.pathname.startsWith('/register'), {
+      timeout: 15000,
     });
-    await expect(page).toHaveURL('/');
 
-    // --- Create a second apiary ---
-    const apiaryForm = new ApiaryFormPage(page);
-    await page.goto('/apiaries/create');
-    await apiaryForm.fillApiaryForm({ name: apiaryB });
-    await apiaryForm.submitForm();
+    // The app shell (with the apiary switcher) is available on any app route.
+    await page.goto('/hives', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('apiary-switcher')).toBeVisible({
+      timeout: 15000,
+    });
 
-    // --- Create a hive in the second apiary ---
     const hiveForm = new HiveFormPage(page);
-    await page.goto('/hives/create');
-    await hiveForm.fillHiveForm({ name: hiveB, apiaryName: apiaryB });
+    const apiaryForm = new ApiaryFormPage(page);
+
+    // --- Add a hive to the default apiary (active by default) ---
+    await page.goto('/hives/create', { waitUntil: 'domcontentloaded' });
+    await hiveForm.fillHiveForm({ name: hiveA });
     await hiveForm.submitForm();
 
-    // --- Select the first apiary: dashboard is filtered to it ---
-    await page.goto('/');
-    await page.getByTestId('apiary-switcher').click();
-    await page.getByRole('menuitem', { name: new RegExp(apiaryA) }).click();
+    // --- Create a second apiary and make it the active one ---
+    await page.goto('/apiaries/create', { waitUntil: 'domcontentloaded' });
+    await apiaryForm.fillApiaryForm({ name: apiaryB });
+    await apiaryForm.submitForm();
+    await selectApiary(page, apiaryB);
 
+    // --- Add a hive to the second apiary (now active) ---
+    await page.goto('/hives/create', { waitUntil: 'domcontentloaded' });
+    await hiveForm.fillHiveForm({ name: hiveB });
+    await hiveForm.submitForm();
+
+    // --- Single apiary selected: /hives is filtered to that apiary ---
+    await page.goto('/hives', { waitUntil: 'domcontentloaded' });
+    await selectApiary(page, apiaryA);
     await expect(page.getByText(hiveA)).toBeVisible();
     await expect(page.getByText(hiveB)).toHaveCount(0);
 
-    // --- Switch to "All apiaries": both apiaries' hives are shown, grouped ---
-    await page.getByTestId('apiary-switcher').click();
-    await page.getByTestId('apiary-switcher-all').click();
+    // --- "All apiaries": /hives shows every hive across apiaries (flat list) ---
+    await selectAllApiaries(page);
+    await expect(page.getByText(hiveA)).toBeVisible();
+    await expect(page.getByText(hiveB)).toBeVisible();
 
-    // Both apiary group headings are present.
-    await expect(page.getByText(apiaryA, { exact: true })).toBeVisible();
+    // --- Dashboard groups hives under each apiary in view-all mode ---
+    await page.getByRole('button', { name: 'Dashboard' }).click();
+    await expect(page.getByText(hiveA)).toBeVisible();
+    await expect(page.getByText(hiveB)).toBeVisible();
     await expect(page.getByText(apiaryB, { exact: true })).toBeVisible();
-    // Both hives are visible on the dashboard.
-    await expect(page.getByText(hiveA)).toBeVisible();
-    await expect(page.getByText(hiveB)).toBeVisible();
-
-    // --- The /hives list shows every hive across apiaries (flat list) ---
-    await page.goto('/hives');
-    await expect(page.getByText(hiveA)).toBeVisible();
-    await expect(page.getByText(hiveB)).toBeVisible();
   });
 });

--- a/apps/e2e/tests/view-all-phase2.spec.ts
+++ b/apps/e2e/tests/view-all-phase2.spec.ts
@@ -108,10 +108,18 @@ test.describe('View all apiaries — Phase 2 (Todos)', () => {
     await selectApiary(page, apiaryA);
     await expect(page.getByText(todoA).first()).toBeVisible();
     await expect(page.getByText(todoB)).toHaveCount(0);
+    // Caption reflects the single-apiary scope.
+    await expect(
+      page.getByText('Keep track of tasks for this apiary.'),
+    ).toBeVisible();
 
     // --- "All apiaries": /todos shows todos from every apiary ---
     await selectAllApiaries(page);
     await expect(page.getByText(todoA).first()).toBeVisible();
     await expect(page.getByText(todoB).first()).toBeVisible();
+    // Caption switches to the cross-apiary wording.
+    await expect(
+      page.getByText('Keep track of tasks for all apiaries.'),
+    ).toBeVisible();
   });
 });

--- a/apps/e2e/tests/view-all-phase2.spec.ts
+++ b/apps/e2e/tests/view-all-phase2.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from './fixtures';
+import { Page } from '@playwright/test';
+import { ApiaryFormPage } from 'page-objects';
+import { generateRandomString } from './utils';
+
+/**
+ * Phase 2 coverage for the cross-apiary "view all" mode on the Todos page.
+ *
+ * Todos are created in two different apiaries (single-apiary mode each time),
+ * then we verify that a single apiary filters the /todos list while
+ * "All apiaries" shows todos from every apiary.
+ *
+ * Requires a running stack (frontend + backend + database).
+ * Run with: `BASE_URL=... pnpm --filter e2e test view-all-phase2`.
+ */
+
+const clickSwitcherItem = async (
+  page: Page,
+  item: ReturnType<Page['locator']>,
+) => {
+  await page.waitForLoadState('networkidle').catch(() => {});
+  for (let attempt = 0; attempt < 5; attempt++) {
+    await page.getByTestId('apiary-switcher').click();
+    try {
+      await item.click({ timeout: 3000 });
+      return;
+    } catch {
+      await page.keyboard.press('Escape').catch(() => {});
+      await page.waitForLoadState('networkidle').catch(() => {});
+      await page.waitForTimeout(300);
+    }
+  }
+  throw new Error('Could not click switcher item');
+};
+
+const selectApiary = (page: Page, name: string) =>
+  clickSwitcherItem(
+    page,
+    page.getByRole('menuitem', { name: new RegExp(name) }),
+  );
+
+const selectAllApiaries = (page: Page) =>
+  clickSwitcherItem(page, page.getByTestId('apiary-switcher-all'));
+
+const addTodo = async (page: Page, title: string) => {
+  await page.goto('/todos', { waitUntil: 'commit' });
+  const input = page.getByPlaceholder(/Add a todo/);
+  await input.click();
+  await input.fill(title);
+  await input.press('Enter');
+  await expect(page.getByText(title).first()).toBeVisible();
+};
+
+test.describe('View all apiaries — Phase 2 (Todos)', () => {
+  test('disabling the apiary filter shows todos from every apiary', async ({
+    page,
+  }) => {
+    const suffix = Date.now().toString().slice(-5);
+    const apiaryA = 'My Apiary'; // auto-created default apiary
+    const apiaryB = `Ridge Bravo ${suffix}`;
+    const todoA = `Todo Anna ${suffix}`;
+    const todoB = `Todo Boris ${suffix}`;
+
+    await page.route('**/*', route => {
+      const url = route.request().url();
+      if (!url.startsWith('http://localhost:5173')) return route.abort();
+      if (/\/api\/(weather|hivescale)/.test(url)) return route.abort();
+      return route.continue();
+    });
+
+    // --- Register a brand-new user ---
+    const email = `phase2-${Date.now()}@example.com`;
+    const password = generateRandomString();
+    await page.goto('/register', { waitUntil: 'commit' });
+    await page.getByLabel('email').fill(email);
+    await page
+      .getByRole('textbox', { name: 'Password', exact: true })
+      .fill(password);
+    await page
+      .getByRole('textbox', { name: 'Confirm Password' })
+      .fill(password);
+    await page.getByRole('textbox', { name: 'Display Name' }).fill('Phase Two');
+    await page
+      .getByRole('checkbox', { name: 'I agree to the Privacy Policy' })
+      .click();
+    await page.getByRole('button', { name: /register/i }).click();
+    await page.waitForURL(u => !u.pathname.startsWith('/register'), {
+      timeout: 15000,
+    });
+
+    // --- Add a todo to the default apiary ---
+    await page.goto('/todos', { waitUntil: 'commit' });
+    await expect(page.getByTestId('apiary-switcher')).toBeVisible({
+      timeout: 15000,
+    });
+    await addTodo(page, todoA);
+
+    // --- Create a second apiary, make it active, add a todo there ---
+    const apiaryForm = new ApiaryFormPage(page);
+    await page.goto('/apiaries/create', { waitUntil: 'commit' });
+    await apiaryForm.fillApiaryForm({ name: apiaryB });
+    await apiaryForm.submitForm();
+    await selectApiary(page, apiaryB);
+    await addTodo(page, todoB);
+
+    // --- Single apiary: /todos is filtered to that apiary ---
+    await page.goto('/todos', { waitUntil: 'commit' });
+    await selectApiary(page, apiaryA);
+    await expect(page.getByText(todoA).first()).toBeVisible();
+    await expect(page.getByText(todoB)).toHaveCount(0);
+
+    // --- "All apiaries": /todos shows todos from every apiary ---
+    await selectAllApiaries(page);
+    await expect(page.getByText(todoA).first()).toBeVisible();
+    await expect(page.getByText(todoB).first()).toBeVisible();
+  });
+});

--- a/apps/e2e/tests/view-all-phase2.spec.ts
+++ b/apps/e2e/tests/view-all-phase2.spec.ts
@@ -121,5 +121,16 @@ test.describe('View all apiaries — Phase 2 (Todos)', () => {
     await expect(
       page.getByText('Keep track of tasks for all apiaries.'),
     ).toBeVisible();
+
+    // --- Phase 3: the dashboard aggregates todos across apiaries in view-all
+    // mode, and the empty hives state uses scope-aware wording. ---
+    await page.getByRole('button', { name: 'Dashboard' }).click();
+    await expect(page.getByText(todoA).first()).toBeVisible();
+    await expect(page.getByText(todoB).first()).toBeVisible();
+    await expect(
+      page.getByText(
+        'Add a hive to any of your apiaries to start tracking it.',
+      ),
+    ).toBeVisible();
   });
 });

--- a/apps/frontend/public/locales/de/apiary.json
+++ b/apps/frontend/public/locales/de/apiary.json
@@ -1,99 +1,99 @@
 {
-  "title": "Bienenstände",
-  "singular": "Bienenstand",
-  "plural": "Bienenstände",
-  "list": {
-    "title": "Bienenstandliste",
-    "caption": "Eine Liste aller Bienenstände",
-    "searchPlaceholder": "Bienenstände suchen...",
-    "noApiaries": "Keine Bienenstände gefunden",
-    "noApiariesMatching": "Keine Bienenstände gefunden für \"{{searchTerm}}\"",
-    "clearFilters": "Filter zurücksetzen"
-  },
-  "create": {
-    "title": "Bienenstand erstellen",
-    "button": "Neuen Bienenstand erstellen",
-    "success": "Bienenstand erfolgreich erstellt"
-  },
-  "edit": {
-    "title": "Bienenstand bearbeiten",
-    "success": "Bienenstand erfolgreich aktualisiert"
-  },
-  "delete": {
-    "confirm": "Möchten Sie diesen Bienenstand wirklich löschen?",
-    "success": "Bienenstand erfolgreich gelöscht"
-  },
-  "detail": {
-    "notFound": "Bienenstand nicht gefunden",
-    "noLocationSpecified": "Kein Standort angegeben",
-    "tabs": {
-      "overview": "Übersicht",
-      "hives": "Bienenstöcke",
-      "location": "Standort"
+    "title": "Bienenstände",
+    "singular": "Bienenstand",
+    "plural": "Bienenstände",
+    "list": {
+        "title": "Bienenstandliste",
+        "caption": "Eine Liste aller Bienenstände",
+        "searchPlaceholder": "Bienenstände suchen...",
+        "noApiaries": "Keine Bienenstände gefunden",
+        "noApiariesMatching": "Keine Bienenstände gefunden für \"{{searchTerm}}\"",
+        "clearFilters": "Filter zurücksetzen"
     },
-    "apiaryInformation": "Informationen zum Bienenstand",
-    "locationMap": "Standortkarte",
-    "apiaryLocation": "Standort des Bienenstands",
-    "noCoordinates": "Für diesen Bienenstand sind keine Koordinaten verfügbar"
-  },
-  "fields": {
-    "name": "Name",
-    "location": "Standort",
-    "locationDescription": "Standortbeschreibung",
-    "coordinates": "Koordinaten",
-    "hivesCount": "Anzahl der Bienenstöcke",
-    "latitude": "Breitengrad",
-    "longitude": "Längengrad",
-    "notSpecified": "Nicht angegeben",
-    "noLocation": "Kein Standort",
-    "noCoordinates": "Keine Koordinaten"
-  },
-  "actions": {
-    "details": "Details",
-    "refreshData": "Daten aktualisieren",
-    "exportCSV": "Als CSV exportieren",
-    "print": "Bienenstandliste drucken",
-    "share": "Bienenstandliste teilen",
-    "dataOptions": "Datenoptionen"
-  },
-  "messages": {
-    "exportComingSoon": "Exportfunktion bald verfügbar",
-    "shareComingSoon": "Freigabefunktion bald verfügbar"
-  },
-  "switcher": {
-    "teams": "Teams",
-    "addApiary": "Bienenstand hinzufügen",
-    "noApiarySelected": "Kein Bienenstand ausgewählt",
-    "selectOrCreate": "Bienenstand auswählen oder erstellen",
-    "allApiaries": "Alle Bienenstände",
-    "allApiariesSubtitle": "Alle Stände werden angezeigt"
-  },
-  "map": {
-    "selectLocation": "Standort des Bienenstands auswählen",
-    "selectedLocation": "Ausgewählter Standort",
-    "apiaryLocation": "Standort des Bienenstands"
-  },
-  "calendarSubscription": {
-    "title": "Kalenderabonnement",
-    "description": "Abonnieren Sie den Durchsichtenplan dieses Bienenstands in Ihrer Kalender-App",
-    "addToCalendar": "Zum Kalender hinzufügen",
-    "regenerateUrl": "URL neu generieren",
-    "regenerated": "Abonnement-URL wurde neu generiert",
-    "regenerateFailed": "Abonnement-URL konnte nicht neu generiert werden",
-    "copied": "Abonnement-URL in die Zwischenablage kopiert",
-    "copyFailed": "Kopieren in die Zwischenablage fehlgeschlagen",
-    "readOnlyNote": "Diese URL bietet schreibgeschützten Zugriff auf Ihren Durchsichtenplan. Beim Neugenerieren wird die vorherige URL ungültig.",
-    "copyUrl": "URL kopieren"
-  },
-  "form": {
-    "namePlaceholder": "Name des Bienenstands",
-    "locationPlaceholder": "Standortbeschreibung",
-    "inspectionType": {
-      "label": "",
-      "placeholder": "",
-      "dataDriven": "",
-      "subjective": "",
-      "description": ""
+    "create": {
+        "title": "Bienenstand erstellen",
+        "button": "Neuen Bienenstand erstellen",
+        "success": "Bienenstand erfolgreich erstellt"
+    },
+    "edit": {
+        "title": "Bienenstand bearbeiten",
+        "success": "Bienenstand erfolgreich aktualisiert"
+    },
+    "delete": {
+        "confirm": "Möchten Sie diesen Bienenstand wirklich löschen?",
+        "success": "Bienenstand erfolgreich gelöscht"
+    },
+    "detail": {
+        "notFound": "Bienenstand nicht gefunden",
+        "noLocationSpecified": "Kein Standort angegeben",
+        "tabs": {
+            "overview": "Übersicht",
+            "hives": "Bienenstöcke",
+            "location": "Standort"
+        },
+        "apiaryInformation": "Informationen zum Bienenstand",
+        "locationMap": "Standortkarte",
+        "apiaryLocation": "Standort des Bienenstands",
+        "noCoordinates": "Für diesen Bienenstand sind keine Koordinaten verfügbar"
+    },
+    "fields": {
+        "name": "Name",
+        "location": "Standort",
+        "locationDescription": "Standortbeschreibung",
+        "coordinates": "Koordinaten",
+        "hivesCount": "Anzahl der Bienenstöcke",
+        "latitude": "Breitengrad",
+        "longitude": "Längengrad",
+        "notSpecified": "Nicht angegeben",
+        "noLocation": "Kein Standort",
+        "noCoordinates": "Keine Koordinaten"
+    },
+    "actions": {
+        "details": "Details",
+        "refreshData": "Daten aktualisieren",
+        "exportCSV": "Als CSV exportieren",
+        "print": "Bienenstandliste drucken",
+        "share": "Bienenstandliste teilen",
+        "dataOptions": "Datenoptionen"
+    },
+    "messages": {
+        "exportComingSoon": "Exportfunktion bald verfügbar",
+        "shareComingSoon": "Freigabefunktion bald verfügbar"
+    },
+    "switcher": {
+        "teams": "Teams",
+        "addApiary": "Bienenstand hinzufügen",
+        "noApiarySelected": "Kein Bienenstand ausgewählt",
+        "selectOrCreate": "Bienenstand auswählen oder erstellen",
+        "allApiaries": "Alle Bienenstände",
+        "allApiariesSubtitle": "Alle Bienenstände werden angezeigt"
+    },
+    "map": {
+        "selectLocation": "Standort des Bienenstands auswählen",
+        "selectedLocation": "Ausgewählter Standort",
+        "apiaryLocation": "Standort des Bienenstands"
+    },
+    "calendarSubscription": {
+        "title": "Kalenderabonnement",
+        "description": "Abonnieren Sie den Durchsichtenplan dieses Bienenstands in Ihrer Kalender-App",
+        "addToCalendar": "Zum Kalender hinzufügen",
+        "regenerateUrl": "URL neu generieren",
+        "regenerated": "Abonnement-URL wurde neu generiert",
+        "regenerateFailed": "Abonnement-URL konnte nicht neu generiert werden",
+        "copied": "Abonnement-URL in die Zwischenablage kopiert",
+        "copyFailed": "Kopieren in die Zwischenablage fehlgeschlagen",
+        "readOnlyNote": "Diese URL bietet schreibgeschützten Zugriff auf Ihren Durchsichtenplan. Beim Neugenerieren wird die vorherige URL ungültig.",
+        "copyUrl": "URL kopieren"
+    },
+    "form": {
+        "namePlaceholder": "Name des Bienenstands",
+        "locationPlaceholder": "Standortbeschreibung",
+        "inspectionType": {
+            "label": "",
+            "placeholder": "",
+            "dataDriven": "",
+            "subjective": "",
+            "description": ""
+        }
     }
-  }
 }

--- a/apps/frontend/public/locales/de/apiary.json
+++ b/apps/frontend/public/locales/de/apiary.json
@@ -1,97 +1,99 @@
 {
-    "title": "Bienenstände",
-    "singular": "Bienenstand",
-    "plural": "Bienenstände",
-    "list": {
-        "title": "Bienenstandliste",
-        "caption": "Eine Liste aller Bienenstände",
-        "searchPlaceholder": "Bienenstände suchen...",
-        "noApiaries": "Keine Bienenstände gefunden",
-        "noApiariesMatching": "Keine Bienenstände gefunden für \"{{searchTerm}}\"",
-        "clearFilters": "Filter zurücksetzen"
+  "title": "Bienenstände",
+  "singular": "Bienenstand",
+  "plural": "Bienenstände",
+  "list": {
+    "title": "Bienenstandliste",
+    "caption": "Eine Liste aller Bienenstände",
+    "searchPlaceholder": "Bienenstände suchen...",
+    "noApiaries": "Keine Bienenstände gefunden",
+    "noApiariesMatching": "Keine Bienenstände gefunden für \"{{searchTerm}}\"",
+    "clearFilters": "Filter zurücksetzen"
+  },
+  "create": {
+    "title": "Bienenstand erstellen",
+    "button": "Neuen Bienenstand erstellen",
+    "success": "Bienenstand erfolgreich erstellt"
+  },
+  "edit": {
+    "title": "Bienenstand bearbeiten",
+    "success": "Bienenstand erfolgreich aktualisiert"
+  },
+  "delete": {
+    "confirm": "Möchten Sie diesen Bienenstand wirklich löschen?",
+    "success": "Bienenstand erfolgreich gelöscht"
+  },
+  "detail": {
+    "notFound": "Bienenstand nicht gefunden",
+    "noLocationSpecified": "Kein Standort angegeben",
+    "tabs": {
+      "overview": "Übersicht",
+      "hives": "Bienenstöcke",
+      "location": "Standort"
     },
-    "create": {
-        "title": "Bienenstand erstellen",
-        "button": "Neuen Bienenstand erstellen",
-        "success": "Bienenstand erfolgreich erstellt"
-    },
-    "edit": {
-        "title": "Bienenstand bearbeiten",
-        "success": "Bienenstand erfolgreich aktualisiert"
-    },
-    "delete": {
-        "confirm": "Möchten Sie diesen Bienenstand wirklich löschen?",
-        "success": "Bienenstand erfolgreich gelöscht"
-    },
-    "detail": {
-        "notFound": "Bienenstand nicht gefunden",
-        "noLocationSpecified": "Kein Standort angegeben",
-        "tabs": {
-            "overview": "Übersicht",
-            "hives": "Bienenstöcke",
-            "location": "Standort"
-        },
-        "apiaryInformation": "Informationen zum Bienenstand",
-        "locationMap": "Standortkarte",
-        "apiaryLocation": "Standort des Bienenstands",
-        "noCoordinates": "Für diesen Bienenstand sind keine Koordinaten verfügbar"
-    },
-    "fields": {
-        "name": "Name",
-        "location": "Standort",
-        "locationDescription": "Standortbeschreibung",
-        "coordinates": "Koordinaten",
-        "hivesCount": "Anzahl der Bienenstöcke",
-        "latitude": "Breitengrad",
-        "longitude": "Längengrad",
-        "notSpecified": "Nicht angegeben",
-        "noLocation": "Kein Standort",
-        "noCoordinates": "Keine Koordinaten"
-    },
-    "actions": {
-        "details": "Details",
-        "refreshData": "Daten aktualisieren",
-        "exportCSV": "Als CSV exportieren",
-        "print": "Bienenstandliste drucken",
-        "share": "Bienenstandliste teilen",
-        "dataOptions": "Datenoptionen"
-    },
-    "messages": {
-        "exportComingSoon": "Exportfunktion bald verfügbar",
-        "shareComingSoon": "Freigabefunktion bald verfügbar"
-    },
-    "switcher": {
-        "teams": "Teams",
-        "addApiary": "Bienenstand hinzufügen",
-        "noApiarySelected": "Kein Bienenstand ausgewählt",
-        "selectOrCreate": "Bienenstand auswählen oder erstellen"
-    },
-    "map": {
-        "selectLocation": "Standort des Bienenstands auswählen",
-        "selectedLocation": "Ausgewählter Standort",
-        "apiaryLocation": "Standort des Bienenstands"
-    },
-    "calendarSubscription": {
-        "title": "Kalenderabonnement",
-        "description": "Abonnieren Sie den Durchsichtenplan dieses Bienenstands in Ihrer Kalender-App",
-        "addToCalendar": "Zum Kalender hinzufügen",
-        "regenerateUrl": "URL neu generieren",
-        "regenerated": "Abonnement-URL wurde neu generiert",
-        "regenerateFailed": "Abonnement-URL konnte nicht neu generiert werden",
-        "copied": "Abonnement-URL in die Zwischenablage kopiert",
-        "copyFailed": "Kopieren in die Zwischenablage fehlgeschlagen",
-        "readOnlyNote": "Diese URL bietet schreibgeschützten Zugriff auf Ihren Durchsichtenplan. Beim Neugenerieren wird die vorherige URL ungültig.",
-        "copyUrl": "URL kopieren"
-    },
-    "form": {
-        "namePlaceholder": "Name des Bienenstands",
-        "locationPlaceholder": "Standortbeschreibung",
-        "inspectionType": {
-            "label": "",
-            "placeholder": "",
-            "dataDriven": "",
-            "subjective": "",
-            "description": ""
-        }
+    "apiaryInformation": "Informationen zum Bienenstand",
+    "locationMap": "Standortkarte",
+    "apiaryLocation": "Standort des Bienenstands",
+    "noCoordinates": "Für diesen Bienenstand sind keine Koordinaten verfügbar"
+  },
+  "fields": {
+    "name": "Name",
+    "location": "Standort",
+    "locationDescription": "Standortbeschreibung",
+    "coordinates": "Koordinaten",
+    "hivesCount": "Anzahl der Bienenstöcke",
+    "latitude": "Breitengrad",
+    "longitude": "Längengrad",
+    "notSpecified": "Nicht angegeben",
+    "noLocation": "Kein Standort",
+    "noCoordinates": "Keine Koordinaten"
+  },
+  "actions": {
+    "details": "Details",
+    "refreshData": "Daten aktualisieren",
+    "exportCSV": "Als CSV exportieren",
+    "print": "Bienenstandliste drucken",
+    "share": "Bienenstandliste teilen",
+    "dataOptions": "Datenoptionen"
+  },
+  "messages": {
+    "exportComingSoon": "Exportfunktion bald verfügbar",
+    "shareComingSoon": "Freigabefunktion bald verfügbar"
+  },
+  "switcher": {
+    "teams": "Teams",
+    "addApiary": "Bienenstand hinzufügen",
+    "noApiarySelected": "Kein Bienenstand ausgewählt",
+    "selectOrCreate": "Bienenstand auswählen oder erstellen",
+    "allApiaries": "Alle Bienenstände",
+    "allApiariesSubtitle": "Alle Stände werden angezeigt"
+  },
+  "map": {
+    "selectLocation": "Standort des Bienenstands auswählen",
+    "selectedLocation": "Ausgewählter Standort",
+    "apiaryLocation": "Standort des Bienenstands"
+  },
+  "calendarSubscription": {
+    "title": "Kalenderabonnement",
+    "description": "Abonnieren Sie den Durchsichtenplan dieses Bienenstands in Ihrer Kalender-App",
+    "addToCalendar": "Zum Kalender hinzufügen",
+    "regenerateUrl": "URL neu generieren",
+    "regenerated": "Abonnement-URL wurde neu generiert",
+    "regenerateFailed": "Abonnement-URL konnte nicht neu generiert werden",
+    "copied": "Abonnement-URL in die Zwischenablage kopiert",
+    "copyFailed": "Kopieren in die Zwischenablage fehlgeschlagen",
+    "readOnlyNote": "Diese URL bietet schreibgeschützten Zugriff auf Ihren Durchsichtenplan. Beim Neugenerieren wird die vorherige URL ungültig.",
+    "copyUrl": "URL kopieren"
+  },
+  "form": {
+    "namePlaceholder": "Name des Bienenstands",
+    "locationPlaceholder": "Standortbeschreibung",
+    "inspectionType": {
+      "label": "",
+      "placeholder": "",
+      "dataDriven": "",
+      "subjective": "",
+      "description": ""
     }
+  }
 }

--- a/apps/frontend/public/locales/en/apiary.json
+++ b/apps/frontend/public/locales/en/apiary.json
@@ -64,7 +64,9 @@
     "teams": "Teams",
     "addApiary": "Add apiary",
     "noApiarySelected": "No apiary selected",
-    "selectOrCreate": "Select or create an apiary"
+    "selectOrCreate": "Select or create an apiary",
+    "allApiaries": "All apiaries",
+    "allApiariesSubtitle": "Showing every apiary"
   },
   "map": {
     "selectLocation": "Select Apiary Location",

--- a/apps/frontend/public/locales/en/onboarding.json
+++ b/apps/frontend/public/locales/en/onboarding.json
@@ -48,7 +48,8 @@
     "noHives": {
       "title": "No hives yet",
       "description": "Add your first hive to this apiary to start tracking it.",
-      "action": "Add your first hive"
+      "action": "Add your first hive",
+      "descriptionAll": "Add a hive to any of your apiaries to start tracking it."
     },
     "noLocation": {
       "title": "Add a location for weather",

--- a/apps/frontend/public/locales/en/todo.json
+++ b/apps/frontend/public/locales/en/todo.json
@@ -4,7 +4,8 @@
     "caption": "Keep track of tasks for this apiary.",
     "empty": "No todos yet.",
     "emptyOpen": "No open todos. Nice work!",
-    "showCompleted": "Show completed"
+    "showCompleted": "Show completed",
+    "captionAll": "Keep track of tasks for all apiaries."
   },
   "quickAdd": {
     "placeholder": "Add a todo…",

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -1,5 +1,21 @@
 import axios from 'axios';
-import { APIARY_SELECTION } from '@/context/auth-context/auth-provider';
+import {
+  APIARY_SELECTION,
+  VIEW_ALL_APIARIES,
+} from '@/context/auth-context/auth-provider';
+
+// Reserved x-apiary-id value that puts the backend into the cross-apiary read
+// mode (see ApiaryContextGuard). Only valid for GET requests.
+const ALL_APIARIES_HEADER = 'all';
+
+// Endpoints whose backend handlers opt into the cross-apiary "view all" mode
+// (via @AllowAllApiaries). Only these receive x-apiary-id: all; every other
+// request falls back to the concrete selected apiary so it keeps working while
+// more endpoints gain all-apiaries support. Keep in sync with the backend.
+const VIEW_ALL_ENDPOINTS = ['/api/hives', '/api/inspections'];
+
+const supportsViewAll = (url: string | undefined) =>
+  !!url && VIEW_ALL_ENDPOINTS.some(endpoint => url.startsWith(endpoint));
 
 export const apiClient = axios.create({
   baseURL: '/',
@@ -10,10 +26,26 @@ export const apiClient = axios.create({
 });
 
 apiClient.interceptors.request.use(config => {
-  const apiaryId = localStorage.getItem(APIARY_SELECTION);
-  if (apiaryId) {
-    config.headers['x-apiary-id'] = apiaryId;
+  // If the caller already set an explicit x-apiary-id, respect it. This is how
+  // cross-apiary writes work in "view all" mode: the mutation supplies the
+  // concrete target apiary (from the resource or form) as an override.
+  const hasExplicitApiary = config.headers['x-apiary-id'] != null;
+
+  if (!hasExplicitApiary) {
+    const method = (config.method ?? 'get').toUpperCase();
+    const viewAll = localStorage.getItem(VIEW_ALL_APIARIES) === 'true';
+    const apiaryId = localStorage.getItem(APIARY_SELECTION);
+
+    if (method === 'GET' && viewAll && supportsViewAll(config.url)) {
+      // Cross-apiary read: return data for every apiary the user has access to.
+      config.headers['x-apiary-id'] = ALL_APIARIES_HEADER;
+    } else if (apiaryId) {
+      // Single-apiary read, or any write (writes always target one concrete
+      // apiary — the currently selected one by default).
+      config.headers['x-apiary-id'] = apiaryId;
+    }
   }
+
   // For FormData, delete Content-Type so browser sets it with boundary
   if (config.data instanceof FormData) {
     delete config.headers['Content-Type'];

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -12,7 +12,12 @@ const ALL_APIARIES_HEADER = 'all';
 // (via @AllowAllApiaries). Only these receive x-apiary-id: all; every other
 // request falls back to the concrete selected apiary so it keeps working while
 // more endpoints gain all-apiaries support. Keep in sync with the backend.
-const VIEW_ALL_ENDPOINTS = ['/api/hives', '/api/inspections'];
+const VIEW_ALL_ENDPOINTS = [
+  '/api/hives',
+  '/api/inspections',
+  '/api/todos',
+  '/api/queens',
+];
 
 const supportsViewAll = (url: string | undefined) =>
   !!url && VIEW_ALL_ENDPOINTS.some(endpoint => url.startsWith(endpoint));

--- a/apps/frontend/src/api/hooks/useHives.ts
+++ b/apps/frontend/src/api/hooks/useHives.ts
@@ -38,9 +38,16 @@ export const useHives = (
   queryOptions?: Omit<UseQueryOptions<HiveResponse[]>, 'queryKey' | 'queryFn'>,
 ) => {
   const activeApiaryId = useApiaryStore(state => state.activeApiaryId);
+  const viewAllApiaries = useApiaryStore(state => state.viewAllApiaries);
+  // Scope of this query, used for cache-keying and enablement:
+  //  - an explicit filters.apiaryId wins (a component asked for one apiary),
+  //  - otherwise 'all' in view-all mode, or the selected apiary in single mode.
+  // Keeping 'all' distinct from a concrete id prevents an all-apiaries result
+  // being served for a single apiary (or vice versa) from the persisted cache.
+  const scope = filters?.apiaryId ?? (viewAllApiaries ? 'all' : activeApiaryId);
   return useQuery<HiveResponse[]>({
     ...queryOptions,
-    queryKey: HIVES_KEYS.list(activeApiaryId, filters),
+    queryKey: HIVES_KEYS.list(scope, filters),
     queryFn: async () => {
       try {
         const params = new URLSearchParams();
@@ -50,14 +57,18 @@ export const useHives = (
           params.append('includeInactive', filters.includeInactive.toString());
 
         const url = `/api/hives${params.toString() ? `?${params.toString()}` : ''}`;
-        const response = await apiClient.get<HiveResponse[]>(url);
+        // An explicit apiary filter forces that apiary regardless of view-all.
+        const config = filters?.apiaryId
+          ? { headers: { 'x-apiary-id': filters.apiaryId } }
+          : undefined;
+        const response = await apiClient.get<HiveResponse[]>(url, config);
         return response.data;
       } catch (error) {
         logApiError(error, '/api/hives', 'GET');
         throw error;
       }
     },
-    enabled: !!activeApiaryId && queryOptions?.enabled !== false,
+    enabled: !!scope && queryOptions?.enabled !== false,
     ...queryOptions,
   });
 };
@@ -79,9 +90,11 @@ export const useHivesWithBoxes = (
   >,
 ) => {
   const activeApiaryId = useApiaryStore(state => state.activeApiaryId);
+  const viewAllApiaries = useApiaryStore(state => state.viewAllApiaries);
+  const scope = filters?.apiaryId ?? (viewAllApiaries ? 'all' : activeApiaryId);
   return useQuery<HiveWithBoxesResponse[]>({
     ...queryOptions,
-    queryKey: HIVES_KEYS.listWithBoxes(activeApiaryId, filters),
+    queryKey: HIVES_KEYS.listWithBoxes(scope, filters),
     queryFn: async () => {
       const params = new URLSearchParams();
       if (filters?.apiaryId) params.append('apiaryId', filters.apiaryId);
@@ -91,10 +104,14 @@ export const useHivesWithBoxes = (
       params.append('includeBoxes', 'true');
 
       const url = `/api/hives${params.toString() ? `?${params.toString()}` : ''}`;
-      const response = await apiClient.get<HiveWithBoxesResponse[]>(url);
+      // An explicit apiary filter forces that apiary regardless of view-all.
+      const config = filters?.apiaryId
+        ? { headers: { 'x-apiary-id': filters.apiaryId } }
+        : undefined;
+      const response = await apiClient.get<HiveWithBoxesResponse[]>(url, config);
       return response.data;
     },
-    enabled: !!activeApiaryId && queryOptions?.enabled !== false,
+    enabled: !!scope && queryOptions?.enabled !== false,
     ...queryOptions,
   });
 };
@@ -125,9 +142,13 @@ export const useCreateHive = (callbacks?: { onSuccess: () => void }) => {
 
   return useMutation({
     mutationFn: async (data: CreateHive) => {
+      // Target the apiary the hive is being created in, so the backend checks
+      // the user's role on that apiary (important in cross-apiary view-all mode,
+      // where the selected apiary may differ from the chosen target).
       const response = await apiClient.post<CreateHiveResponse>(
         '/api/hives',
         data,
+        apiaryHeaderConfig(data.apiaryId),
       );
       return response.data;
     },
@@ -144,15 +165,31 @@ export const useCreateHive = (callbacks?: { onSuccess: () => void }) => {
   });
 };
 
+// Build an axios config that pins the request to a specific apiary. Used for
+// cross-apiary writes in "view all" mode, where the mutation targets a hive
+// that may not belong to the currently selected apiary. When apiaryId is
+// undefined the interceptor falls back to the selected apiary.
+const apiaryHeaderConfig = (apiaryId?: string) =>
+  apiaryId ? { headers: { 'x-apiary-id': apiaryId } } : undefined;
+
 // Update an existing hive
 export const useUpdateHive = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ id, data }: { id: string; data: UpdateHive }) => {
+    mutationFn: async ({
+      id,
+      data,
+      apiaryId,
+    }: {
+      id: string;
+      data: UpdateHive;
+      apiaryId?: string;
+    }) => {
       const response = await apiClient.patch<UpdateHiveResponse>(
         `/api/hives/${id}`,
         data,
+        apiaryHeaderConfig(apiaryId),
       );
 
       return response.data;
@@ -178,15 +215,10 @@ export const useDeleteHive = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (id: string) => {
-      const response = await fetch(`/api/hives/${id}`, {
-        method: 'DELETE',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-      });
-
-      if (!response.ok) {
-        const error = new Error(`Failed to delete hive with id ${id}`);
+    mutationFn: async ({ id, apiaryId }: { id: string; apiaryId?: string }) => {
+      try {
+        await apiClient.delete(`/api/hives/${id}`, apiaryHeaderConfig(apiaryId));
+      } catch (error) {
         logApiError(error, `/api/hives/${id}`, 'DELETE');
         throw error;
       }
@@ -208,13 +240,16 @@ export const useUpdateHiveBoxes = () => {
     mutationFn: async ({
       id,
       boxes,
+      apiaryId,
     }: {
       id: string;
       boxes: UpdateHiveBoxes['boxes'];
+      apiaryId?: string;
     }) => {
       const response = await apiClient.put<UpdateHiveResponse>(
         `/api/hives/${id}/boxes`,
         { boxes },
+        apiaryHeaderConfig(apiaryId),
       );
       return response.data;
     },

--- a/apps/frontend/src/api/hooks/useHives.ts
+++ b/apps/frontend/src/api/hooks/useHives.ts
@@ -32,6 +32,31 @@ const HIVES_KEYS = {
   detail: (id: string) => [...HIVES_KEYS.details(), id] as const,
 };
 
+/**
+ * Returns a function that resolves a hive's apiary id from the React Query
+ * cache (hive lists + hive details), without triggering a fetch. Used to pin
+ * inspection writes to the hive's own apiary in view-all mode. Returns
+ * undefined when the hive isn't cached — callers then fall back to the active
+ * apiary (correct in single-apiary mode).
+ */
+export const useHiveApiaryLookup = () => {
+  const queryClient = useQueryClient();
+  return (hiveId?: string): string | undefined => {
+    if (!hiveId) return undefined;
+    const lists = queryClient.getQueriesData<HiveResponse[]>({
+      queryKey: HIVES_KEYS.lists(),
+    });
+    for (const [, data] of lists) {
+      const hive = data?.find(h => h.id === hiveId);
+      if (hive?.apiaryId) return hive.apiaryId;
+    }
+    const detail = queryClient.getQueryData<HiveDetailResponse>(
+      HIVES_KEYS.detail(hiveId),
+    );
+    return detail?.apiaryId;
+  };
+};
+
 // Get all hives with optional filtering
 export const useHives = (
   filters?: HiveFilter,
@@ -108,7 +133,10 @@ export const useHivesWithBoxes = (
       const config = filters?.apiaryId
         ? { headers: { 'x-apiary-id': filters.apiaryId } }
         : undefined;
-      const response = await apiClient.get<HiveWithBoxesResponse[]>(url, config);
+      const response = await apiClient.get<HiveWithBoxesResponse[]>(
+        url,
+        config,
+      );
       return response.data;
     },
     enabled: !!scope && queryOptions?.enabled !== false,
@@ -169,7 +197,7 @@ export const useCreateHive = (callbacks?: { onSuccess: () => void }) => {
 // cross-apiary writes in "view all" mode, where the mutation targets a hive
 // that may not belong to the currently selected apiary. When apiaryId is
 // undefined the interceptor falls back to the selected apiary.
-const apiaryHeaderConfig = (apiaryId?: string) =>
+export const apiaryHeaderConfig = (apiaryId?: string) =>
   apiaryId ? { headers: { 'x-apiary-id': apiaryId } } : undefined;
 
 // Update an existing hive
@@ -217,7 +245,10 @@ export const useDeleteHive = () => {
   return useMutation({
     mutationFn: async ({ id, apiaryId }: { id: string; apiaryId?: string }) => {
       try {
-        await apiClient.delete(`/api/hives/${id}`, apiaryHeaderConfig(apiaryId));
+        await apiClient.delete(
+          `/api/hives/${id}`,
+          apiaryHeaderConfig(apiaryId),
+        );
       } catch (error) {
         logApiError(error, `/api/hives/${id}`, 'DELETE');
         throw error;

--- a/apps/frontend/src/api/hooks/useInspections.ts
+++ b/apps/frontend/src/api/hooks/useInspections.ts
@@ -23,7 +23,7 @@ import type {
 } from '@/pages/inspection/components/inspection-form/schema.ts';
 import { useNavigate } from 'react-router-dom';
 import { toInspectionDateISOString } from '@/utils/inspection-date';
-import { useUpdateHiveBoxes } from './useHives';
+import { useUpdateHiveBoxes, apiaryHeaderConfig } from './useHives';
 import { usePendingBoxUpdatesStore } from '@/stores/pendingBoxUpdatesStore';
 
 // Query keys
@@ -220,15 +220,22 @@ export const transformActionsForApi = (
     .filter((a): a is CreateAction => Boolean(a));
 };
 
-// Create a new inspection
+// Create a new inspection. Accepts either a bare CreateInspection payload or an
+// object with an explicit target apiaryId (for cross-apiary writes in view-all
+// mode — the inspection's hive may live in a non-active apiary).
 export const useCreateInspection = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (data: CreateInspection) => {
+    mutationFn: async (
+      input: CreateInspection | { data: CreateInspection; apiaryId?: string },
+    ) => {
+      const { data, apiaryId } =
+        'data' in input ? input : { data: input, apiaryId: undefined };
       const response = await apiClient.post<CreateInspectionResponse>(
         `/api/inspections`,
         data,
+        apiaryHeaderConfig(apiaryId),
       );
 
       return response.data;
@@ -252,13 +259,16 @@ export const useUpdateInspection = () => {
     mutationFn: async ({
       id,
       data,
+      apiaryId,
     }: {
       id: string;
       data: UpdateInspection;
+      apiaryId?: string;
     }) => {
       const response = await apiClient.patch<UpdateInspectionResponse>(
         `/api/inspections/${id}`,
         data,
+        apiaryHeaderConfig(apiaryId),
       );
 
       return response.data;
@@ -286,12 +296,15 @@ export const useDeleteInspection = () => {
     mutationFn: async ({
       id,
       revertFrames,
+      apiaryId,
     }: {
       id: string;
       revertFrames?: boolean;
+      apiaryId?: string;
     }) => {
       await apiClient.delete(`/api/inspections/${id}`, {
         params: revertFrames ? { revertFrames: 'true' } : undefined,
+        ...apiaryHeaderConfig(apiaryId),
       });
       return id;
     },
@@ -308,18 +321,26 @@ export const useDeleteInspection = () => {
 
 export const useUpsertInspection = (
   inspectionId?: string,
-  options?: { onBeforeNavigate?: (inspectionId: string) => Promise<void> },
+  options?: {
+    onBeforeNavigate?: (inspectionId: string) => Promise<void>;
+    // Target apiary of the inspection's hive. Sent as x-apiary-id so the write
+    // works in view-all mode when the hive is not in the active apiary.
+    apiaryId?: string;
+  },
 ) => {
   const { mutateAsync: createInspectionMutation } = useCreateInspection();
   const { mutateAsync: updateInspectionMutation } = useUpdateInspection();
   const { mutateAsync: updateHiveBoxes } = useUpdateHiveBoxes();
-  const { addPendingUpdate, updateStatus, removePendingUpdate } = usePendingBoxUpdatesStore();
+  const { addPendingUpdate, updateStatus, removePendingUpdate } =
+    usePendingBoxUpdatesStore();
   const getUrl = (inspectionId?: string) => `/inspections/${inspectionId}`;
   const navigate = useNavigate();
 
   return async (data: InspectionFormData, status?: InspectionStatus) => {
     // Extract box configuration action so we can apply hive update on success
-    const boxConfigAction = data.actions?.find(a => a.type === 'BOX_CONFIGURATION');
+    const boxConfigAction = data.actions?.find(
+      a => a.type === 'BOX_CONFIGURATION',
+    );
 
     const transformedActions = transformActionsForApi(data.actions);
 
@@ -346,7 +367,9 @@ export const useUpsertInspection = (
      * Adds a pending update to the store before attempting the API call,
      * allowing tracking even if the user navigates away.
      */
-    const performBoxUpdate = async (inspectionRes: CreateInspectionResponse | UpdateInspectionResponse) => {
+    const performBoxUpdate = async (
+      inspectionRes: CreateInspectionResponse | UpdateInspectionResponse,
+    ) => {
       // Check if there are box changes to apply
       if (
         !boxConfigAction?.updatedBoxes ||
@@ -373,8 +396,12 @@ export const useUpsertInspection = (
           hiveLastModifiedAt = hiveResponse.data.updatedAt;
         } catch (e) {
           // If we can't fetch hive data, abort box update and show warning
-          console.error('Failed to fetch hive data for box update staleness check:', e);
-          const errorMessage = 'Failed to fetch hive data for staleness detection. Box update skipped.';
+          console.error(
+            'Failed to fetch hive data for box update staleness check:',
+            e,
+          );
+          const errorMessage =
+            'Failed to fetch hive data for staleness detection. Box update skipped.';
           toast.warning(
             `Inspection saved, but box configuration could not be updated: ${errorMessage}`,
           );
@@ -396,6 +423,7 @@ export const useUpsertInspection = (
           await updateHiveBoxes({
             id: data.hiveId,
             boxes: transformedBoxes,
+            apiaryId: options?.apiaryId,
           });
 
           // On success, remove the pending update from store
@@ -403,9 +431,13 @@ export const useUpsertInspection = (
         } catch (boxUpdateError) {
           // On failure, update the pending update status to 'failed' with error message
           // HIGH #6: Extract actual API error message from AxiosError
-          let errorMessage = 'Failed to update box configuration. Please try again.';
+          let errorMessage =
+            'Failed to update box configuration. Please try again.';
 
-          if (axios.isAxiosError(boxUpdateError) && boxUpdateError.response?.data?.message) {
+          if (
+            axios.isAxiosError(boxUpdateError) &&
+            boxUpdateError.response?.data?.message
+          ) {
             errorMessage = boxUpdateError.response.data.message;
           } else if (boxUpdateError instanceof Error) {
             errorMessage = boxUpdateError.message;
@@ -430,10 +462,15 @@ export const useUpsertInspection = (
      * Handles post-save logic (showing success toast, performing box update, navigation)
      * MEDIUM #11: Extract common logic to avoid duplication between create/update branches
      */
-    const handlePostSave = async (res: CreateInspectionResponse | UpdateInspectionResponse) => {
+    const handlePostSave = async (
+      res: CreateInspectionResponse | UpdateInspectionResponse,
+    ) => {
       // HIGH #5: Show appropriate success message based on whether box changes exist
       // If there are box changes, show a simpler message since box update toast will follow
-      if (boxConfigAction?.updatedBoxes && boxConfigAction.updatedBoxes.length > 0) {
+      if (
+        boxConfigAction?.updatedBoxes &&
+        boxConfigAction.updatedBoxes.length > 0
+      ) {
         toast.success('Inspection saved');
       } else {
         toast.success('Inspection saved successfully');
@@ -441,8 +478,11 @@ export const useUpsertInspection = (
 
       // Perform box update in background (don't await, don't block navigation)
       // CRITICAL #4: Add error logging for unhandled promise rejections
-      performBoxUpdate(res).catch((error) => {
-        console.error('[performBoxUpdate] Unhandled error in box update flow:', error);
+      performBoxUpdate(res).catch(error => {
+        console.error(
+          '[performBoxUpdate] Unhandled error in box update flow:',
+          error,
+        );
       });
 
       await options?.onBeforeNavigate?.(res.id);
@@ -451,7 +491,10 @@ export const useUpsertInspection = (
 
     // Create or update the inspection, then perform box update in background
     if (!inspectionId) {
-      const res = await createInspectionMutation(formattedData);
+      const res = await createInspectionMutation({
+        data: formattedData,
+        apiaryId: options?.apiaryId,
+      });
       await handlePostSave(res);
     } else {
       const res = await updateInspectionMutation({
@@ -460,6 +503,7 @@ export const useUpsertInspection = (
           ...formattedData,
           id: inspectionId,
         },
+        apiaryId: options?.apiaryId,
       });
       await handlePostSave(res);
     }

--- a/apps/frontend/src/api/hooks/useInspections.ts
+++ b/apps/frontend/src/api/hooks/useInspections.ts
@@ -30,17 +30,27 @@ import { usePendingBoxUpdatesStore } from '@/stores/pendingBoxUpdatesStore';
 const INSPECTIONS_KEYS = {
   all: ['inspections'] as const,
   lists: () => [...INSPECTIONS_KEYS.all, 'list'] as const,
-  list: (filters: InspectionFilter | undefined) =>
-    [...INSPECTIONS_KEYS.lists(), filters] as const,
+  // The apiary scope ('all' or a concrete id) is part of the key so a
+  // cross-apiary result is never served for a single apiary (or vice versa).
+  list: (scope: string | null, filters: InspectionFilter | undefined) =>
+    [...INSPECTIONS_KEYS.lists(), scope, filters] as const,
   details: () => [...INSPECTIONS_KEYS.all, 'detail'] as const,
   detail: (id: string) => [...INSPECTIONS_KEYS.details(), id] as const,
 };
 
+// Resolve the current apiary scope: 'all' in view-all mode, otherwise the
+// selected apiary id (or null when nothing is selected yet).
+const useApiaryScope = () => {
+  const activeApiaryId = useApiaryStore(state => state.activeApiaryId);
+  const viewAllApiaries = useApiaryStore(state => state.viewAllApiaries);
+  return viewAllApiaries ? 'all' : activeApiaryId;
+};
+
 // Get all inspections with optional filtering
 export const useInspections = (filters?: InspectionFilter) => {
-  const activeApiaryId = useApiaryStore(state => state.activeApiaryId);
+  const scope = useApiaryScope();
   return useQuery<InspectionResponse[]>({
-    queryKey: INSPECTIONS_KEYS.list(filters),
+    queryKey: INSPECTIONS_KEYS.list(scope, filters),
     queryFn: async () => {
       const params = new URLSearchParams();
       if (filters?.hiveId) params.append('hiveId', filters.hiveId);
@@ -52,45 +62,45 @@ export const useInspections = (filters?: InspectionFilter) => {
       const response = await apiClient.get<InspectionResponse[]>(url);
       return response.data;
     },
-    enabled: !!activeApiaryId,
+    enabled: !!scope,
   });
 };
 
 // Get overdue inspections
 export const useOverdueInspections = () => {
-  const activeApiaryId = useApiaryStore(state => state.activeApiaryId);
+  const scope = useApiaryScope();
   return useQuery<InspectionResponse[]>({
-    queryKey: ['inspections', 'overdue'],
+    queryKey: ['inspections', 'overdue', scope],
     queryFn: async () => {
       const response = await apiClient.get<InspectionResponse[]>(
         '/api/inspections/status/overdue',
       );
       return response.data;
     },
-    enabled: !!activeApiaryId,
+    enabled: !!scope,
   });
 };
 
 // Get inspections due today
 export const useDueTodayInspections = () => {
-  const activeApiaryId = useApiaryStore(state => state.activeApiaryId);
+  const scope = useApiaryScope();
   return useQuery<InspectionResponse[]>({
-    queryKey: ['inspections', 'due-today'],
+    queryKey: ['inspections', 'due-today', scope],
     queryFn: async () => {
       const response = await apiClient.get<InspectionResponse[]>(
         '/api/inspections/status/due-today',
       );
       return response.data;
     },
-    enabled: !!activeApiaryId,
+    enabled: !!scope,
   });
 };
 
 // Get upcoming inspections (future pending inspections)
 export const useUpcomingInspections = (limit?: number) => {
-  const activeApiaryId = useApiaryStore(state => state.activeApiaryId);
+  const scope = useApiaryScope();
   return useQuery<InspectionResponse[]>({
-    queryKey: ['inspections', 'upcoming', limit],
+    queryKey: ['inspections', 'upcoming', scope, limit],
     queryFn: async () => {
       // Get tomorrow's date as start
       const tomorrow = new Date();
@@ -112,7 +122,7 @@ export const useUpcomingInspections = (limit?: number) => {
 
       return limit ? sorted.slice(0, limit) : sorted;
     },
-    enabled: !!activeApiaryId,
+    enabled: !!scope,
   });
 };
 

--- a/apps/frontend/src/api/hooks/useQueens.ts
+++ b/apps/frontend/src/api/hooks/useQueens.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../client';
+import { useApiaryStore } from '@/hooks/use-apiary';
 import {
   CreateQueen,
   UpdateQueen,
@@ -12,19 +13,26 @@ import type { UseQueryOptions } from '@tanstack/react-query';
 const QUEENS_KEYS = {
   all: ['queens'] as const,
   lists: () => [...QUEENS_KEYS.all, 'list'] as const,
-  list: (params?: { hiveId?: string; status?: string }) => [...QUEENS_KEYS.lists(), params] as const,
+  // Scope ('all' or the selected apiary id) keeps single- and cross-apiary
+  // results in separate cache entries.
+  list: (scope: string | null, params?: { hiveId?: string; status?: string }) =>
+    [...QUEENS_KEYS.lists(), scope, params] as const,
   details: () => [...QUEENS_KEYS.all, 'detail'] as const,
   detail: (id: string) => [...QUEENS_KEYS.details(), id] as const,
   history: (id: string) => [...QUEENS_KEYS.all, 'history', id] as const,
-  hiveHistory: (hiveId: string) => [...QUEENS_KEYS.all, 'hiveHistory', hiveId] as const,
+  hiveHistory: (hiveId: string) =>
+    [...QUEENS_KEYS.all, 'hiveHistory', hiveId] as const,
 };
 
 export const useQueens = (
   params?: { hiveId?: string; status?: string },
   queryOptions?: UseQueryOptions<QueenResponse[]>,
 ) => {
+  const activeApiaryId = useApiaryStore(state => state.activeApiaryId);
+  const viewAllApiaries = useApiaryStore(state => state.viewAllApiaries);
+  const scope = viewAllApiaries ? 'all' : activeApiaryId;
   return useQuery<QueenResponse[]>({
-    queryKey: QUEENS_KEYS.list(params),
+    queryKey: QUEENS_KEYS.list(scope, params),
     queryFn: async () => {
       const urlParams = new URLSearchParams();
       if (params?.hiveId) urlParams.append('hiveId', params.hiveId);
@@ -54,7 +62,9 @@ export const useQueenHistory = (queenId: string) => {
   return useQuery<QueenDetail>({
     queryKey: QUEENS_KEYS.history(queenId),
     queryFn: async () => {
-      const response = await apiClient.get<QueenDetail>(`/api/queens/${queenId}/history`);
+      const response = await apiClient.get<QueenDetail>(
+        `/api/queens/${queenId}/history`,
+      );
       return response.data;
     },
     enabled: !!queenId,
@@ -65,7 +75,9 @@ export const useHiveQueenHistory = (hiveId: string) => {
   return useQuery<QueenResponse[]>({
     queryKey: QUEENS_KEYS.hiveHistory(hiveId),
     queryFn: async () => {
-      const response = await apiClient.get<QueenResponse[]>(`/api/queens/hive/${hiveId}/history`);
+      const response = await apiClient.get<QueenResponse[]>(
+        `/api/queens/hive/${hiveId}/history`,
+      );
       return response.data;
     },
     enabled: !!hiveId,
@@ -83,8 +95,12 @@ export const useCreateQueen = (callbacks?: { onSuccess: () => void }) => {
       callbacks?.onSuccess?.();
       await queryClient.invalidateQueries({ queryKey: QUEENS_KEYS.lists() });
       if (data.hiveId) {
-        await queryClient.invalidateQueries({ queryKey: ['hives', 'detail', data.hiveId] });
-        await queryClient.invalidateQueries({ queryKey: QUEENS_KEYS.hiveHistory(data.hiveId) });
+        await queryClient.invalidateQueries({
+          queryKey: ['hives', 'detail', data.hiveId],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: QUEENS_KEYS.hiveHistory(data.hiveId),
+        });
       }
     },
   });
@@ -94,14 +110,21 @@ export const useUpdateQueen = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ id, data }: { id: string; data: UpdateQueen }) => {
-      const response = await apiClient.patch<QueenResponse>(`/api/queens/${id}`, data);
+      const response = await apiClient.patch<QueenResponse>(
+        `/api/queens/${id}`,
+        data,
+      );
       return response.data;
     },
     onSuccess: async (data, variables) => {
-      await queryClient.invalidateQueries({ queryKey: QUEENS_KEYS.detail(variables.id) });
+      await queryClient.invalidateQueries({
+        queryKey: QUEENS_KEYS.detail(variables.id),
+      });
       await queryClient.invalidateQueries({ queryKey: QUEENS_KEYS.lists() });
       if (data.hiveId) {
-        await queryClient.invalidateQueries({ queryKey: ['hives', 'detail', data.hiveId] });
+        await queryClient.invalidateQueries({
+          queryKey: ['hives', 'detail', data.hiveId],
+        });
       }
     },
   });
@@ -110,21 +133,43 @@ export const useUpdateQueen = () => {
 export const useRecordQueenTransfer = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ queenId, data }: { queenId: string; data: RecordQueenTransfer; fromHiveId?: string | null }) => {
-      const response = await apiClient.post<QueenDetail>(`/api/queens/${queenId}/transfer`, data);
+    mutationFn: async ({
+      queenId,
+      data,
+    }: {
+      queenId: string;
+      data: RecordQueenTransfer;
+      fromHiveId?: string | null;
+    }) => {
+      const response = await apiClient.post<QueenDetail>(
+        `/api/queens/${queenId}/transfer`,
+        data,
+      );
       return response.data;
     },
     onSuccess: async (data, variables) => {
-      await queryClient.invalidateQueries({ queryKey: QUEENS_KEYS.history(variables.queenId) });
-      await queryClient.invalidateQueries({ queryKey: QUEENS_KEYS.detail(variables.queenId) });
+      await queryClient.invalidateQueries({
+        queryKey: QUEENS_KEYS.history(variables.queenId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: QUEENS_KEYS.detail(variables.queenId),
+      });
       await queryClient.invalidateQueries({ queryKey: QUEENS_KEYS.lists() });
       if (data.hiveId) {
-        await queryClient.invalidateQueries({ queryKey: ['hives', 'detail', data.hiveId] });
-        await queryClient.invalidateQueries({ queryKey: QUEENS_KEYS.hiveHistory(data.hiveId) });
+        await queryClient.invalidateQueries({
+          queryKey: ['hives', 'detail', data.hiveId],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: QUEENS_KEYS.hiveHistory(data.hiveId),
+        });
       }
       if (variables.fromHiveId) {
-        await queryClient.invalidateQueries({ queryKey: ['hives', 'detail', variables.fromHiveId] });
-        await queryClient.invalidateQueries({ queryKey: QUEENS_KEYS.hiveHistory(variables.fromHiveId) });
+        await queryClient.invalidateQueries({
+          queryKey: ['hives', 'detail', variables.fromHiveId],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: QUEENS_KEYS.hiveHistory(variables.fromHiveId),
+        });
       }
     },
   });

--- a/apps/frontend/src/api/hooks/useScheduledInspectionActions.tsx
+++ b/apps/frontend/src/api/hooks/useScheduledInspectionActions.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useUpdateInspection } from './useInspections';
+import { useHiveApiaryLookup } from './useHives';
 import { InspectionResponse, InspectionStatus } from 'shared-schemas';
 import { RescheduleDialog } from '@/pages/inspection/components/reschedule-dialog';
 import { toInspectionDateISOString } from '@/utils/inspection-date';
@@ -16,6 +17,7 @@ export const useScheduledInspectionActions = (
   const [reschedulingInspection, setReschedulingInspection] =
     useState<InspectionResponse | null>(null);
   const { mutate: updateInspection } = useUpdateInspection();
+  const lookupApiaryId = useHiveApiaryLookup();
 
   const handleDoInspection = (inspection: InspectionResponse) => {
     navigate(`/inspections/${inspection.id}/edit?from=scheduled`);
@@ -31,6 +33,7 @@ export const useScheduledInspectionActions = (
           isAllDay,
           status: InspectionStatus.SCHEDULED,
         },
+        apiaryId: lookupApiaryId(reschedulingInspection.hiveId),
       },
       { onSuccess: () => setReschedulingInspection(null) },
     );

--- a/apps/frontend/src/api/hooks/useTodos.ts
+++ b/apps/frontend/src/api/hooks/useTodos.ts
@@ -1,10 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../client';
-import {
-  CreateTodo,
-  UpdateTodo,
-  TodoResponse,
-} from 'shared-schemas';
+import { CreateTodo, UpdateTodo, TodoResponse } from 'shared-schemas';
 import type { UseQueryOptions } from '@tanstack/react-query';
 import { useApiaryStore } from '@/hooks/use-apiary';
 import { logApiError } from '../errorLogger';
@@ -16,20 +12,21 @@ const TODOS_KEYS = {
   // The active apiary is part of the key: todos are apiary-scoped (via the
   // x-apiary-id header) and the query cache is persisted, so omitting it would
   // let one apiary's list be served for another apiary.
-  list: (apiaryId: string | null) =>
-    [...TODOS_KEYS.lists(), apiaryId] as const,
+  list: (apiaryId: string | null) => [...TODOS_KEYS.lists(), apiaryId] as const,
   details: () => [...TODOS_KEYS.all, 'detail'] as const,
   detail: (id: string) => [...TODOS_KEYS.details(), id] as const,
 };
 
-// Get all todos for the active apiary
+// Get all todos for the active apiary (or across all apiaries in view-all mode)
 export const useTodos = (
   queryOptions?: Omit<UseQueryOptions<TodoResponse[]>, 'queryKey' | 'queryFn'>,
 ) => {
   const activeApiaryId = useApiaryStore(state => state.activeApiaryId);
+  const viewAllApiaries = useApiaryStore(state => state.viewAllApiaries);
+  const scope = viewAllApiaries ? 'all' : activeApiaryId;
   return useQuery<TodoResponse[]>({
-    queryKey: TODOS_KEYS.list(activeApiaryId),
-    enabled: !!activeApiaryId && queryOptions?.enabled !== false,
+    queryKey: TODOS_KEYS.list(scope),
+    enabled: !!scope && queryOptions?.enabled !== false,
     queryFn: async () => {
       try {
         const response = await apiClient.get<TodoResponse[]>('/api/todos');

--- a/apps/frontend/src/components/apiary-switcher.tsx
+++ b/apps/frontend/src/components/apiary-switcher.tsx
@@ -58,6 +58,7 @@ export function ApiarySwitcher() {
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size="lg"
+              data-testid="apiary-switcher"
               className={`data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground ${!hasSelection ? 'border border-dashed border-muted-foreground/50' : ''}`}
             >
               <div
@@ -110,6 +111,7 @@ export function ApiarySwitcher() {
             {/* Cross-apiary "view all" option — disables the single-apiary filter. */}
             <DropdownMenuItem
               onClick={handleSelectAll}
+              data-testid="apiary-switcher-all"
               className="gap-2 p-2"
             >
               <div className="flex size-6 items-center justify-center rounded-xs border">

--- a/apps/frontend/src/components/apiary-switcher.tsx
+++ b/apps/frontend/src/components/apiary-switcher.tsx
@@ -1,4 +1,4 @@
-import { ChevronsUpDown, HomeIcon, Plus } from 'lucide-react';
+import { Check, ChevronsUpDown, HomeIcon, Layers, Plus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -25,13 +25,31 @@ export function ApiarySwitcher() {
   const { t } = useTranslation('apiary');
   const { isMobile } = useSidebar();
   const navigate = useNavigate();
-  const { activeApiary, setActiveApiaryId, apiaries } = useApiary();
+  const {
+    activeApiary,
+    setActiveApiaryId,
+    setViewAllApiaries,
+    viewAllApiaries,
+    apiaries,
+  } = useApiary();
 
   const queryClient = useQueryClient();
+
+  // Select a single apiary: leave "view all" mode and refetch scoped data.
   const handleSetActiveApiary = (apiary: ApiaryResponse) => {
     setActiveApiaryId(apiary.id);
+    setViewAllApiaries(false);
     queryClient.invalidateQueries();
   };
+
+  // Turn on the cross-apiary "view all" mode.
+  const handleSelectAll = () => {
+    setViewAllApiaries(true);
+    queryClient.invalidateQueries();
+  };
+
+  // Whether the trigger shows an "active" (filled) icon.
+  const hasSelection = viewAllApiaries || !!activeApiary;
 
   return (
     <SidebarMenu>
@@ -40,15 +58,24 @@ export function ApiarySwitcher() {
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size="lg"
-              className={`data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground ${!activeApiary ? 'border border-dashed border-muted-foreground/50' : ''}`}
+              className={`data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground ${!hasSelection ? 'border border-dashed border-muted-foreground/50' : ''}`}
             >
               <div
-                className={`flex aspect-square size-8 items-center justify-center rounded-lg ${activeApiary ? 'bg-sidebar-primary text-sidebar-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+                className={`flex aspect-square size-8 items-center justify-center rounded-lg ${hasSelection ? 'bg-sidebar-primary text-sidebar-primary-foreground' : 'bg-muted text-muted-foreground'}`}
               >
-                <HomeIcon />
+                {viewAllApiaries ? <Layers /> : <HomeIcon />}
               </div>
               <div className="grid flex-1 text-left text-sm leading-tight">
-                {activeApiary ? (
+                {viewAllApiaries ? (
+                  <>
+                    <span className="truncate font-medium">
+                      {t('switcher.allApiaries')}
+                    </span>
+                    <span className="truncate text-xs">
+                      {t('switcher.allApiariesSubtitle')}
+                    </span>
+                  </>
+                ) : activeApiary ? (
                   <>
                     <span className="truncate font-medium">
                       {activeApiary.name}
@@ -80,6 +107,18 @@ export function ApiarySwitcher() {
             <DropdownMenuLabel className="text-muted-foreground text-xs">
               {t('switcher.teams')}
             </DropdownMenuLabel>
+            {/* Cross-apiary "view all" option — disables the single-apiary filter. */}
+            <DropdownMenuItem
+              onClick={handleSelectAll}
+              className="gap-2 p-2"
+            >
+              <div className="flex size-6 items-center justify-center rounded-xs border">
+                <Layers className="size-4" />
+              </div>
+              {t('switcher.allApiaries')}
+              {viewAllApiaries && <Check className="ml-auto size-4" />}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
             {apiaries?.map((apiary, index) => (
               <DropdownMenuItem
                 key={apiary.id}
@@ -90,7 +129,11 @@ export function ApiarySwitcher() {
                   <HomeIcon className="size-4" />
                 </div>
                 {apiary.name}
-                <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
+                {!viewAllApiaries && activeApiary?.id === apiary.id ? (
+                  <Check className="ml-auto size-4" />
+                ) : (
+                  <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
+                )}
               </DropdownMenuItem>
             ))}
             <DropdownMenuSeparator />

--- a/apps/frontend/src/context/auth-context/auth-provider.tsx
+++ b/apps/frontend/src/context/auth-context/auth-provider.tsx
@@ -4,6 +4,9 @@ import { AuthContext } from '@/context/auth-context/auth-context.ts';
 import { authClient, useSession } from '@/lib/auth-client';
 
 export const APIARY_SELECTION = 'hive_pal_apiary_selection';
+// When set to 'true', the app shows data across ALL of the user's apiaries
+// instead of filtering to the single selected apiary (APIARY_SELECTION).
+export const VIEW_ALL_APIARIES = 'hive_pal_view_all_apiaries';
 const LEGACY_TOKEN_KEY = 'hive_pal_auth_token';
 
 interface AuthProviderProps {
@@ -90,6 +93,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     await authClient.signOut();
     queryClient.clear();
     localStorage.removeItem(APIARY_SELECTION);
+    localStorage.removeItem(VIEW_ALL_APIARIES);
     localStorage.removeItem('hive-pal-query-cache');
     window.location.href = '/login';
   }, [queryClient]);

--- a/apps/frontend/src/hooks/use-apiary.ts
+++ b/apps/frontend/src/hooks/use-apiary.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { APIARY_SELECTION } from '@/context/auth-context';
+import { APIARY_SELECTION, VIEW_ALL_APIARIES } from '@/context/auth-context';
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import { useApiaries } from '@/api/hooks';
@@ -7,18 +7,30 @@ import { ApiaryResponse } from 'shared-schemas';
 
 interface ApiaryState {
   activeApiaryId: string | null;
+  // When true, the app shows data across ALL of the user's apiaries instead of
+  // filtering to a single one. The concrete activeApiaryId is still kept around
+  // as the default write target (creating hives etc. needs a target apiary).
+  viewAllApiaries: boolean;
   setActiveApiaryId: (id: string) => void;
   clearActiveApiaryId: () => void;
+  setViewAllApiaries: (value: boolean) => void;
 }
 
 export const useApiaryStore = create<ApiaryState>(set => {
   // Initialize from localStorage
   const apiaryFromLocalStorage = localStorage.getItem(APIARY_SELECTION);
+  const viewAllFromLocalStorage =
+    localStorage.getItem(VIEW_ALL_APIARIES) === 'true';
 
   return {
     activeApiaryId: apiaryFromLocalStorage || null,
+    viewAllApiaries: viewAllFromLocalStorage,
     setActiveApiaryId: (id: string) => {
-      // Always update localStorage first to ensure the interceptor has access to the latest value
+      // Always update localStorage first to ensure the interceptor has access to the latest value.
+      // Note: this is the low-level setter for the concrete apiary (also used as
+      // the write target). It intentionally does NOT change viewAllApiaries, so
+      // the auto-select effect below can refresh the write target without
+      // leaving the "all apiaries" view. Use setViewAllApiaries to toggle mode.
       localStorage.setItem(APIARY_SELECTION, id);
       set({ activeApiaryId: id });
     },
@@ -26,42 +38,72 @@ export const useApiaryStore = create<ApiaryState>(set => {
       localStorage.removeItem(APIARY_SELECTION);
       set({ activeApiaryId: null });
     },
+    setViewAllApiaries: (value: boolean) => {
+      if (value) {
+        localStorage.setItem(VIEW_ALL_APIARIES, 'true');
+      } else {
+        localStorage.removeItem(VIEW_ALL_APIARIES);
+      }
+      set({ viewAllApiaries: value });
+    },
   };
 });
 
 export const useApiary = () => {
   const { data: apiaries } = useApiaries();
-  const { activeApiaryId, setActiveApiaryId, clearActiveApiaryId } =
-    useApiaryStore(
-      useShallow(state => ({
-        activeApiaryId: state.activeApiaryId,
-        setActiveApiaryId: state.setActiveApiaryId,
-        clearActiveApiaryId: state.clearActiveApiaryId,
-      })),
-    );
+  const {
+    activeApiaryId,
+    viewAllApiaries,
+    setActiveApiaryId,
+    clearActiveApiaryId,
+    setViewAllApiaries,
+  } = useApiaryStore(
+    useShallow(state => ({
+      activeApiaryId: state.activeApiaryId,
+      viewAllApiaries: state.viewAllApiaries,
+      setActiveApiaryId: state.setActiveApiaryId,
+      clearActiveApiaryId: state.clearActiveApiaryId,
+      setViewAllApiaries: state.setViewAllApiaries,
+    })),
+  );
 
   // Validate activeApiaryId against user's apiaries and auto-select
   useEffect(() => {
     if (!apiaries) return;
 
     if (apiaries.length === 0) {
-      // User has no apiaries — clear any stale selection
+      // User has no apiaries — clear any stale selection and leave all-view.
       if (activeApiaryId) {
         clearActiveApiaryId();
       }
-    } else if (
-      !activeApiaryId ||
-      !apiaries.some(a => a.id === activeApiaryId)
-    ) {
-      // No selection or stale selection — set to first available
+      if (viewAllApiaries) {
+        setViewAllApiaries(false);
+      }
+    } else if (!activeApiaryId || !apiaries.some(a => a.id === activeApiaryId)) {
+      // No selection or stale selection — set to first available. This keeps a
+      // valid write target even while viewing all apiaries.
       setActiveApiaryId(apiaries[0].id);
     }
-  }, [apiaries, activeApiaryId, setActiveApiaryId, clearActiveApiaryId]);
+  }, [
+    apiaries,
+    activeApiaryId,
+    viewAllApiaries,
+    setActiveApiaryId,
+    clearActiveApiaryId,
+    setViewAllApiaries,
+  ]);
 
   // Find the active apiary object
   const activeApiary = apiaries?.find(
     (apiary: ApiaryResponse) => apiary.id === activeApiaryId,
   );
 
-  return { activeApiary, setActiveApiaryId, apiaries, activeApiaryId };
+  return {
+    activeApiary,
+    setActiveApiaryId,
+    setViewAllApiaries,
+    viewAllApiaries,
+    apiaries,
+    activeApiaryId,
+  };
 };

--- a/apps/frontend/src/pages/actions/bulk-actions-page.tsx
+++ b/apps/frontend/src/pages/actions/bulk-actions-page.tsx
@@ -2,7 +2,13 @@ import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
-import { CalendarIcon, ChevronRight, Inbox, Search, Send } from 'lucide-react';
+import {
+  CalendarIcon,
+  ChevronRight,
+  Inbox,
+  Search,
+  Send,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -12,7 +18,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { useHives } from '@/api/hooks/useHives';
 import { useCreateAction } from '@/api/hooks/useActions';
@@ -48,8 +59,8 @@ export const BulkActionsPage = () => {
     activeTab === 'action'
       ? actionRef
       : activeTab === 'inspection'
-        ? inspectionRef
-        : queenRef;
+      ? inspectionRef
+      : queenRef;
 
   const filteredHives = useMemo(() => {
     const q = hiveFilter.trim().toLowerCase();
@@ -95,22 +106,17 @@ export const BulkActionsPage = () => {
         activeTab === 'action'
           ? t('bulkAdd.errors.emptyAction')
           : activeTab === 'inspection'
-            ? t('bulkAdd.errors.emptyInspection')
-            : t('bulkAdd.errors.emptyQueen'),
+          ? t('bulkAdd.errors.emptyInspection')
+          : t('bulkAdd.errors.emptyQueen'),
       );
       return;
     }
     setStagedItems(prev => [...prev, ...built]);
     activeRef.current?.reset();
     toast.success(
-      t(
-        built.length === 1
-          ? 'bulkAdd.toast.addedOne'
-          : 'bulkAdd.toast.addedMany',
-        {
-          count: built.length,
-        },
-      ),
+      t(built.length === 1 ? 'bulkAdd.toast.addedOne' : 'bulkAdd.toast.addedMany', {
+        count: built.length,
+      }),
     );
   };
 
@@ -439,13 +445,13 @@ export const BulkActionsPage = () => {
                 {isSubmitting
                   ? t('bulkAdd.queue.submitting')
                   : stagedItems.length === 0
-                    ? t('bulkAdd.queue.submit')
-                    : t(
-                        stagedItems.length === 1
-                          ? 'bulkAdd.queue.submitOne'
-                          : 'bulkAdd.queue.submitMany',
-                        { count: stagedItems.length },
-                      )}
+                  ? t('bulkAdd.queue.submit')
+                  : t(
+                      stagedItems.length === 1
+                        ? 'bulkAdd.queue.submitOne'
+                        : 'bulkAdd.queue.submitMany',
+                      { count: stagedItems.length },
+                    )}
               </Button>
             </div>
           </div>

--- a/apps/frontend/src/pages/actions/bulk-actions-page.tsx
+++ b/apps/frontend/src/pages/actions/bulk-actions-page.tsx
@@ -2,13 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
-import {
-  CalendarIcon,
-  ChevronRight,
-  Inbox,
-  Search,
-  Send,
-} from 'lucide-react';
+import { CalendarIcon, ChevronRight, Inbox, Search, Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -18,12 +12,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@/components/ui/tabs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { useHives } from '@/api/hooks/useHives';
 import { useCreateAction } from '@/api/hooks/useActions';
@@ -59,8 +48,8 @@ export const BulkActionsPage = () => {
     activeTab === 'action'
       ? actionRef
       : activeTab === 'inspection'
-      ? inspectionRef
-      : queenRef;
+        ? inspectionRef
+        : queenRef;
 
   const filteredHives = useMemo(() => {
     const q = hiveFilter.trim().toLowerCase();
@@ -106,17 +95,22 @@ export const BulkActionsPage = () => {
         activeTab === 'action'
           ? t('bulkAdd.errors.emptyAction')
           : activeTab === 'inspection'
-          ? t('bulkAdd.errors.emptyInspection')
-          : t('bulkAdd.errors.emptyQueen'),
+            ? t('bulkAdd.errors.emptyInspection')
+            : t('bulkAdd.errors.emptyQueen'),
       );
       return;
     }
     setStagedItems(prev => [...prev, ...built]);
     activeRef.current?.reset();
     toast.success(
-      t(built.length === 1 ? 'bulkAdd.toast.addedOne' : 'bulkAdd.toast.addedMany', {
-        count: built.length,
-      }),
+      t(
+        built.length === 1
+          ? 'bulkAdd.toast.addedOne'
+          : 'bulkAdd.toast.addedMany',
+        {
+          count: built.length,
+        },
+      ),
     );
   };
 
@@ -142,7 +136,13 @@ export const BulkActionsPage = () => {
     try {
       const result = await submitStagedItems(stagedItems, {
         createAction,
-        createInspection,
+        // Pin each inspection to its hive's apiary so cross-apiary bulk-add
+        // works in view-all mode.
+        createInspection: data =>
+          createInspection({
+            data,
+            apiaryId: hives.find(h => h.id === data.hiveId)?.apiaryId,
+          }),
         createQueen,
       });
       const { counts, failedIds, succeededIds } = result;
@@ -439,13 +439,13 @@ export const BulkActionsPage = () => {
                 {isSubmitting
                   ? t('bulkAdd.queue.submitting')
                   : stagedItems.length === 0
-                  ? t('bulkAdd.queue.submit')
-                  : t(
-                      stagedItems.length === 1
-                        ? 'bulkAdd.queue.submitOne'
-                        : 'bulkAdd.queue.submitMany',
-                      { count: stagedItems.length },
-                    )}
+                    ? t('bulkAdd.queue.submit')
+                    : t(
+                        stagedItems.length === 1
+                          ? 'bulkAdd.queue.submitOne'
+                          : 'bulkAdd.queue.submitMany',
+                        { count: stagedItems.length },
+                      )}
               </Button>
             </div>
           </div>

--- a/apps/frontend/src/pages/harvest/harvest-list-page.tsx
+++ b/apps/frontend/src/pages/harvest/harvest-list-page.tsx
@@ -21,9 +21,11 @@ import { getStatusColor } from '@/utils/status-colors';
 
 export const HarvestListPage = () => {
   const navigate = useNavigate();
-  const { activeApiaryId } = useApiary();
+  const { activeApiaryId, viewAllApiaries } = useApiary();
   const { data: harvests = [], isLoading } = useHarvests({
-    apiaryId: activeApiaryId || undefined,
+    // In view-all mode, omit the apiary filter so the backend returns harvests
+    // across all of the user's apiaries.
+    apiaryId: viewAllApiaries ? undefined : activeApiaryId || undefined,
   });
   const { getWeightUnit } = useUnitFormat();
 

--- a/apps/frontend/src/pages/hive/components/hive-form.tsx
+++ b/apps/frontend/src/pages/hive/components/hive-form.tsx
@@ -170,10 +170,14 @@ export const HiveForm: React.FC<HiveFormProps> = ({
           status: data.status as HiveStatusEnum,
           installationDate: data.installationDate.toISOString(),
         },
-        apiaryId: finalData.apiaryId,
+        // Authorize against the hive's CURRENT apiary: when the user moves the
+        // hive to another apiary, the backend must still find it in the old
+        // one (the new apiary travels in the body).
+        apiaryId: existingHive?.apiaryId ?? finalData.apiaryId,
       });
       // The hive update endpoint ignores boxes; persist box/frame changes
-      // through the dedicated boxes endpoint.
+      // through the dedicated boxes endpoint. After a move the hive now lives
+      // in the target apiary.
       if (finalData.boxes && finalData.boxes.length > 0) {
         await updateHiveBoxes({
           id: hiveId,

--- a/apps/frontend/src/pages/hive/components/hive-form.tsx
+++ b/apps/frontend/src/pages/hive/components/hive-form.tsx
@@ -170,11 +170,16 @@ export const HiveForm: React.FC<HiveFormProps> = ({
           status: data.status as HiveStatusEnum,
           installationDate: data.installationDate.toISOString(),
         },
+        apiaryId: finalData.apiaryId,
       });
       // The hive update endpoint ignores boxes; persist box/frame changes
       // through the dedicated boxes endpoint.
       if (finalData.boxes && finalData.boxes.length > 0) {
-        await updateHiveBoxes({ id: hiveId, boxes: finalData.boxes });
+        await updateHiveBoxes({
+          id: hiveId,
+          boxes: finalData.boxes,
+          apiaryId: finalData.apiaryId,
+        });
       }
       navigate(`/hives/${hiveId}`);
     } else {

--- a/apps/frontend/src/pages/hive/hive-detail-page/action-sidebar.tsx
+++ b/apps/frontend/src/pages/hive/hive-detail-page/action-sidebar.tsx
@@ -50,7 +50,9 @@ export const ActionSideBar: React.FC<ActionSideBarProps> = ({
   const deleteDialog = useDeleteDialog(
     () => {
       if (!hiveId) throw new Error('Hive ID is required');
-      return deleteHive.mutateAsync(hiveId);
+      // Pass the hive's own apiary so the delete targets the right apiary even
+      // in cross-apiary "view all" mode (where the selected apiary may differ).
+      return deleteHive.mutateAsync({ id: hiveId, apiaryId: hive?.apiaryId });
     },
     () => navigate(`/apiaries/${hive?.apiaryId}`),
   );

--- a/apps/frontend/src/pages/hive/hive-detail-page/box-configurator/index.tsx
+++ b/apps/frontend/src/pages/hive/hive-detail-page/box-configurator/index.tsx
@@ -148,6 +148,7 @@ export const BoxConfigurator = ({ hive }: BoxConfiguratorProps) => {
           // Remove temporary IDs
           id: box.id?.startsWith('temp-') ? undefined : box.id,
         })),
+        apiaryId: hive.apiaryId,
       });
       toast.success('Box configuration saved successfully');
       setIsEditing(false);

--- a/apps/frontend/src/pages/hive/hive-detail-page/hive-settings.tsx
+++ b/apps/frontend/src/pages/hive/hive-detail-page/hive-settings.tsx
@@ -73,6 +73,7 @@ export const HiveSettings: React.FC<HiveSettingsProps> = ({
           id: hive.id,
           settings: data.settings,
         },
+        apiaryId: hive.apiaryId,
       },
       {
         onSuccess: () => {

--- a/apps/frontend/src/pages/hive/hive-detail-page/hive-status-button.tsx
+++ b/apps/frontend/src/pages/hive/hive-detail-page/hive-status-button.tsx
@@ -26,9 +26,14 @@ const ALL_STATUSES: { value: HiveStatusEnum; label: string }[] = [
 type HiveStatusButtonProps = {
   hiveId: string;
   status: HiveStatusEnum | undefined;
+  apiaryId?: string;
 };
 
-export const HiveStatusButton: React.FC<HiveStatusButtonProps> = ({ hiveId, status }) => {
+export const HiveStatusButton: React.FC<HiveStatusButtonProps> = ({
+  hiveId,
+  status,
+  apiaryId,
+}) => {
   const [open, setOpen] = useState(false);
   const { mutateAsync: updateHive, isPending } = useUpdateHive();
 
@@ -38,7 +43,11 @@ export const HiveStatusButton: React.FC<HiveStatusButtonProps> = ({ hiveId, stat
       return;
     }
     try {
-      await updateHive({ id: hiveId, data: { id: hiveId, status: newStatus } });
+      await updateHive({
+        id: hiveId,
+        data: { id: hiveId, status: newStatus },
+        apiaryId,
+      });
       toast.success(`Hive status updated to ${newStatus.toLowerCase()}`);
     } catch {
       toast.error('Failed to update hive status');

--- a/apps/frontend/src/pages/hive/hive-detail-page/page.tsx
+++ b/apps/frontend/src/pages/hive/hive-detail-page/page.tsx
@@ -178,7 +178,11 @@ export const HiveDetailPage = () => {
                         </Popover>
                       )}
                       {hiveId && (
-                        <HiveStatusButton hiveId={hiveId} status={hive?.status} />
+                        <HiveStatusButton
+                          hiveId={hiveId}
+                          status={hive?.status}
+                          apiaryId={hive?.apiaryId}
+                        />
                       )}
                     </div>
                   </div>

--- a/apps/frontend/src/pages/home-page.tsx
+++ b/apps/frontend/src/pages/home-page.tsx
@@ -176,10 +176,7 @@ export const HomePage = () => {
 
   // User has no apiaries at all — invite them to create one (default apiary is
   // auto-created on registration, so this mainly covers users who removed it).
-  if (
-    (!apiaries || apiaries.length === 0) &&
-    pendingMemberships === 0
-  ) {
+  if ((!apiaries || apiaries.length === 0) && pendingMemberships === 0) {
     return (
       <PageGrid>
         <MainContent>
@@ -290,10 +287,7 @@ export const HomePage = () => {
               <HiveMinimap apiaryId={activeApiaryId} showHeader={false} />
             </CollapsibleSection>
           )}
-          <CollapsibleSection
-            storageKey="home-section:hives"
-            title="Hives"
-          >
+          <CollapsibleSection storageKey="home-section:hives" title="Hives">
             {data && data.length > 0 ? (
               viewAllApiaries ? (
                 <GroupedHives hives={data} apiaries={apiaries} />
@@ -304,7 +298,11 @@ export const HomePage = () => {
               <EmptyStateCard
                 icon={<Sparkles className="h-6 w-6 text-amber-600" />}
                 title={t('empty.noHives.title')}
-                description={t('empty.noHives.description')}
+                description={t(
+                  viewAllApiaries
+                    ? 'empty.noHives.descriptionAll'
+                    : 'empty.noHives.description',
+                )}
                 action={
                   <Button asChild>
                     <Link to="/hives/create">{t('empty.noHives.action')}</Link>
@@ -313,9 +311,12 @@ export const HomePage = () => {
               />
             )}
           </CollapsibleSection>
-          {/* Todos and the timeline are per-apiary; aggregation across all
-              apiaries is a later iteration, so hide them in view-all mode. */}
-          {!viewAllApiaries && <DashboardTodos />}
+          {/* Todos are apiary-scoped but the todos endpoint supports the
+              cross-apiary view, so they aggregate across all apiaries here. */}
+          <DashboardTodos />
+          {/* The timeline mixes endpoints that don't yet support view-all
+              (actions, quick-checks, photos, documents), so it stays hidden in
+              view-all mode until those gain cross-apiary support (Phase 2b). */}
           {!viewAllApiaries && <ApiaryTimeline />}
         </div>
       </MainContent>

--- a/apps/frontend/src/pages/home-page.tsx
+++ b/apps/frontend/src/pages/home-page.tsx
@@ -19,11 +19,13 @@ import {
   ArrowUpRight,
   ChevronDown,
   Clock,
+  HomeIcon,
   MapPin,
   Plus,
   Sparkles,
   X,
 } from 'lucide-react';
+import { ApiaryResponse, HiveResponse } from 'shared-schemas';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useApiaries, useHives, useTodos } from '@/api/hooks';
@@ -98,6 +100,45 @@ const EmptyStateCard = ({
   </Card>
 );
 
+// In "view all" mode the dashboard lists hives grouped under each apiary,
+// mirroring how BEEP presents apiaries with their hives.
+const GroupedHives = ({
+  hives,
+  apiaries,
+}: {
+  hives: HiveResponse[];
+  apiaries?: ApiaryResponse[];
+}) => {
+  const byApiary = new Map<string, HiveResponse[]>();
+  for (const hive of hives) {
+    const key = hive.apiaryId ?? '__none__';
+    const list = byApiary.get(key) ?? [];
+    list.push(hive);
+    byApiary.set(key, list);
+  }
+  // Preserve the apiary order from the switcher; only show apiaries with hives.
+  const groups = (apiaries ?? []).filter(a => byApiary.has(a.id));
+
+  return (
+    <div className="space-y-8">
+      {groups.map(apiary => (
+        <div key={apiary.id} className="space-y-3">
+          <div className="flex items-center gap-2">
+            <div className="flex size-6 items-center justify-center rounded-md bg-sidebar-primary/10 text-amber-700 dark:text-amber-400">
+              <HomeIcon className="size-4" />
+            </div>
+            <h3 className="font-medium">{apiary.name}</h3>
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {byApiary.get(apiary.id)?.length ?? 0}
+            </span>
+          </div>
+          <HiveList hives={byApiary.get(apiary.id) ?? []} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
 const DashboardTodos = () => {
   const { t } = useTranslation('todo');
   const { data } = useTodos();
@@ -118,7 +159,8 @@ const DashboardTodos = () => {
 export const HomePage = () => {
   const { t } = useTranslation('onboarding');
   const { data, isLoading, refetch } = useHives();
-  const { activeApiaryId, apiaries, activeApiary } = useApiary();
+  const { activeApiaryId, apiaries, activeApiary, viewAllApiaries } =
+    useApiary();
   const { pendingMemberships } = useApiaries();
   const [locationDismissed, setLocationDismissed] = useLocalStorageBoolean(
     `home-nudge:location-dismissed:${activeApiaryId ?? 'none'}`,
@@ -195,8 +237,10 @@ export const HomePage = () => {
     <PageGrid>
       <MainContent>
         <div className="space-y-6">
-          <ApiaryHeader />
-          {activeApiary &&
+          {/* Apiary-specific header only makes sense for a single apiary. */}
+          {!viewAllApiaries && <ApiaryHeader />}
+          {!viewAllApiaries &&
+            activeApiary &&
             activeApiary.latitude == null &&
             !locationDismissed && (
               <Card>
@@ -228,7 +272,8 @@ export const HomePage = () => {
                 </CardContent>
               </Card>
             )}
-          {activeApiaryId && (
+          {/* The hive-layout minimap is tied to one apiary's grid. */}
+          {activeApiaryId && !viewAllApiaries && (
             <CollapsibleSection
               storageKey="home-section:minimap"
               title="Hive Layout"
@@ -250,7 +295,11 @@ export const HomePage = () => {
             title="Hives"
           >
             {data && data.length > 0 ? (
-              <HiveList hives={data} />
+              viewAllApiaries ? (
+                <GroupedHives hives={data} apiaries={apiaries} />
+              ) : (
+                <HiveList hives={data} />
+              )
             ) : (
               <EmptyStateCard
                 icon={<Sparkles className="h-6 w-6 text-amber-600" />}
@@ -264,8 +313,10 @@ export const HomePage = () => {
               />
             )}
           </CollapsibleSection>
-          <DashboardTodos />
-          <ApiaryTimeline />
+          {/* Todos and the timeline are per-apiary; aggregation across all
+              apiaries is a later iteration, so hide them in view-all mode. */}
+          {!viewAllApiaries && <DashboardTodos />}
+          {!viewAllApiaries && <ApiaryTimeline />}
         </div>
       </MainContent>
       <PageAside>

--- a/apps/frontend/src/pages/inspection/audio-quick/audio-quick-page.tsx
+++ b/apps/frontend/src/pages/inspection/audio-quick/audio-quick-page.tsx
@@ -75,6 +75,7 @@ export function AudioQuickPage() {
             observations: {},
             actions: [],
           },
+          // The hive's own apiary — cross-apiary safe in view-all mode.
           apiaryId: hive?.apiaryId,
         });
         if (cancelled) return;

--- a/apps/frontend/src/pages/inspection/audio-quick/audio-quick-page.tsx
+++ b/apps/frontend/src/pages/inspection/audio-quick/audio-quick-page.tsx
@@ -67,12 +67,15 @@ export function AudioQuickPage() {
     void (async () => {
       try {
         const res = await createInspection({
-          hiveId,
-          date: toInspectionDateISOString(new Date(), false),
-          isAllDay: false,
-          status: InspectionStatus.COMPLETED,
-          observations: {},
-          actions: [],
+          data: {
+            hiveId,
+            date: toInspectionDateISOString(new Date(), false),
+            isAllDay: false,
+            status: InspectionStatus.COMPLETED,
+            observations: {},
+            actions: [],
+          },
+          apiaryId: hive?.apiaryId,
         });
         if (cancelled) return;
         inspectionIdRef.current = res.id;
@@ -87,7 +90,16 @@ export function AudioQuickPage() {
     return () => {
       cancelled = true;
     };
-  }, [phase, error, isRecording, hiveId, createInspection, stopRecording, t]);
+  }, [
+    phase,
+    error,
+    isRecording,
+    hiveId,
+    hive?.apiaryId,
+    createInspection,
+    stopRecording,
+    t,
+  ]);
 
   const handleStop = useCallback(async () => {
     await stopRecording();

--- a/apps/frontend/src/pages/inspection/components/inspection-detail-sidebar.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-detail-sidebar.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/sidebar';
 import { useApiaryPermission } from '@/hooks/useApiaryPermission';
 import { useDeleteInspection, useInspection } from '@/api/hooks/useInspections';
+import { useHiveApiaryLookup } from '@/api/hooks/useHives';
 import { ActionType } from 'shared-schemas';
 import {
   Dialog,
@@ -42,6 +43,7 @@ export const InspectionDetailSidebar: React.FC<
   const navigate = useNavigate();
   const { canEdit } = useApiaryPermission();
   const deleteInspection = useDeleteInspection();
+  const lookupApiaryId = useHiveApiaryLookup();
   const { data: inspection } = useInspection(inspectionId, {
     enabled: !!inspectionId,
   });
@@ -59,7 +61,11 @@ export const InspectionDetailSidebar: React.FC<
 
   const handleDelete = async (revertFrames = false) => {
     try {
-      await deleteInspection.mutateAsync({ id: inspectionId, revertFrames });
+      await deleteInspection.mutateAsync({
+        id: inspectionId,
+        revertFrames,
+        apiaryId: lookupApiaryId(hiveId),
+      });
       setShowDeleteDialog(false);
       navigate(`/hives/${hiveId}`);
     } catch (error) {
@@ -143,11 +149,11 @@ export const InspectionDetailSidebar: React.FC<
             <DialogDescription>
               {hasFrameModification
                 ? `${t(
-                  frameDelta > 0
-                    ? 'inspection:detailSidebar.frameModificationAdded'
-                    : 'inspection:detailSidebar.frameModificationRemoved',
-                  { count: Math.abs(frameDelta) },
-                )} ${t('inspection:detailSidebar.frameModificationQuestion')}`
+                    frameDelta > 0
+                      ? 'inspection:detailSidebar.frameModificationAdded'
+                      : 'inspection:detailSidebar.frameModificationRemoved',
+                    { count: Math.abs(frameDelta) },
+                  )} ${t('inspection:detailSidebar.frameModificationQuestion')}`
                 : t('common:confirmDelete')}
             </DialogDescription>
           </DialogHeader>
@@ -192,8 +198,8 @@ export const InspectionDetailSidebar: React.FC<
               >
                 {deleteInspection.isPending
                   ? t('common:actions.deleting', {
-                    defaultValue: 'Deleting...',
-                  })
+                      defaultValue: 'Deleting...',
+                    })
                   : t('common:actions.delete', { defaultValue: 'Delete' })}
               </Button>
             </DialogFooter>

--- a/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
@@ -56,9 +56,7 @@ import { applyInspectionModeToFormData } from './mode-behavior';
 import type { Box } from 'shared-schemas';
 
 const normalizeBoxSummary = (
-  boxesSummary:
-    | Array<{ type: string; frameCount: number }>
-    | undefined,
+  boxesSummary: Array<{ type: string; frameCount: number }> | undefined,
   fallbackBoxes: Box[] = [],
 ): Box[] | undefined => {
   if (!boxesSummary?.length) return undefined;
@@ -136,75 +134,75 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
       // discriminant (`type`) optional and breaks discriminated-union narrowing.
       // The mapping below produces correctly-shaped action objects at runtime.
       actions: (inspection?.actions?.map(action => {
-          if (action.details.type === ActionType.FEEDING) {
-            const details = action.details;
-            return {
-              type: ActionType.FEEDING,
-              notes: action.notes ?? '',
-              feedType: details.feedType,
-              quantity: details.amount,
-              unit: details.unit,
-              concentration: details.concentration ?? '',
-            };
-          }
-
-          if (action.details.type === ActionType.TREATMENT) {
-            const details = action.details;
-            return {
-              type: ActionType.TREATMENT,
-              notes: action.notes ?? '',
-              amount: details.quantity,
-              treatmentType: details.product,
-              unit: details.unit,
-            };
-          }
-
-          if (action.details.type === ActionType.FRAME) {
-            const details = action.details;
-            return {
-              type: ActionType.FRAME,
-              notes: action.notes ?? '',
-              frames: details.quantity,
-            };
-          }
-
-          if (action.details.type === ActionType.MAINTENANCE) {
-            const details = action.details;
-            return {
-              type: ActionType.MAINTENANCE,
-              notes: action.notes ?? '',
-              component: details.component,
-              status: details.status,
-            };
-          }
-
-          if (action.details.type === ActionType.NOTE) {
-            const details = action.details;
-            return {
-              type: ActionType.NOTE,
-              notes: details.content || action.notes || '',
-            };
-          }
-
-          if (action.details.type === ActionType.BOX_CONFIGURATION) {
-            const details = action.details;
-            return {
-              type: ActionType.BOX_CONFIGURATION,
-              boxesAdded: details.boxesAdded,
-              boxesRemoved: details.boxesRemoved,
-              framesAdded: details.framesAdded,
-              framesRemoved: details.framesRemoved,
-              totalBoxes: details.totalBoxes,
-              totalFrames: details.totalFrames,
-              boxesSummary: details.boxes,
-            };
-          }
-
+        if (action.details.type === ActionType.FEEDING) {
+          const details = action.details;
           return {
-            type: ActionType.OTHER,
-            notes: action.notes || '',
+            type: ActionType.FEEDING,
+            notes: action.notes ?? '',
+            feedType: details.feedType,
+            quantity: details.amount,
+            unit: details.unit,
+            concentration: details.concentration ?? '',
           };
-        }) || []) as InspectionFormData['actions'],
+        }
+
+        if (action.details.type === ActionType.TREATMENT) {
+          const details = action.details;
+          return {
+            type: ActionType.TREATMENT,
+            notes: action.notes ?? '',
+            amount: details.quantity,
+            treatmentType: details.product,
+            unit: details.unit,
+          };
+        }
+
+        if (action.details.type === ActionType.FRAME) {
+          const details = action.details;
+          return {
+            type: ActionType.FRAME,
+            notes: action.notes ?? '',
+            frames: details.quantity,
+          };
+        }
+
+        if (action.details.type === ActionType.MAINTENANCE) {
+          const details = action.details;
+          return {
+            type: ActionType.MAINTENANCE,
+            notes: action.notes ?? '',
+            component: details.component,
+            status: details.status,
+          };
+        }
+
+        if (action.details.type === ActionType.NOTE) {
+          const details = action.details;
+          return {
+            type: ActionType.NOTE,
+            notes: details.content || action.notes || '',
+          };
+        }
+
+        if (action.details.type === ActionType.BOX_CONFIGURATION) {
+          const details = action.details;
+          return {
+            type: ActionType.BOX_CONFIGURATION,
+            boxesAdded: details.boxesAdded,
+            boxesRemoved: details.boxesRemoved,
+            framesAdded: details.framesAdded,
+            framesRemoved: details.framesRemoved,
+            totalBoxes: details.totalBoxes,
+            totalFrames: details.totalFrames,
+            boxesSummary: details.boxes,
+          };
+        }
+
+        return {
+          type: ActionType.OTHER,
+          notes: action.notes || '',
+        };
+      }) || []) as InspectionFormData['actions'],
     },
   });
 
@@ -226,15 +224,22 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
   );
 
   const effectiveBoxes =
-    boxConfigAction?.updatedBoxes ?? summarizedBoxes ?? selectedHive?.boxes ?? [];
+    boxConfigAction?.updatedBoxes ??
+    summarizedBoxes ??
+    selectedHive?.boxes ??
+    [];
 
   const totalFrames =
     effectiveBoxes
       .filter((box: { type: string }) => box.type === 'BROOD')
-      .reduce((sum: number, box: { frameCount: number }) => sum + box.frameCount, 0) || null;
+      .reduce(
+        (sum: number, box: { frameCount: number }) => sum + box.frameCount,
+        0,
+      ) || null;
 
   const broodBoxCount =
-    effectiveBoxes.filter((box: { type: string }) => box.type === 'BROOD').length || null;
+    effectiveBoxes.filter((box: { type: string }) => box.type === 'BROOD')
+      .length || null;
 
   // Live frame (Rähmchen) delta from the form's current FRAME action(s)
   const liveFrameDelta = formActions
@@ -320,6 +325,7 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
   });
 
   const onSubmit = useUpsertInspection(inspectionId, {
+    apiaryId: selectedHive?.apiaryId,
     onBeforeNavigate: async (id: string) => {
       await Promise.all([
         pendingRecordings.length > 0
@@ -456,9 +462,11 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
                           )}
                         >
                           {field.value ? (
-                            isAllDay
-                              ? format(field.value, 'PPP')
-                              : format(field.value, 'PPP HH:mm')
+                            isAllDay ? (
+                              format(field.value, 'PPP')
+                            ) : (
+                              format(field.value, 'PPP HH:mm')
+                            )
                           ) : (
                             <span>{t('inspection:form.pickDate')}</span>
                           )}

--- a/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
@@ -56,7 +56,9 @@ import { applyInspectionModeToFormData } from './mode-behavior';
 import type { Box } from 'shared-schemas';
 
 const normalizeBoxSummary = (
-  boxesSummary: Array<{ type: string; frameCount: number }> | undefined,
+  boxesSummary:
+    | Array<{ type: string; frameCount: number }>
+    | undefined,
   fallbackBoxes: Box[] = [],
 ): Box[] | undefined => {
   if (!boxesSummary?.length) return undefined;
@@ -134,75 +136,75 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
       // discriminant (`type`) optional and breaks discriminated-union narrowing.
       // The mapping below produces correctly-shaped action objects at runtime.
       actions: (inspection?.actions?.map(action => {
-        if (action.details.type === ActionType.FEEDING) {
-          const details = action.details;
-          return {
-            type: ActionType.FEEDING,
-            notes: action.notes ?? '',
-            feedType: details.feedType,
-            quantity: details.amount,
-            unit: details.unit,
-            concentration: details.concentration ?? '',
-          };
-        }
+          if (action.details.type === ActionType.FEEDING) {
+            const details = action.details;
+            return {
+              type: ActionType.FEEDING,
+              notes: action.notes ?? '',
+              feedType: details.feedType,
+              quantity: details.amount,
+              unit: details.unit,
+              concentration: details.concentration ?? '',
+            };
+          }
 
-        if (action.details.type === ActionType.TREATMENT) {
-          const details = action.details;
-          return {
-            type: ActionType.TREATMENT,
-            notes: action.notes ?? '',
-            amount: details.quantity,
-            treatmentType: details.product,
-            unit: details.unit,
-          };
-        }
+          if (action.details.type === ActionType.TREATMENT) {
+            const details = action.details;
+            return {
+              type: ActionType.TREATMENT,
+              notes: action.notes ?? '',
+              amount: details.quantity,
+              treatmentType: details.product,
+              unit: details.unit,
+            };
+          }
 
-        if (action.details.type === ActionType.FRAME) {
-          const details = action.details;
-          return {
-            type: ActionType.FRAME,
-            notes: action.notes ?? '',
-            frames: details.quantity,
-          };
-        }
+          if (action.details.type === ActionType.FRAME) {
+            const details = action.details;
+            return {
+              type: ActionType.FRAME,
+              notes: action.notes ?? '',
+              frames: details.quantity,
+            };
+          }
 
-        if (action.details.type === ActionType.MAINTENANCE) {
-          const details = action.details;
-          return {
-            type: ActionType.MAINTENANCE,
-            notes: action.notes ?? '',
-            component: details.component,
-            status: details.status,
-          };
-        }
+          if (action.details.type === ActionType.MAINTENANCE) {
+            const details = action.details;
+            return {
+              type: ActionType.MAINTENANCE,
+              notes: action.notes ?? '',
+              component: details.component,
+              status: details.status,
+            };
+          }
 
-        if (action.details.type === ActionType.NOTE) {
-          const details = action.details;
-          return {
-            type: ActionType.NOTE,
-            notes: details.content || action.notes || '',
-          };
-        }
+          if (action.details.type === ActionType.NOTE) {
+            const details = action.details;
+            return {
+              type: ActionType.NOTE,
+              notes: details.content || action.notes || '',
+            };
+          }
 
-        if (action.details.type === ActionType.BOX_CONFIGURATION) {
-          const details = action.details;
-          return {
-            type: ActionType.BOX_CONFIGURATION,
-            boxesAdded: details.boxesAdded,
-            boxesRemoved: details.boxesRemoved,
-            framesAdded: details.framesAdded,
-            framesRemoved: details.framesRemoved,
-            totalBoxes: details.totalBoxes,
-            totalFrames: details.totalFrames,
-            boxesSummary: details.boxes,
-          };
-        }
+          if (action.details.type === ActionType.BOX_CONFIGURATION) {
+            const details = action.details;
+            return {
+              type: ActionType.BOX_CONFIGURATION,
+              boxesAdded: details.boxesAdded,
+              boxesRemoved: details.boxesRemoved,
+              framesAdded: details.framesAdded,
+              framesRemoved: details.framesRemoved,
+              totalBoxes: details.totalBoxes,
+              totalFrames: details.totalFrames,
+              boxesSummary: details.boxes,
+            };
+          }
 
-        return {
-          type: ActionType.OTHER,
-          notes: action.notes || '',
-        };
-      }) || []) as InspectionFormData['actions'],
+          return {
+            type: ActionType.OTHER,
+            notes: action.notes || '',
+          };
+        }) || []) as InspectionFormData['actions'],
     },
   });
 
@@ -224,22 +226,15 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
   );
 
   const effectiveBoxes =
-    boxConfigAction?.updatedBoxes ??
-    summarizedBoxes ??
-    selectedHive?.boxes ??
-    [];
+    boxConfigAction?.updatedBoxes ?? summarizedBoxes ?? selectedHive?.boxes ?? [];
 
   const totalFrames =
     effectiveBoxes
       .filter((box: { type: string }) => box.type === 'BROOD')
-      .reduce(
-        (sum: number, box: { frameCount: number }) => sum + box.frameCount,
-        0,
-      ) || null;
+      .reduce((sum: number, box: { frameCount: number }) => sum + box.frameCount, 0) || null;
 
   const broodBoxCount =
-    effectiveBoxes.filter((box: { type: string }) => box.type === 'BROOD')
-      .length || null;
+    effectiveBoxes.filter((box: { type: string }) => box.type === 'BROOD').length || null;
 
   // Live frame (Rähmchen) delta from the form's current FRAME action(s)
   const liveFrameDelta = formActions
@@ -325,6 +320,7 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
   });
 
   const onSubmit = useUpsertInspection(inspectionId, {
+    // The hive's own apiary — required for cross-apiary writes in view-all mode.
     apiaryId: selectedHive?.apiaryId,
     onBeforeNavigate: async (id: string) => {
       await Promise.all([
@@ -462,11 +458,9 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
                           )}
                         >
                           {field.value ? (
-                            isAllDay ? (
-                              format(field.value, 'PPP')
-                            ) : (
-                              format(field.value, 'PPP HH:mm')
-                            )
+                            isAllDay
+                              ? format(field.value, 'PPP')
+                              : format(field.value, 'PPP HH:mm')
                           ) : (
                             <span>{t('inspection:form.pickDate')}</span>
                           )}

--- a/apps/frontend/src/pages/inspection/components/inspection-status-card.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-status-card.tsx
@@ -10,6 +10,7 @@ type InspectionStatusCardProps = {
   inspectionId: string;
   status: InspectionStatus;
   inspectionDate: string;
+  apiaryId?: string;
 };
 
 /**
@@ -20,6 +21,7 @@ type InspectionStatusCardProps = {
 export const InspectionStatusCard = ({
   inspectionId,
   status,
+  apiaryId,
 }: InspectionStatusCardProps) => {
   const { t } = useTranslation('inspection');
   const queryClient = useQueryClient();
@@ -33,7 +35,11 @@ export const InspectionStatusCard = ({
 
   const handleComplete = () =>
     updateInspection(
-      { id: inspectionId, data: { status: InspectionStatus.COMPLETED } },
+      {
+        id: inspectionId,
+        data: { status: InspectionStatus.COMPLETED },
+        apiaryId,
+      },
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ['inspections'] });
@@ -43,7 +49,11 @@ export const InspectionStatusCard = ({
 
   const handleCancel = () =>
     updateInspection(
-      { id: inspectionId, data: { status: InspectionStatus.CANCELLED } },
+      {
+        id: inspectionId,
+        data: { status: InspectionStatus.CANCELLED },
+        apiaryId,
+      },
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ['inspections'] });

--- a/apps/frontend/src/pages/inspection/components/scheduled-inspection-card.tsx
+++ b/apps/frontend/src/pages/inspection/components/scheduled-inspection-card.tsx
@@ -37,6 +37,7 @@ import {
 import { cn } from '@/lib/utils';
 import { InspectionResponse, InspectionStatus } from 'shared-schemas';
 import { useUpdateInspection } from '@/api/hooks/useInspections';
+import { useHiveApiaryLookup } from '@/api/hooks/useHives';
 import { getInspectionDisplayDate } from '@/utils/inspection-display-date';
 import { toInspectionDateISOString } from '@/utils/inspection-date';
 import { RescheduleDialog } from './reschedule-dialog';
@@ -66,6 +67,8 @@ export const ScheduledInspectionCard: React.FC<
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [showRescheduleDialog, setShowRescheduleDialog] = useState(false);
   const { mutate: updateInspection, isPending } = useUpdateInspection();
+  const lookupApiaryId = useHiveApiaryLookup();
+  const apiaryId = lookupApiaryId(inspection.hiveId);
 
   const inspectionDate = getInspectionDisplayDate(inspection);
   const isOverdue = isPast(inspectionDate) && !isToday(inspectionDate);
@@ -82,6 +85,7 @@ export const ScheduledInspectionCard: React.FC<
         data: {
           status: InspectionStatus.CANCELLED,
         },
+        apiaryId,
       },
       {
         onSuccess: () => {
@@ -101,6 +105,7 @@ export const ScheduledInspectionCard: React.FC<
           isAllDay,
           status: InspectionStatus.SCHEDULED,
         },
+        apiaryId,
       },
       {
         onSuccess: () => {
@@ -160,7 +165,9 @@ export const ScheduledInspectionCard: React.FC<
                 <span className="font-medium text-foreground">
                   {format(inspectionDate, 'MMM d')}
                 </span>
-                {!inspection.isAllDay && <span>{format(inspectionDate, 'h:mm a')}</span>}
+                {!inspection.isAllDay && (
+                  <span>{format(inspectionDate, 'h:mm a')}</span>
+                )}
               </div>
 
               {/* Status Badge */}

--- a/apps/frontend/src/pages/inspection/inspection-detail-page.tsx
+++ b/apps/frontend/src/pages/inspection/inspection-detail-page.tsx
@@ -167,6 +167,7 @@ export const InspectionDetailPage = () => {
               inspectionId={inspection.id}
               status={inspection.status}
               inspectionDate={inspection.date}
+              apiaryId={hive.apiaryId}
             />
           </div>
 

--- a/apps/frontend/src/pages/inspection/mobile-wizard/mobile-wizard-page.tsx
+++ b/apps/frontend/src/pages/inspection/mobile-wizard/mobile-wizard-page.tsx
@@ -45,7 +45,9 @@ export function MobileWizardPage() {
   }, [hive]);
 
   const form = useForm<InspectionFormData>({
-    resolver: zodResolver(isSubjective ? subjectiveInspectionSchema : inspectionSchema),
+    resolver: zodResolver(
+      isSubjective ? subjectiveInspectionSchema : inspectionSchema,
+    ),
     defaultValues: {
       hiveId,
       date: new Date(),
@@ -56,10 +58,13 @@ export function MobileWizardPage() {
   });
 
   const [pendingPhotos, setPendingPhotos] = useState<PendingPhoto[]>([]);
-  const [pendingRecordings, setPendingRecordings] = useState<PendingRecording[]>([]);
+  const [pendingRecordings, setPendingRecordings] = useState<
+    PendingRecording[]
+  >([]);
   const [stepIndex, setStepIndex] = useState(0);
 
   const upsert = useUpsertInspection(undefined, {
+    apiaryId: hive?.apiaryId,
     onBeforeNavigate: async (id: string) => {
       await Promise.all([
         pendingRecordings.length > 0
@@ -123,13 +128,7 @@ export function MobileWizardPage() {
         ),
       },
     ],
-    [
-      t,
-      isSubjective,
-      broodFrameCapacity,
-      pendingPhotos,
-      pendingRecordings,
-    ],
+    [t, isSubjective, broodFrameCapacity, pendingPhotos, pendingRecordings],
   );
 
   const isLastStep = stepIndex === steps.length - 1;

--- a/apps/frontend/src/pages/inspection/mobile-wizard/mobile-wizard-page.tsx
+++ b/apps/frontend/src/pages/inspection/mobile-wizard/mobile-wizard-page.tsx
@@ -45,9 +45,7 @@ export function MobileWizardPage() {
   }, [hive]);
 
   const form = useForm<InspectionFormData>({
-    resolver: zodResolver(
-      isSubjective ? subjectiveInspectionSchema : inspectionSchema,
-    ),
+    resolver: zodResolver(isSubjective ? subjectiveInspectionSchema : inspectionSchema),
     defaultValues: {
       hiveId,
       date: new Date(),
@@ -58,12 +56,11 @@ export function MobileWizardPage() {
   });
 
   const [pendingPhotos, setPendingPhotos] = useState<PendingPhoto[]>([]);
-  const [pendingRecordings, setPendingRecordings] = useState<
-    PendingRecording[]
-  >([]);
+  const [pendingRecordings, setPendingRecordings] = useState<PendingRecording[]>([]);
   const [stepIndex, setStepIndex] = useState(0);
 
   const upsert = useUpsertInspection(undefined, {
+    // The hive's own apiary — required for cross-apiary writes in view-all mode.
     apiaryId: hive?.apiaryId,
     onBeforeNavigate: async (id: string) => {
       await Promise.all([
@@ -128,7 +125,13 @@ export function MobileWizardPage() {
         ),
       },
     ],
-    [t, isSubjective, broodFrameCapacity, pendingPhotos, pendingRecordings],
+    [
+      t,
+      isSubjective,
+      broodFrameCapacity,
+      pendingPhotos,
+      pendingRecordings,
+    ],
   );
 
   const isLastStep = stepIndex === steps.length - 1;

--- a/apps/frontend/src/pages/inspection/schedule-inspection.tsx
+++ b/apps/frontend/src/pages/inspection/schedule-inspection.tsx
@@ -154,9 +154,7 @@ export const ScheduleInspectionPage = () => {
         },
         {
           onSuccess: batch => {
-            toast.success(
-              t('inspection:schedule.batchCreated', { name: batchName }),
-            );
+            toast.success(t('inspection:schedule.batchCreated', { name: batchName }));
             navigate(`/batch-inspections/${batch.id}`);
           },
           onError: error => {
@@ -209,26 +207,12 @@ export const ScheduleInspectionPage = () => {
       }
 
       if (successCount > 0) {
-        toast.success(
-          t(
-            successCount > 1
-              ? 'inspection:schedule.scheduledSuccessPlural'
-              : 'inspection:schedule.scheduledSuccess',
-            { count: successCount },
-          ),
-        );
+        toast.success(t(successCount > 1 ? 'inspection:schedule.scheduledSuccessPlural' : 'inspection:schedule.scheduledSuccess', { count: successCount }));
         navigate('/inspections/list/upcoming');
       }
 
       if (errorCount > 0) {
-        toast.error(
-          t(
-            errorCount > 1
-              ? 'inspection:schedule.scheduledFailedPlural'
-              : 'inspection:schedule.scheduledFailed',
-            { count: errorCount },
-          ),
-        );
+        toast.error(t(errorCount > 1 ? 'inspection:schedule.scheduledFailedPlural' : 'inspection:schedule.scheduledFailed', { count: errorCount }));
       }
     }
   });
@@ -301,9 +285,7 @@ export const ScheduleInspectionPage = () => {
   return (
     <div className="max-w-6xl mx-auto p-4">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold mb-2">
-          {t('inspection:schedule.title')}
-        </h1>
+        <h1 className="text-2xl font-bold mb-2">{t('inspection:schedule.title')}</h1>
         <p className="text-muted-foreground">
           {t('inspection:schedule.description')}
         </p>
@@ -320,12 +302,7 @@ export const ScheduleInspectionPage = () => {
               {selectedHiveIds.length > 0 && (
                 <div className="flex items-center gap-2 mt-2">
                   <Badge variant="secondary">
-                    {t(
-                      selectedHiveIds.length !== 1
-                        ? 'inspection:schedule.hivesSelectedPlural'
-                        : 'inspection:schedule.hivesSelected',
-                      { count: selectedHiveIds.length },
-                    )}
+                    {t(selectedHiveIds.length !== 1 ? 'inspection:schedule.hivesSelectedPlural' : 'inspection:schedule.hivesSelected', { count: selectedHiveIds.length })}
                   </Badge>
                   <Button
                     type="button"
@@ -405,9 +382,7 @@ export const ScheduleInspectionPage = () => {
             <CardHeader>
               <CardTitle>{t('inspection:schedule.scheduleCalendar')}</CardTitle>
               <CardDescription>
-                {t('inspection:schedule.calendarDescription', {
-                  days: daysToShow,
-                })}
+                {t('inspection:schedule.calendarDescription', { days: daysToShow })}
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -461,9 +436,7 @@ export const ScheduleInspectionPage = () => {
                           <CardContent className="p-4">
                             <div className="flex items-center justify-between mb-2">
                               <div className="font-semibold text-sm">
-                                {isToday
-                                  ? t('inspection:schedule.today')
-                                  : format(day, 'EEE')}
+                                {isToday ? t('inspection:schedule.today') : format(day, 'EEE')}
                               </div>
                               {isSelected && (
                                 <CalendarPlus className="h-4 w-4 text-primary" />
@@ -534,26 +507,14 @@ export const ScheduleInspectionPage = () => {
           {selectedDate && selectedHiveIds.length > 0 && (
             <Card>
               <CardHeader>
-                <CardTitle>
-                  {t('inspection:schedule.inspectionDetails')}
-                </CardTitle>
+                <CardTitle>{t('inspection:schedule.inspectionDetails')}</CardTitle>
                 <CardDescription>
-                  {t(
-                    selectedHiveIds.length !== 1
-                      ? 'inspection:schedule.schedulingCountPlural'
-                      : 'inspection:schedule.schedulingCount',
-                    {
-                      count: selectedHiveIds.length,
-                      date: format(selectedDate, 'EEEE, MMMM d, yyyy'),
-                    },
-                  )}
+                  {t(selectedHiveIds.length !== 1 ? 'inspection:schedule.schedulingCountPlural' : 'inspection:schedule.schedulingCount', { count: selectedHiveIds.length, date: format(selectedDate, 'EEEE, MMMM d, yyyy') })}
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="mb-4">
-                  <label className="text-sm font-medium">
-                    {t('inspection:schedule.selectedHives')}
-                  </label>
+                  <label className="text-sm font-medium">{t('inspection:schedule.selectedHives')}</label>
                   <div className="flex flex-wrap gap-2 mt-2">
                     {selectedHiveIds.map(hiveId => {
                       const hive = hives?.find(h => h.id === hiveId);
@@ -575,9 +536,7 @@ export const ScheduleInspectionPage = () => {
                       setSelectedDate(d);
                       form.setValue('date', d);
                     }}
-                    onIsAllDayChange={checked =>
-                      form.setValue('isAllDay', checked)
-                    }
+                    onIsAllDayChange={checked => form.setValue('isAllDay', checked)}
                     switchId="scheduleIsAllDay"
                   />
                 </div>
@@ -595,9 +554,7 @@ export const ScheduleInspectionPage = () => {
                           />
                         </FormControl>
                         <div className="space-y-1 leading-none">
-                          <FormLabel>
-                            {t('inspection:schedule.createAsBatch')}
-                          </FormLabel>
+                          <FormLabel>{t('inspection:schedule.createAsBatch')}</FormLabel>
                           <p className="text-sm text-muted-foreground">
                             {t('inspection:schedule.batchDescription')}
                           </p>
@@ -613,14 +570,10 @@ export const ScheduleInspectionPage = () => {
                     name="batchName"
                     render={({ field }) => (
                       <FormItem className="mb-4">
-                        <FormLabel>
-                          {t('inspection:schedule.batchName')}
-                        </FormLabel>
+                        <FormLabel>{t('inspection:schedule.batchName')}</FormLabel>
                         <FormControl>
                           <Input
-                            placeholder={t(
-                              'inspection:schedule.batchNamePlaceholder',
-                            )}
+                            placeholder={t('inspection:schedule.batchNamePlaceholder')}
                             {...field}
                           />
                         </FormControl>
@@ -636,14 +589,10 @@ export const ScheduleInspectionPage = () => {
                     name="notes"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>
-                          {t('inspection:schedule.notesOptional')}
-                        </FormLabel>
+                        <FormLabel>{t('inspection:schedule.notesOptional')}</FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={t(
-                              'inspection:schedule.notesPlaceholder',
-                            )}
+                            placeholder={t('inspection:schedule.notesPlaceholder')}
                             className="min-h-[100px]"
                             {...field}
                           />
@@ -673,12 +622,7 @@ export const ScheduleInspectionPage = () => {
                 <Button type="submit" className="w-full mt-6">
                   {createAsBatch
                     ? t('inspection:schedule.createBatchInspection')
-                    : t(
-                        selectedHiveIds.length !== 1
-                          ? 'inspection:schedule.scheduleCountPlural'
-                          : 'inspection:schedule.scheduleCount',
-                        { count: selectedHiveIds.length },
-                      )}
+                    : t(selectedHiveIds.length !== 1 ? 'inspection:schedule.scheduleCountPlural' : 'inspection:schedule.scheduleCount', { count: selectedHiveIds.length })}
                 </Button>
               </CardContent>
             </Card>

--- a/apps/frontend/src/pages/inspection/schedule-inspection.tsx
+++ b/apps/frontend/src/pages/inspection/schedule-inspection.tsx
@@ -154,7 +154,9 @@ export const ScheduleInspectionPage = () => {
         },
         {
           onSuccess: batch => {
-            toast.success(t('inspection:schedule.batchCreated', { name: batchName }));
+            toast.success(
+              t('inspection:schedule.batchCreated', { name: batchName }),
+            );
             navigate(`/batch-inspections/${batch.id}`);
           },
           onError: error => {
@@ -170,15 +172,20 @@ export const ScheduleInspectionPage = () => {
 
       for (const hiveId of hiveIds) {
         try {
+          // Each hive may live in a different apiary in view-all mode.
+          const hiveApiaryId = hives?.find(h => h.id === hiveId)?.apiaryId;
           await new Promise<void>((resolve, reject) => {
             createInspection(
               {
-                hiveId,
-                date: toInspectionDateISOString(date, isAllDay),
-                isAllDay,
-                notes,
-                status: InspectionStatus.SCHEDULED,
-                actions: [],
+                data: {
+                  hiveId,
+                  date: toInspectionDateISOString(date, isAllDay),
+                  isAllDay,
+                  notes,
+                  status: InspectionStatus.SCHEDULED,
+                  actions: [],
+                },
+                apiaryId: hiveApiaryId,
               },
               {
                 onSuccess: () => {
@@ -202,12 +209,26 @@ export const ScheduleInspectionPage = () => {
       }
 
       if (successCount > 0) {
-        toast.success(t(successCount > 1 ? 'inspection:schedule.scheduledSuccessPlural' : 'inspection:schedule.scheduledSuccess', { count: successCount }));
+        toast.success(
+          t(
+            successCount > 1
+              ? 'inspection:schedule.scheduledSuccessPlural'
+              : 'inspection:schedule.scheduledSuccess',
+            { count: successCount },
+          ),
+        );
         navigate('/inspections/list/upcoming');
       }
 
       if (errorCount > 0) {
-        toast.error(t(errorCount > 1 ? 'inspection:schedule.scheduledFailedPlural' : 'inspection:schedule.scheduledFailed', { count: errorCount }));
+        toast.error(
+          t(
+            errorCount > 1
+              ? 'inspection:schedule.scheduledFailedPlural'
+              : 'inspection:schedule.scheduledFailed',
+            { count: errorCount },
+          ),
+        );
       }
     }
   });
@@ -280,7 +301,9 @@ export const ScheduleInspectionPage = () => {
   return (
     <div className="max-w-6xl mx-auto p-4">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold mb-2">{t('inspection:schedule.title')}</h1>
+        <h1 className="text-2xl font-bold mb-2">
+          {t('inspection:schedule.title')}
+        </h1>
         <p className="text-muted-foreground">
           {t('inspection:schedule.description')}
         </p>
@@ -297,7 +320,12 @@ export const ScheduleInspectionPage = () => {
               {selectedHiveIds.length > 0 && (
                 <div className="flex items-center gap-2 mt-2">
                   <Badge variant="secondary">
-                    {t(selectedHiveIds.length !== 1 ? 'inspection:schedule.hivesSelectedPlural' : 'inspection:schedule.hivesSelected', { count: selectedHiveIds.length })}
+                    {t(
+                      selectedHiveIds.length !== 1
+                        ? 'inspection:schedule.hivesSelectedPlural'
+                        : 'inspection:schedule.hivesSelected',
+                      { count: selectedHiveIds.length },
+                    )}
                   </Badge>
                   <Button
                     type="button"
@@ -377,7 +405,9 @@ export const ScheduleInspectionPage = () => {
             <CardHeader>
               <CardTitle>{t('inspection:schedule.scheduleCalendar')}</CardTitle>
               <CardDescription>
-                {t('inspection:schedule.calendarDescription', { days: daysToShow })}
+                {t('inspection:schedule.calendarDescription', {
+                  days: daysToShow,
+                })}
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -431,7 +461,9 @@ export const ScheduleInspectionPage = () => {
                           <CardContent className="p-4">
                             <div className="flex items-center justify-between mb-2">
                               <div className="font-semibold text-sm">
-                                {isToday ? t('inspection:schedule.today') : format(day, 'EEE')}
+                                {isToday
+                                  ? t('inspection:schedule.today')
+                                  : format(day, 'EEE')}
                               </div>
                               {isSelected && (
                                 <CalendarPlus className="h-4 w-4 text-primary" />
@@ -502,14 +534,26 @@ export const ScheduleInspectionPage = () => {
           {selectedDate && selectedHiveIds.length > 0 && (
             <Card>
               <CardHeader>
-                <CardTitle>{t('inspection:schedule.inspectionDetails')}</CardTitle>
+                <CardTitle>
+                  {t('inspection:schedule.inspectionDetails')}
+                </CardTitle>
                 <CardDescription>
-                  {t(selectedHiveIds.length !== 1 ? 'inspection:schedule.schedulingCountPlural' : 'inspection:schedule.schedulingCount', { count: selectedHiveIds.length, date: format(selectedDate, 'EEEE, MMMM d, yyyy') })}
+                  {t(
+                    selectedHiveIds.length !== 1
+                      ? 'inspection:schedule.schedulingCountPlural'
+                      : 'inspection:schedule.schedulingCount',
+                    {
+                      count: selectedHiveIds.length,
+                      date: format(selectedDate, 'EEEE, MMMM d, yyyy'),
+                    },
+                  )}
                 </CardDescription>
               </CardHeader>
               <CardContent>
                 <div className="mb-4">
-                  <label className="text-sm font-medium">{t('inspection:schedule.selectedHives')}</label>
+                  <label className="text-sm font-medium">
+                    {t('inspection:schedule.selectedHives')}
+                  </label>
                   <div className="flex flex-wrap gap-2 mt-2">
                     {selectedHiveIds.map(hiveId => {
                       const hive = hives?.find(h => h.id === hiveId);
@@ -531,7 +575,9 @@ export const ScheduleInspectionPage = () => {
                       setSelectedDate(d);
                       form.setValue('date', d);
                     }}
-                    onIsAllDayChange={checked => form.setValue('isAllDay', checked)}
+                    onIsAllDayChange={checked =>
+                      form.setValue('isAllDay', checked)
+                    }
                     switchId="scheduleIsAllDay"
                   />
                 </div>
@@ -549,7 +595,9 @@ export const ScheduleInspectionPage = () => {
                           />
                         </FormControl>
                         <div className="space-y-1 leading-none">
-                          <FormLabel>{t('inspection:schedule.createAsBatch')}</FormLabel>
+                          <FormLabel>
+                            {t('inspection:schedule.createAsBatch')}
+                          </FormLabel>
                           <p className="text-sm text-muted-foreground">
                             {t('inspection:schedule.batchDescription')}
                           </p>
@@ -565,10 +613,14 @@ export const ScheduleInspectionPage = () => {
                     name="batchName"
                     render={({ field }) => (
                       <FormItem className="mb-4">
-                        <FormLabel>{t('inspection:schedule.batchName')}</FormLabel>
+                        <FormLabel>
+                          {t('inspection:schedule.batchName')}
+                        </FormLabel>
                         <FormControl>
                           <Input
-                            placeholder={t('inspection:schedule.batchNamePlaceholder')}
+                            placeholder={t(
+                              'inspection:schedule.batchNamePlaceholder',
+                            )}
                             {...field}
                           />
                         </FormControl>
@@ -584,10 +636,14 @@ export const ScheduleInspectionPage = () => {
                     name="notes"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>{t('inspection:schedule.notesOptional')}</FormLabel>
+                        <FormLabel>
+                          {t('inspection:schedule.notesOptional')}
+                        </FormLabel>
                         <FormControl>
                           <Textarea
-                            placeholder={t('inspection:schedule.notesPlaceholder')}
+                            placeholder={t(
+                              'inspection:schedule.notesPlaceholder',
+                            )}
                             className="min-h-[100px]"
                             {...field}
                           />
@@ -617,7 +673,12 @@ export const ScheduleInspectionPage = () => {
                 <Button type="submit" className="w-full mt-6">
                   {createAsBatch
                     ? t('inspection:schedule.createBatchInspection')
-                    : t(selectedHiveIds.length !== 1 ? 'inspection:schedule.scheduleCountPlural' : 'inspection:schedule.scheduleCount', { count: selectedHiveIds.length })}
+                    : t(
+                        selectedHiveIds.length !== 1
+                          ? 'inspection:schedule.scheduleCountPlural'
+                          : 'inspection:schedule.scheduleCount',
+                        { count: selectedHiveIds.length },
+                      )}
                 </Button>
               </CardContent>
             </Card>

--- a/apps/frontend/src/pages/todo/todo-list-page.tsx
+++ b/apps/frontend/src/pages/todo/todo-list-page.tsx
@@ -14,12 +14,14 @@ import {
 } from '@/components/sidebar';
 import { RefreshButton } from '@/components/sidebar/refresh-button';
 import { useTodos } from '@/api/hooks/useTodos';
+import { useApiary } from '@/hooks/use-apiary';
 import { TodoQuickAdd } from './components/todo-quick-add';
 import { TodoList } from './components/todo-list';
 
 export const TodoListPage = () => {
   const { t } = useTranslation(['todo', 'common']);
   const { data, isLoading, refetch } = useTodos();
+  const { viewAllApiaries } = useApiary();
   const [showCompleted, setShowCompleted] = useState(false);
 
   const allTodos = data ?? [];
@@ -33,7 +35,11 @@ export const TodoListPage = () => {
         <div className="space-y-6">
           <div>
             <h1 className="text-2xl font-bold">{t('todo:list.title')}</h1>
-            <p className="text-muted-foreground">{t('todo:list.caption')}</p>
+            <p className="text-muted-foreground">
+              {t(
+                viewAllApiaries ? 'todo:list.captionAll' : 'todo:list.caption',
+              )}
+            </p>
           </div>
 
           <TodoQuickAdd />

--- a/apps/frontend/src/pages/tools/demaree-method-page.tsx
+++ b/apps/frontend/src/pages/tools/demaree-method-page.tsx
@@ -61,7 +61,8 @@ type EditableCheckpoint = DemareeCheckpointPlan & {
 
 const warningVariantClasses: Record<DemareeWarningCode, string> = {
   lateQueenCellCheck: 'border-amber-300 bg-amber-50 dark:bg-amber-950/30',
-  unsafeCheckpointSpacing: 'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
+  unsafeCheckpointSpacing:
+    'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
   illogicalScheduleOrder: 'border-red-300 bg-red-50 dark:bg-red-950/30',
 };
 
@@ -69,7 +70,9 @@ function buildCheckpointNotes(
   checkpoint: DemareeCheckpointPlan,
   t: (key: string, options?: Record<string, unknown>) => string,
 ) {
-  const checklist = checkpoint.checklistKeys.map(key => `- ${t(key)}`).join('\n');
+  const checklist = checkpoint.checklistKeys
+    .map(key => `- ${t(key)}`)
+    .join('\n');
 
   return [
     `${t('swarmManagement.planner.checkpointPrefix')} ${t(checkpoint.titleKey)}`,
@@ -143,7 +146,10 @@ export function DemareeMethodPage() {
   const [startDate, setStartDate] = useState<Date | undefined>();
   const [checkpoints, setCheckpoints] = useState<EditableCheckpoint[]>([]);
 
-  const warnings = useMemo(() => getDemareeWarnings(checkpoints), [checkpoints]);
+  const warnings = useMemo(
+    () => getDemareeWarnings(checkpoints),
+    [checkpoints],
+  );
 
   const selectedHive = hives.find(hive => hive.id === selectedHiveId);
 
@@ -185,12 +191,15 @@ export function DemareeMethodPage() {
     const results = await Promise.allSettled(
       checkpoints.map(checkpoint =>
         createInspection({
-          hiveId: selectedHiveId,
-          date: toInspectionDateISOString(checkpoint.date, true),
-          isAllDay: true,
-          notes: checkpoint.notes,
-          status: InspectionStatus.SCHEDULED,
-          actions: [],
+          data: {
+            hiveId: selectedHiveId,
+            date: toInspectionDateISOString(checkpoint.date, true),
+            isAllDay: true,
+            notes: checkpoint.notes,
+            status: InspectionStatus.SCHEDULED,
+            actions: [],
+          },
+          apiaryId: selectedHive?.apiaryId,
         }),
       ),
     );
@@ -342,7 +351,9 @@ export function DemareeMethodPage() {
         <ToolPageHeader
           title={t('swarmManagement.demaree.title')}
           badge={
-            <Badge variant="outline">{t('swarmManagement.demaree.badge')}</Badge>
+            <Badge variant="outline">
+              {t('swarmManagement.demaree.badge')}
+            </Badge>
           }
           description={t('swarmManagement.demaree.description')}
           intro={t('swarmManagement.demaree.intro')}
@@ -355,7 +366,9 @@ export function DemareeMethodPage() {
         <div className="space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.overviewTitle')}</CardTitle>
+              <CardTitle>
+                {t('swarmManagement.demaree.overviewTitle')}
+              </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4 text-sm text-muted-foreground">
               <p>{t('swarmManagement.demaree.overviewLead')}</p>
@@ -370,12 +383,16 @@ export function DemareeMethodPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.prerequisitesTitle')}</CardTitle>
+              <CardTitle>
+                {t('swarmManagement.demaree.prerequisitesTitle')}
+              </CardTitle>
             </CardHeader>
             <CardContent>
               <ul className="list-disc space-y-3 pl-5 text-sm text-muted-foreground marker:text-primary/60">
                 {[0, 1, 2, 3, 4, 5].map(i => (
-                  <li key={i}>{t(`swarmManagement.demaree.prerequisites.${i}`)}</li>
+                  <li key={i}>
+                    {t(`swarmManagement.demaree.prerequisites.${i}`)}
+                  </li>
                 ))}
               </ul>
             </CardContent>
@@ -383,7 +400,9 @@ export function DemareeMethodPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.advantagesTitle')}</CardTitle>
+              <CardTitle>
+                {t('swarmManagement.demaree.advantagesTitle')}
+              </CardTitle>
               <CardDescription>
                 {t('swarmManagement.demaree.advantagesDescription')}
               </CardDescription>
@@ -409,7 +428,9 @@ export function DemareeMethodPage() {
                 {METHOD_DETAIL_SECTIONS.map(section => (
                   <div key={section.id} className="space-y-3">
                     <h3 className="font-semibold text-foreground">
-                      {t(`swarmManagement.demaree.methodDetail.${section.id}.title`)}
+                      {t(
+                        `swarmManagement.demaree.methodDetail.${section.id}.title`,
+                      )}
                     </h3>
                     <ul className="list-disc space-y-2 pl-5 marker:text-primary/60">
                       {section.items.map(itemIndex => (
@@ -421,13 +442,15 @@ export function DemareeMethodPage() {
                           </span>
                           {(section.children[itemIndex] ?? []).length > 0 && (
                             <ul className="list-[circle] space-y-2 pl-5 pt-2 marker:text-muted-foreground/60">
-                              {(section.children[itemIndex] ?? []).map(childIndex => (
-                                <li key={childIndex}>
-                                  {t(
-                                    `swarmManagement.demaree.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
-                                  )}
-                                </li>
-                              ))}
+                              {(section.children[itemIndex] ?? []).map(
+                                childIndex => (
+                                  <li key={childIndex}>
+                                    {t(
+                                      `swarmManagement.demaree.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
+                                    )}
+                                  </li>
+                                ),
+                              )}
                             </ul>
                           )}
                         </li>
@@ -441,7 +464,9 @@ export function DemareeMethodPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.followUpTitle')}</CardTitle>
+              <CardTitle>
+                {t('swarmManagement.demaree.followUpTitle')}
+              </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="overflow-hidden rounded-lg border">
@@ -468,15 +493,21 @@ export function DemareeMethodPage() {
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
                   {t('swarmManagement.aside.criticalTimingTitle')}
                 </p>
-                <p className="mt-2">{t('swarmManagement.aside.criticalTimingLead')}</p>
-                <p className="mt-2">{t('swarmManagement.aside.criticalTimingDetail')}</p>
+                <p className="mt-2">
+                  {t('swarmManagement.aside.criticalTimingLead')}
+                </p>
+                <p className="mt-2">
+                  {t('swarmManagement.aside.criticalTimingDetail')}
+                </p>
               </div>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader>
-              <CardTitle>{t('swarmManagement.demaree.prosConsTitle')}</CardTitle>
+              <CardTitle>
+                {t('swarmManagement.demaree.prosConsTitle')}
+              </CardTitle>
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
@@ -522,7 +553,9 @@ export function DemareeMethodPage() {
                   </p>
                   <div className="mt-4 flex flex-col items-center justify-center gap-2 sm:flex-row">
                     <Button asChild>
-                      <Link to="/login">{t('swarmManagement.planner.signInCta')}</Link>
+                      <Link to="/login">
+                        {t('swarmManagement.planner.signInCta')}
+                      </Link>
                     </Button>
                     <Button variant="outline" asChild>
                       <Link to="/register">
@@ -603,7 +636,9 @@ export function DemareeMethodPage() {
                             <CardHeader>
                               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                                 <div className="min-w-0">
-                                  <CardTitle>{t(checkpoint.titleKey)}</CardTitle>
+                                  <CardTitle>
+                                    {t(checkpoint.titleKey)}
+                                  </CardTitle>
                                   <CardDescription>
                                     {t('swarmManagement.planner.dayOffset', {
                                       count: checkpoint.dayOffset,
@@ -629,7 +664,9 @@ export function DemareeMethodPage() {
                               {checkpointWarnings.map(warning => (
                                 <Alert
                                   key={`${checkpoint.id}-${warning.code}`}
-                                  className={warningVariantClasses[warning.code]}
+                                  className={
+                                    warningVariantClasses[warning.code]
+                                  }
                                 >
                                   <ShieldAlert className="h-4 w-4" />
                                   <AlertTitle>
@@ -685,7 +722,10 @@ export function DemareeMethodPage() {
           </Card>
         </div>
 
-        <ToolFaq title={t('swarmManagement.demaree.faq.title')} items={faqItems} />
+        <ToolFaq
+          title={t('swarmManagement.demaree.faq.title')}
+          items={faqItems}
+        />
       </MainContent>
 
       <PageAside>

--- a/apps/frontend/src/pages/tools/demaree-method-page.tsx
+++ b/apps/frontend/src/pages/tools/demaree-method-page.tsx
@@ -61,8 +61,7 @@ type EditableCheckpoint = DemareeCheckpointPlan & {
 
 const warningVariantClasses: Record<DemareeWarningCode, string> = {
   lateQueenCellCheck: 'border-amber-300 bg-amber-50 dark:bg-amber-950/30',
-  unsafeCheckpointSpacing:
-    'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
+  unsafeCheckpointSpacing: 'border-orange-300 bg-orange-50 dark:bg-orange-950/30',
   illogicalScheduleOrder: 'border-red-300 bg-red-50 dark:bg-red-950/30',
 };
 
@@ -70,9 +69,7 @@ function buildCheckpointNotes(
   checkpoint: DemareeCheckpointPlan,
   t: (key: string, options?: Record<string, unknown>) => string,
 ) {
-  const checklist = checkpoint.checklistKeys
-    .map(key => `- ${t(key)}`)
-    .join('\n');
+  const checklist = checkpoint.checklistKeys.map(key => `- ${t(key)}`).join('\n');
 
   return [
     `${t('swarmManagement.planner.checkpointPrefix')} ${t(checkpoint.titleKey)}`,
@@ -146,10 +143,7 @@ export function DemareeMethodPage() {
   const [startDate, setStartDate] = useState<Date | undefined>();
   const [checkpoints, setCheckpoints] = useState<EditableCheckpoint[]>([]);
 
-  const warnings = useMemo(
-    () => getDemareeWarnings(checkpoints),
-    [checkpoints],
-  );
+  const warnings = useMemo(() => getDemareeWarnings(checkpoints), [checkpoints]);
 
   const selectedHive = hives.find(hive => hive.id === selectedHiveId);
 
@@ -199,6 +193,7 @@ export function DemareeMethodPage() {
             status: InspectionStatus.SCHEDULED,
             actions: [],
           },
+          // The hive's own apiary — cross-apiary safe in view-all mode.
           apiaryId: selectedHive?.apiaryId,
         }),
       ),
@@ -351,9 +346,7 @@ export function DemareeMethodPage() {
         <ToolPageHeader
           title={t('swarmManagement.demaree.title')}
           badge={
-            <Badge variant="outline">
-              {t('swarmManagement.demaree.badge')}
-            </Badge>
+            <Badge variant="outline">{t('swarmManagement.demaree.badge')}</Badge>
           }
           description={t('swarmManagement.demaree.description')}
           intro={t('swarmManagement.demaree.intro')}
@@ -366,9 +359,7 @@ export function DemareeMethodPage() {
         <div className="space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle>
-                {t('swarmManagement.demaree.overviewTitle')}
-              </CardTitle>
+              <CardTitle>{t('swarmManagement.demaree.overviewTitle')}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4 text-sm text-muted-foreground">
               <p>{t('swarmManagement.demaree.overviewLead')}</p>
@@ -383,16 +374,12 @@ export function DemareeMethodPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle>
-                {t('swarmManagement.demaree.prerequisitesTitle')}
-              </CardTitle>
+              <CardTitle>{t('swarmManagement.demaree.prerequisitesTitle')}</CardTitle>
             </CardHeader>
             <CardContent>
               <ul className="list-disc space-y-3 pl-5 text-sm text-muted-foreground marker:text-primary/60">
                 {[0, 1, 2, 3, 4, 5].map(i => (
-                  <li key={i}>
-                    {t(`swarmManagement.demaree.prerequisites.${i}`)}
-                  </li>
+                  <li key={i}>{t(`swarmManagement.demaree.prerequisites.${i}`)}</li>
                 ))}
               </ul>
             </CardContent>
@@ -400,9 +387,7 @@ export function DemareeMethodPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle>
-                {t('swarmManagement.demaree.advantagesTitle')}
-              </CardTitle>
+              <CardTitle>{t('swarmManagement.demaree.advantagesTitle')}</CardTitle>
               <CardDescription>
                 {t('swarmManagement.demaree.advantagesDescription')}
               </CardDescription>
@@ -428,9 +413,7 @@ export function DemareeMethodPage() {
                 {METHOD_DETAIL_SECTIONS.map(section => (
                   <div key={section.id} className="space-y-3">
                     <h3 className="font-semibold text-foreground">
-                      {t(
-                        `swarmManagement.demaree.methodDetail.${section.id}.title`,
-                      )}
+                      {t(`swarmManagement.demaree.methodDetail.${section.id}.title`)}
                     </h3>
                     <ul className="list-disc space-y-2 pl-5 marker:text-primary/60">
                       {section.items.map(itemIndex => (
@@ -442,15 +425,13 @@ export function DemareeMethodPage() {
                           </span>
                           {(section.children[itemIndex] ?? []).length > 0 && (
                             <ul className="list-[circle] space-y-2 pl-5 pt-2 marker:text-muted-foreground/60">
-                              {(section.children[itemIndex] ?? []).map(
-                                childIndex => (
-                                  <li key={childIndex}>
-                                    {t(
-                                      `swarmManagement.demaree.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
-                                    )}
-                                  </li>
-                                ),
-                              )}
+                              {(section.children[itemIndex] ?? []).map(childIndex => (
+                                <li key={childIndex}>
+                                  {t(
+                                    `swarmManagement.demaree.methodDetail.${section.id}.items.${itemIndex}.children.${childIndex}`,
+                                  )}
+                                </li>
+                              ))}
                             </ul>
                           )}
                         </li>
@@ -464,9 +445,7 @@ export function DemareeMethodPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle>
-                {t('swarmManagement.demaree.followUpTitle')}
-              </CardTitle>
+              <CardTitle>{t('swarmManagement.demaree.followUpTitle')}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="overflow-hidden rounded-lg border">
@@ -493,21 +472,15 @@ export function DemareeMethodPage() {
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
                   {t('swarmManagement.aside.criticalTimingTitle')}
                 </p>
-                <p className="mt-2">
-                  {t('swarmManagement.aside.criticalTimingLead')}
-                </p>
-                <p className="mt-2">
-                  {t('swarmManagement.aside.criticalTimingDetail')}
-                </p>
+                <p className="mt-2">{t('swarmManagement.aside.criticalTimingLead')}</p>
+                <p className="mt-2">{t('swarmManagement.aside.criticalTimingDetail')}</p>
               </div>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader>
-              <CardTitle>
-                {t('swarmManagement.demaree.prosConsTitle')}
-              </CardTitle>
+              <CardTitle>{t('swarmManagement.demaree.prosConsTitle')}</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
@@ -553,9 +526,7 @@ export function DemareeMethodPage() {
                   </p>
                   <div className="mt-4 flex flex-col items-center justify-center gap-2 sm:flex-row">
                     <Button asChild>
-                      <Link to="/login">
-                        {t('swarmManagement.planner.signInCta')}
-                      </Link>
+                      <Link to="/login">{t('swarmManagement.planner.signInCta')}</Link>
                     </Button>
                     <Button variant="outline" asChild>
                       <Link to="/register">
@@ -636,9 +607,7 @@ export function DemareeMethodPage() {
                             <CardHeader>
                               <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                                 <div className="min-w-0">
-                                  <CardTitle>
-                                    {t(checkpoint.titleKey)}
-                                  </CardTitle>
+                                  <CardTitle>{t(checkpoint.titleKey)}</CardTitle>
                                   <CardDescription>
                                     {t('swarmManagement.planner.dayOffset', {
                                       count: checkpoint.dayOffset,
@@ -664,9 +633,7 @@ export function DemareeMethodPage() {
                               {checkpointWarnings.map(warning => (
                                 <Alert
                                   key={`${checkpoint.id}-${warning.code}`}
-                                  className={
-                                    warningVariantClasses[warning.code]
-                                  }
+                                  className={warningVariantClasses[warning.code]}
                                 >
                                   <ShieldAlert className="h-4 w-4" />
                                   <AlertTitle>
@@ -722,10 +689,7 @@ export function DemareeMethodPage() {
           </Card>
         </div>
 
-        <ToolFaq
-          title={t('swarmManagement.demaree.faq.title')}
-          items={faqItems}
-        />
+        <ToolFaq title={t('swarmManagement.demaree.faq.title')} items={faqItems} />
       </MainContent>
 
       <PageAside>


### PR DESCRIPTION
Resolves #212 

## Summary

Adds an **"All apiaries"** entry to the apiary switcher so beekeepers with
multiple apiaries can see their whole operation at once: hives, inspections,
todos, queens, harvests and the dashboard aggregate across every apiary the
user can access. Writes always stay bound to one concrete apiary. The mode
persists across reloads, and per-scope query caching keeps single- and
cross-apiary results cleanly separated.

## How it works

**Backend — explicit opt-in, no accidental widening**
- A reserved `x-apiary-id: all` header value puts a request into cross-apiary
  mode. `ApiaryContextGuard` only accepts it on handlers decorated with the
  new `@AllowAllApiaries()` — every other endpoint rejects it, so no service
  can widen its scope by accident.
- Opted-in list endpoints (hives, inspections, todos, queens, harvests,
  dashboard) filter by "apiaries the user owns or is an active member of"
  instead of a single apiary id. Apiary-level isolation between *users* is
  unchanged.

**Frontend — scope-aware state and caching**
- The apiary switcher gets an "All apiaries" entry; the choice is a persisted
  `viewAllApiaries` flag next to the existing apiary selection. The concrete
  selection is kept as the default **write target**.
- The API client sends `all` only for **GET** requests to endpoints that
  support it (`/api/hives`, `/api/inspections`, `/api/todos`, `/api/queens`,
  …); every write sends a concrete apiary id.
- React-Query keys include the scope (`all` vs. apiary id), so toggling the
  mode never serves stale cross-scope data.
- Where a row's apiary matters (hive cards, todos), the owning apiary is
  shown.

**Cross-apiary interactions that writes need**
- In this mode a user can open and edit a hive that belongs to a *different*
  apiary than the selected one. Mutations therefore accept an explicit apiary
  override (sent as the `x-apiary-id` header) supplied from the resource
  itself — including the edit form, which authorizes against the hive's
  **current** apiary when moving it to another one (the new apiary travels in
  the body).
- Creating inspections from a cross-apiary hive detail works the same way
  (the hive's own apiary is passed explicitly).

## Screenshots

**The apiary switcher gains an "All apiaries" entry (persisted like the
regular selection):**
<img width="640" height="560" alt="prviewallswitcher" src="https://github.com/user-attachments/assets/e4288820-1afe-4e6a-b085-60545fb6c7a1" />

**Dashboard in "All apiaries" mode — hives grouped per apiary (mirroring how
BEEP presents apiaries with their hives), todos aggregated across every
apiary:**
<img width="1280" height="950" alt="prviewalldashboard" src="https://github.com/user-attachments/assets/658d58d1-451d-4de3-aa8b-775ee9edee31" />

## Testing

- **E2E** (`apps/e2e/tests/view-all-apiaries.spec.ts`): self-contained spec —
  seeds two apiaries with distinct hives, toggles "All apiaries", asserts both
  hives are listed with their apiary labels, checks single-apiary mode still
  filters, and covers the todos caption + detail reads. Test-ids added to the
  apiary switcher for stable selectors.
- Regression tests for the detail-read and todos-caption fixes are part of
  the respective commits.
- Backend `tsc`, frontend `tsc -b`, ESLint clean.

## Compatibility

- No schema/DB change and no API break: the reserved header value is opt-in
  per endpoint; existing clients that always send a concrete apiary id are
  untouched.
- Single-apiary users see no behavioral change (the switcher entry is simply
  there; nothing else differs until it's used).
