### PR TITLE
Feature: custom treatment products with active-ingredient tracking

### DIFF
--- a/apps/backend/prisma/migrations/20260722094020_add_treatment_products/migration.sql
+++ b/apps/backend/prisma/migrations/20260722094020_add_treatment_products/migration.sql
@@ -1,0 +1,170 @@
+-- CreateEnum
+CREATE TYPE "TreatmentPhysicalForm" AS ENUM ('LIQUID', 'POWDER', 'GEL', 'STRIP', 'GASEOUS');
+
+-- CreateEnum
+CREATE TYPE "TreatmentApplicationMethod" AS ENUM ('TRICKLE', 'SPRAY', 'SUBLIMATE', 'EVAPORATE', 'INSERT', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "MiteCountMethod" AS ENUM ('NATURAL_DROP', 'SUGAR_ROLL', 'ALCOHOL_WASH', 'CO2', 'OTHER');
+
+-- AlterTable
+ALTER TABLE "TreatmentAction" ADD COLUMN     "miteCountAfter" DOUBLE PRECISION,
+ADD COLUMN     "miteCountBefore" DOUBLE PRECISION,
+ADD COLUMN     "miteCountMethod" "MiteCountMethod",
+ADD COLUMN     "miteSampleSize" INTEGER,
+ADD COLUMN     "productId" TEXT;
+
+-- CreateTable
+CREATE TABLE "ActiveIngredient" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "isBuiltIn" BOOLEAN NOT NULL DEFAULT true,
+    "createdByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ActiveIngredient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TreatmentProduct" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT,
+    "name" TEXT NOT NULL,
+    "physicalForm" "TreatmentPhysicalForm" NOT NULL,
+    "applicationMethod" "TreatmentApplicationMethod",
+    "defaultUnit" TEXT,
+    "density" DOUBLE PRECISION,
+    "withdrawalPeriodDays" INTEGER,
+    "isBuiltIn" BOOLEAN NOT NULL DEFAULT false,
+    "createdByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TreatmentProduct_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TreatmentProductIngredient" (
+    "id" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "activeIngredientId" TEXT NOT NULL,
+    "concentration" DOUBLE PRECISION NOT NULL,
+    "concentrationUnit" TEXT NOT NULL,
+
+    CONSTRAINT "TreatmentProductIngredient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActiveIngredient_key_key" ON "ActiveIngredient"("key");
+
+-- CreateIndex
+CREATE INDEX "TreatmentProduct_userId_idx" ON "TreatmentProduct"("userId");
+
+-- CreateIndex
+CREATE INDEX "TreatmentProductIngredient_activeIngredientId_idx" ON "TreatmentProductIngredient"("activeIngredientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TreatmentProductIngredient_productId_activeIngredientId_key" ON "TreatmentProductIngredient"("productId", "activeIngredientId");
+
+-- CreateIndex
+CREATE INDEX "TreatmentAction_productId_idx" ON "TreatmentAction"("productId");
+
+-- AddForeignKey
+ALTER TABLE "TreatmentAction" ADD CONSTRAINT "TreatmentAction_productId_fkey" FOREIGN KEY ("productId") REFERENCES "TreatmentProduct"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TreatmentProduct" ADD CONSTRAINT "TreatmentProduct_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TreatmentProductIngredient" ADD CONSTRAINT "TreatmentProductIngredient_productId_fkey" FOREIGN KEY ("productId") REFERENCES "TreatmentProduct"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TreatmentProductIngredient" ADD CONSTRAINT "TreatmentProductIngredient_activeIngredientId_fkey" FOREIGN KEY ("activeIngredientId") REFERENCES "ActiveIngredient"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- ============================================================================
+-- Uniqueness: built-in product names are globally unique; custom product names
+-- are unique per owning user. (Partial unique indexes — not expressible in the
+-- Prisma schema, kept in sync here.)
+-- ============================================================================
+CREATE UNIQUE INDEX "TreatmentProduct_builtin_name_key" ON "TreatmentProduct"("name") WHERE "userId" IS NULL;
+CREATE UNIQUE INDEX "TreatmentProduct_user_name_key" ON "TreatmentProduct"("userId", "name") WHERE "userId" IS NOT NULL;
+
+-- ============================================================================
+-- Seed: built-in active ingredients (canonical identities for cross-product totals)
+-- ============================================================================
+INSERT INTO "ActiveIngredient" (id, key, name, "isBuiltIn", "createdAt", "updatedAt") VALUES
+  (gen_random_uuid(), 'OXALIC_ACID', 'Oxalic acid (dihydrate)', true, NOW(), NOW()),
+  (gen_random_uuid(), 'FORMIC_ACID', 'Formic acid', true, NOW(), NOW()),
+  (gen_random_uuid(), 'LACTIC_ACID', 'Lactic acid', true, NOW(), NOW()),
+  (gen_random_uuid(), 'THYMOL', 'Thymol', true, NOW(), NOW()),
+  (gen_random_uuid(), 'MENTHOL', 'Menthol', true, NOW(), NOW()),
+  (gen_random_uuid(), 'AMITRAZ', 'Amitraz', true, NOW(), NOW()),
+  (gen_random_uuid(), 'TAU_FLUVALINATE', 'Tau-fluvalinate', true, NOW(), NOW()),
+  (gen_random_uuid(), 'COUMAPHOS', 'Coumaphos', true, NOW(), NOW()),
+  (gen_random_uuid(), 'FLUMETHRIN', 'Flumethrin', true, NOW(), NOW()),
+  (gen_random_uuid(), 'HOP_BETA_ACIDS', 'Hop beta acids', true, NOW(), NOW()),
+  (gen_random_uuid(), 'LITHIUM_CHLORIDE', 'Lithium chloride', true, NOW(), NOW());
+
+-- ============================================================================
+-- Seed: built-in treatment products (global, userId = NULL).
+-- withdrawalPeriodDays and concentrations are sensible, EDITABLE defaults;
+-- generic substances use a pure-substance basis, branded products use documented
+-- label values (e.g. VarroMed 5 mg/ml formic + 44 mg/ml oxalic acid).
+-- ============================================================================
+INSERT INTO "TreatmentProduct" (id, "userId", name, "physicalForm", "applicationMethod", "defaultUnit", density, "withdrawalPeriodDays", "isBuiltIn", "createdAt", "updatedAt") VALUES
+  (gen_random_uuid(), NULL, 'VarroMed',    'LIQUID',  'TRICKLE',   'ml',  NULL, 0,    true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'Oxalic Acid', 'POWDER',  'SUBLIMATE', 'g',   NULL, 0,    true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'Formic Acid', 'LIQUID',  'EVAPORATE', 'ml',  1.22, 0,    true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'Thymol',      'POWDER',  NULL,        'g',   NULL, 0,    true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'Apivar',      'STRIP',   'INSERT',    'pcs', NULL, NULL, true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'Apistan',     'STRIP',   'INSERT',    'pcs', NULL, NULL, true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'CheckMite+',  'STRIP',   'INSERT',    'pcs', NULL, 42,   true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'HopGuard',    'STRIP',   'INSERT',    'pcs', NULL, 0,    true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'Api-Bioxal',  'POWDER',  'SUBLIMATE', 'g',   NULL, 0,    true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'Apiguard',    'GEL',     NULL,        'g',   NULL, 0,    true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'MAQS',        'STRIP',   'EVAPORATE', 'pcs', NULL, 0,    true, NOW(), NOW()),
+  (gen_random_uuid(), NULL, 'Fumigation',  'GASEOUS', NULL,        'pcs', NULL, NULL, true, NOW(), NOW());
+
+-- ============================================================================
+-- Seed: built-in product compositions (documented label values where known;
+-- HopGuard/Fumigation intentionally left without composition rather than guess).
+-- ============================================================================
+INSERT INTO "TreatmentProductIngredient" (id, "productId", "activeIngredientId", concentration, "concentrationUnit")
+SELECT gen_random_uuid(), p.id, i.id, c.conc, c.unit
+FROM (VALUES
+  ('VarroMed',    'FORMIC_ACID',     5,     'mg/ml'),
+  ('VarroMed',    'OXALIC_ACID',     44,    'mg/ml'),
+  ('Oxalic Acid', 'OXALIC_ACID',     1000,  'mg/g'),
+  ('Formic Acid', 'FORMIC_ACID',     1000,  'mg/g'),
+  ('Thymol',      'THYMOL',          1000,  'mg/g'),
+  ('Apivar',      'AMITRAZ',         500,   'mg/piece'),
+  ('Apistan',     'TAU_FLUVALINATE', 824,   'mg/piece'),
+  ('CheckMite+',  'COUMAPHOS',       1360,  'mg/piece'),
+  ('Api-Bioxal',  'OXALIC_ACID',     886,   'mg/g'),
+  ('Apiguard',    'THYMOL',          25,    '%w/w'),
+  ('MAQS',        'FORMIC_ACID',     31850, 'mg/piece')
+) AS c(prod, ing, conc, unit)
+JOIN "TreatmentProduct" p ON p.name = c.prod AND p."userId" IS NULL
+JOIN "ActiveIngredient" i ON i.key = c.ing;
+
+-- ============================================================================
+-- Data migration: link existing treatment records to the new built-in catalog
+-- (match either the stored enum key or its label). Unknown/OTHER stay uncatalogued.
+-- ============================================================================
+UPDATE "TreatmentAction" ta SET "productId" = p.id
+FROM "TreatmentProduct" p
+WHERE p."userId" IS NULL AND ta."productId" IS NULL AND (
+  (ta.product IN ('OXALIC_ACID','Oxalic Acid')     AND p.name = 'Oxalic Acid') OR
+  (ta.product IN ('FORMIC_ACID','Formic Acid')     AND p.name = 'Formic Acid') OR
+  (ta.product IN ('THYMOL','Thymol')               AND p.name = 'Thymol') OR
+  (ta.product IN ('APIVAR','Apivar')               AND p.name = 'Apivar') OR
+  (ta.product IN ('APISTAN','Apistan')             AND p.name = 'Apistan') OR
+  (ta.product IN ('CHECKMITE_PLUS','CheckMite+')   AND p.name = 'CheckMite+') OR
+  (ta.product IN ('HOPGUARD','HopGuard')           AND p.name = 'HopGuard') OR
+  (ta.product IN ('API_BIOXAL','Api-Bioxal')       AND p.name = 'Api-Bioxal') OR
+  (ta.product IN ('APIGUARD','Apiguard')           AND p.name = 'Apiguard') OR
+  (ta.product IN ('MAQS')                          AND p.name = 'MAQS') OR
+  (ta.product IN ('FUMIGATION','Fumigation')       AND p.name = 'Fumigation')
+);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   preferences            Json?                  // JSON field for user preferences
   feedbacks              Feedback[]
   frameSizes             FrameSize[]
+  treatmentProducts      TreatmentProduct[]
   shareLinks             ShareLink[]
   apiaryMemberships      ApiaryMember[]
   createdInspections     Inspection[]           @relation("InspectionCreator")
@@ -456,10 +457,111 @@ model TreatmentAction {
   id       String  @id @default(uuid())
   actionId String  @unique
   action   Action  @relation(fields: [actionId], references: [id], onDelete: Cascade)
-  product  String // Apivar, Formic Pro, etc.
+  product  String // Free-text label / uncatalogued fallback (Apivar, Formic Pro, etc.)
   quantity Float? // Numeric quantity (optional for some treatments like fumigation)
   unit     String // pcs, ml, g
   duration String? // 7 days, 14 days, etc.
+
+  // Link to the catalog product this treatment used (null = uncatalogued/legacy).
+  // Its composition + this quantity/unit drive per-colony active-ingredient totals.
+  productId        String?
+  treatmentProduct TreatmentProduct? @relation(fields: [productId], references: [id], onDelete: SetNull)
+
+  // Optional efficacy tracking. Same method before & after ->
+  // efficacy% = (before - after) / before. NATURAL_DROP = mites/day;
+  // SUGAR_ROLL / ALCOHOL_WASH = mites per sample of `miteSampleSize` bees.
+  miteCountMethod MiteCountMethod?
+  miteCountBefore Float?
+  miteCountAfter  Float?
+  miteSampleSize  Int?
+
+  @@index([productId])
+}
+
+// Physical form of a treatment product (drives how it is applied / how amount is measured).
+enum TreatmentPhysicalForm {
+  LIQUID
+  POWDER
+  GEL
+  STRIP
+  GASEOUS
+}
+
+// Optional application method (independent of physical form: a liquid can be trickled or sprayed).
+enum TreatmentApplicationMethod {
+  TRICKLE
+  SPRAY
+  SUBLIMATE
+  EVAPORATE
+  INSERT
+  OTHER
+}
+
+// Method used to count Varroa mites for efficacy calculation.
+enum MiteCountMethod {
+  NATURAL_DROP
+  SUGAR_ROLL
+  ALCOHOL_WASH
+  CO2
+  OTHER
+}
+
+// Canonical active substance (oxalic acid, formic acid, thymol, ...). Shared
+// identity so applied amounts can be summed across different products. Seeded
+// with built-ins; extensible (users/admins may add more).
+model ActiveIngredient {
+  id              String  @id @default(uuid())
+  key             String  @unique // canonical key, e.g. "OXALIC_ACID"
+  name            String // display name, e.g. "Oxalic acid (dihydrate)"
+  isBuiltIn       Boolean @default(true)
+  createdByUserId String? // set for user-added ingredients
+
+  compositions TreatmentProductIngredient[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+// A treatment product in the catalog. `userId = null` => global built-in
+// (or, in the future, an approved community product); `userId` set => a private
+// custom product owned by that user. Nullable userId keeps the door open for a
+// shared, admin-approved catalog without a schema rewrite.
+model TreatmentProduct {
+  id                   String                      @id @default(uuid())
+  userId               String? // null = global built-in; set = private custom
+  user                 User?                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name                 String
+  physicalForm         TreatmentPhysicalForm
+  applicationMethod    TreatmentApplicationMethod?
+  defaultUnit          String? // suggested amount unit (ml, g, pcs)
+  density              Float? // g/ml — only needed when amount unit and concentration basis differ dimensions
+  withdrawalPeriodDays Int? // honey withdrawal period (Wartezeit); null = unknown
+  isBuiltIn            Boolean                     @default(false)
+
+  ingredients      TreatmentProductIngredient[]
+  treatmentActions TreatmentAction[]
+
+  createdByUserId String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@index([userId])
+  // Built-in uniqueness (name WHERE user_id IS NULL) and per-user uniqueness
+  // (userId, name) are enforced via partial unique indexes in the migration SQL.
+}
+
+// One active-ingredient entry in a product's composition, at a given concentration.
+model TreatmentProductIngredient {
+  id                 String           @id @default(uuid())
+  productId          String
+  product            TreatmentProduct @relation(fields: [productId], references: [id], onDelete: Cascade)
+  activeIngredientId String
+  activeIngredient   ActiveIngredient @relation(fields: [activeIngredientId], references: [id], onDelete: Restrict)
+  concentration      Float // e.g. 44
+  concentrationUnit  String // "mg/ml" | "g/l" | "%w/w" | "mg/g" | "mg/piece"
+
+  @@unique([productId, activeIngredientId])
+  @@index([activeIngredientId])
 }
 
 // Frame-specific details

--- a/apps/backend/src/actions/actions.service.ts
+++ b/apps/backend/src/actions/actions.service.ts
@@ -79,9 +79,14 @@ export class ActionsService {
           data: {
             actionId,
             product: details.product,
+            productId: details.productId ?? null,
             quantity: details.quantity,
             unit: details.unit,
             duration: details.duration,
+            miteCountMethod: details.miteCountMethod ?? null,
+            miteCountBefore: details.miteCountBefore ?? null,
+            miteCountAfter: details.miteCountAfter ?? null,
+            miteSampleSize: details.miteSampleSize ?? null,
           },
         });
         break;
@@ -724,9 +729,18 @@ export class ActionsService {
           details: {
             type: ActionType.TREATMENT,
             product: prismaAction.treatmentAction.product,
+            productId: prismaAction.treatmentAction.productId ?? undefined,
             quantity: convertedQuantity,
             unit: convertedTreatmentUnit,
             duration: prismaAction.treatmentAction.duration ?? undefined,
+            miteCountMethod:
+              prismaAction.treatmentAction.miteCountMethod ?? undefined,
+            miteCountBefore:
+              prismaAction.treatmentAction.miteCountBefore ?? undefined,
+            miteCountAfter:
+              prismaAction.treatmentAction.miteCountAfter ?? undefined,
+            miteSampleSize:
+              prismaAction.treatmentAction.miteSampleSize ?? undefined,
           },
         };
       }

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -30,6 +30,7 @@ import { AlertsModule } from './alerts/alerts.module';
 import { CalendarModule } from './calendar/calendar.module';
 import { FeedbackModule } from './feedback/feedback.module';
 import { FrameSizesModule } from './frame-sizes/frame-sizes.module';
+import { TreatmentProductsModule } from './treatment-products/treatment-products.module';
 import { MailModule } from './mail/mail.module';
 import { SentryModule } from '@sentry/nestjs/setup';
 import { ReportsModule } from './reports/reports.module';
@@ -86,6 +87,7 @@ import { AccountTransferModule } from './account-transfer/account-transfer.modul
     CalendarModule,
     FeedbackModule,
     FrameSizesModule,
+    TreatmentProductsModule,
     MailModule,
     ReportsModule,
     PlatformMetricsModule,

--- a/apps/backend/src/common/apiary-scope.ts
+++ b/apps/backend/src/common/apiary-scope.ts
@@ -1,0 +1,10 @@
+import { Prisma } from '@/prisma/client';
+
+/**
+ * Prisma `ApiaryWhereInput` that matches every apiary a user can access
+ * (owned or an active membership). Used to scope cross-apiary "view all"
+ * queries to the current user's apiaries.
+ */
+export const apiaryAccessWhere = (userId: string): Prisma.ApiaryWhereInput => ({
+  OR: [{ userId }, { members: { some: { userId, status: 'ACTIVE' } } }],
+});

--- a/apps/backend/src/common/index.ts
+++ b/apps/backend/src/common/index.ts
@@ -1,2 +1,3 @@
 export * from './decorators/zod-validation.decorator';
 export * from './pipes/zod-validation.pipe';
+export * from './apiary-scope';

--- a/apps/backend/src/treatment-products/treatment-products.controller.ts
+++ b/apps/backend/src/treatment-products/treatment-products.controller.ts
@@ -1,0 +1,124 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { TreatmentProductsService } from './treatment-products.service';
+import {
+  createTreatmentProductSchema,
+  updateTreatmentProductSchema,
+  createActiveIngredientSchema,
+  type CreateTreatmentProductDto,
+  type UpdateTreatmentProductDto,
+  type CreateActiveIngredientDto,
+} from 'shared-schemas';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RequestWithUser } from '../auth/interface/request-with-user.interface';
+import { ZodValidation } from '../common';
+
+function parseDate(value?: string): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+@ApiTags('treatment-products')
+@Controller()
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class TreatmentProductsController {
+  constructor(private readonly service: TreatmentProductsService) {}
+
+  @Get('treatment-products')
+  @ApiOperation({ summary: 'List built-in and own custom treatment products' })
+  findAll(@Req() req: RequestWithUser) {
+    return this.service.findAll(req.user.id);
+  }
+
+  @Post('treatment-products')
+  @ApiOperation({ summary: 'Create a custom treatment product' })
+  @ZodValidation(createTreatmentProductSchema)
+  create(
+    @Body() dto: CreateTreatmentProductDto,
+    @Req() req: RequestWithUser,
+  ) {
+    return this.service.create(req.user.id, dto);
+  }
+
+  @Put('treatment-products/:id')
+  @ApiOperation({ summary: 'Update a custom treatment product' })
+  @ZodValidation(updateTreatmentProductSchema)
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateTreatmentProductDto,
+    @Req() req: RequestWithUser,
+  ) {
+    return this.service.update(req.user.id, id, dto);
+  }
+
+  @Delete('treatment-products/:id')
+  @ApiOperation({ summary: 'Delete a custom treatment product' })
+  remove(@Param('id') id: string, @Req() req: RequestWithUser) {
+    return this.service.remove(req.user.id, id);
+  }
+
+  @Get('hives/:hiveId/treatment-summary')
+  @ApiOperation({
+    summary: 'Applied active-ingredient totals & withdrawal status for a hive',
+  })
+  getHiveSummary(
+    @Param('hiveId') hiveId: string,
+    @Req() req: RequestWithUser,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    return this.service.getHiveTreatmentSummary(
+      req.user.id,
+      hiveId,
+      parseDate(from),
+      parseDate(to),
+    );
+  }
+
+  @Get('apiaries/:apiaryId/treatment-ingredient-totals')
+  @ApiOperation({
+    summary: 'Per-hive applied active-ingredient totals across an apiary',
+  })
+  getApiaryTotals(
+    @Param('apiaryId') apiaryId: string,
+    @Req() req: RequestWithUser,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    return this.service.getApiaryIngredientTotals(
+      req.user.id,
+      apiaryId,
+      parseDate(from),
+      parseDate(to),
+    );
+  }
+
+  @Get('active-ingredients')
+  @ApiOperation({ summary: 'List active ingredients (built-in + custom)' })
+  listActiveIngredients() {
+    return this.service.listActiveIngredients();
+  }
+
+  @Post('active-ingredients')
+  @ApiOperation({ summary: 'Add a custom active ingredient' })
+  @ZodValidation(createActiveIngredientSchema)
+  createActiveIngredient(
+    @Body() dto: CreateActiveIngredientDto,
+    @Req() req: RequestWithUser,
+  ) {
+    return this.service.createActiveIngredient(req.user.id, dto);
+  }
+}

--- a/apps/backend/src/treatment-products/treatment-products.module.ts
+++ b/apps/backend/src/treatment-products/treatment-products.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TreatmentProductsController } from './treatment-products.controller';
+import { TreatmentProductsService } from './treatment-products.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Module({
+  controllers: [TreatmentProductsController],
+  providers: [TreatmentProductsService, PrismaService],
+  exports: [TreatmentProductsService],
+})
+export class TreatmentProductsModule {}

--- a/apps/backend/src/treatment-products/treatment-products.service.ts
+++ b/apps/backend/src/treatment-products/treatment-products.service.ts
@@ -1,0 +1,314 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  ConflictException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { apiaryAccessWhere } from '../common';
+import {
+  computeTreatmentIngredientMasses,
+  type ConcentrationUnit,
+  type CreateTreatmentProductDto,
+  type UpdateTreatmentProductDto,
+  type CreateActiveIngredientDto,
+  type AppliedIngredientTotal,
+} from 'shared-schemas';
+
+const productInclude = {
+  ingredients: { include: { activeIngredient: true } },
+} as const;
+
+@Injectable()
+export class TreatmentProductsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Built-in (global) products plus the caller's own custom products. */
+  async findAll(userId: string) {
+    return this.prisma.treatmentProduct.findMany({
+      where: { OR: [{ userId: null }, { userId }] },
+      include: productInclude,
+      orderBy: [{ isBuiltIn: 'desc' }, { name: 'asc' }],
+    });
+  }
+
+  async findOneForUser(userId: string, id: string) {
+    const product = await this.prisma.treatmentProduct.findUnique({
+      where: { id },
+      include: productInclude,
+    });
+    if (!product || (product.userId !== null && product.userId !== userId)) {
+      throw new NotFoundException('Treatment product not found');
+    }
+    return product;
+  }
+
+  async create(userId: string, dto: CreateTreatmentProductDto) {
+    await this.assertNameFree(userId, dto.name);
+    return this.prisma.treatmentProduct.create({
+      data: {
+        userId,
+        createdByUserId: userId,
+        isBuiltIn: false,
+        name: dto.name,
+        physicalForm: dto.physicalForm,
+        applicationMethod: dto.applicationMethod ?? null,
+        defaultUnit: dto.defaultUnit ?? null,
+        density: dto.density ?? null,
+        withdrawalPeriodDays: dto.withdrawalPeriodDays ?? null,
+        ingredients: {
+          create: (dto.ingredients ?? []).map((i) => ({
+            activeIngredientId: i.activeIngredientId,
+            concentration: i.concentration,
+            concentrationUnit: i.concentrationUnit,
+          })),
+        },
+      },
+      include: productInclude,
+    });
+  }
+
+  async update(userId: string, id: string, dto: UpdateTreatmentProductDto) {
+    const existing = await this.prisma.treatmentProduct.findUnique({
+      where: { id },
+    });
+    if (!existing) throw new NotFoundException('Treatment product not found');
+    if (existing.userId === null || existing.isBuiltIn) {
+      throw new ForbiddenException('Built-in products cannot be edited');
+    }
+    if (existing.userId !== userId) {
+      throw new NotFoundException('Treatment product not found');
+    }
+    if (dto.name && dto.name !== existing.name) {
+      await this.assertNameFree(userId, dto.name);
+    }
+
+    return this.prisma.treatmentProduct.update({
+      where: { id },
+      data: {
+        name: dto.name ?? undefined,
+        physicalForm: dto.physicalForm ?? undefined,
+        applicationMethod:
+          dto.applicationMethod === undefined
+            ? undefined
+            : dto.applicationMethod,
+        defaultUnit:
+          dto.defaultUnit === undefined ? undefined : dto.defaultUnit,
+        density: dto.density === undefined ? undefined : dto.density,
+        withdrawalPeriodDays:
+          dto.withdrawalPeriodDays === undefined
+            ? undefined
+            : dto.withdrawalPeriodDays,
+        // Replace the composition wholesale when provided.
+        ...(dto.ingredients !== undefined
+          ? {
+              ingredients: {
+                deleteMany: {},
+                create: dto.ingredients.map((i) => ({
+                  activeIngredientId: i.activeIngredientId,
+                  concentration: i.concentration,
+                  concentrationUnit: i.concentrationUnit,
+                })),
+              },
+            }
+          : {}),
+      },
+      include: productInclude,
+    });
+  }
+
+  async remove(userId: string, id: string) {
+    const existing = await this.prisma.treatmentProduct.findUnique({
+      where: { id },
+    });
+    if (!existing) throw new NotFoundException('Treatment product not found');
+    if (existing.userId === null || existing.isBuiltIn) {
+      throw new ForbiddenException('Built-in products cannot be deleted');
+    }
+    if (existing.userId !== userId) {
+      throw new NotFoundException('Treatment product not found');
+    }
+    await this.prisma.treatmentProduct.delete({ where: { id } });
+    return { success: true };
+  }
+
+  // --- Active ingredients ---
+
+  async listActiveIngredients() {
+    return this.prisma.activeIngredient.findMany({
+      orderBy: [{ isBuiltIn: 'desc' }, { name: 'asc' }],
+    });
+  }
+
+  async createActiveIngredient(userId: string, dto: CreateActiveIngredientDto) {
+    const existing = await this.prisma.activeIngredient.findUnique({
+      where: { key: dto.key },
+    });
+    if (existing) {
+      throw new ConflictException('An active ingredient with this key exists');
+    }
+    return this.prisma.activeIngredient.create({
+      data: {
+        key: dto.key,
+        name: dto.name,
+        isBuiltIn: false,
+        createdByUserId: userId,
+      },
+    });
+  }
+
+  // --- Per-colony aggregation: applied active-ingredient totals + withdrawal ---
+
+  /**
+   * Applied active-ingredient totals + current withdrawal status for one hive.
+   * Verifies the caller can access the hive (owned or shared apiary).
+   */
+  async getHiveTreatmentSummary(
+    userId: string,
+    hiveId: string,
+    from?: Date,
+    to?: Date,
+  ) {
+    const hive = await this.prisma.hive.findFirst({
+      where: { id: hiveId, apiary: apiaryAccessWhere(userId) },
+      select: { id: true },
+    });
+    if (!hive) {
+      throw new NotFoundException('Hive not found or access denied');
+    }
+
+    const treatments = await this.fetchTreatments([hiveId], from, to);
+    const allTreatments =
+      from || to ? await this.fetchTreatments([hiveId]) : treatments;
+
+    return {
+      hiveId,
+      from: from ?? null,
+      to: to ?? null,
+      ingredientTotals: this.aggregateIngredientTotals(treatments),
+      withdrawal: this.computeWithdrawal(allTreatments),
+    };
+  }
+
+  /** Per-hive applied ingredient totals across an apiary the caller can access. */
+  async getApiaryIngredientTotals(
+    userId: string,
+    apiaryId: string,
+    from?: Date,
+    to?: Date,
+  ) {
+    const hives = await this.prisma.hive.findMany({
+      where: { apiaryId, apiary: apiaryAccessWhere(userId) },
+      select: { id: true, name: true },
+    });
+    const byHive = await Promise.all(
+      hives.map(async (h) => {
+        const treatments = await this.fetchTreatments([h.id], from, to);
+        return {
+          hiveId: h.id,
+          hiveName: h.name,
+          ingredientTotals: this.aggregateIngredientTotals(treatments),
+        };
+      }),
+    );
+    return { apiaryId, from: from ?? null, to: to ?? null, byHive };
+  }
+
+  private fetchTreatments(hiveIds: string[], from?: Date, to?: Date) {
+    const dateFilter =
+      from || to
+        ? { date: { ...(from ? { gte: from } : {}), ...(to ? { lte: to } : {}) } }
+        : {};
+    return this.prisma.action.findMany({
+      where: { hiveId: { in: hiveIds }, type: 'TREATMENT', ...dateFilter },
+      orderBy: { date: 'desc' },
+      include: {
+        treatmentAction: {
+          include: {
+            treatmentProduct: {
+              include: { ingredients: { include: { activeIngredient: true } } },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  private aggregateIngredientTotals(
+    treatments: Awaited<ReturnType<typeof this.fetchTreatments>>,
+  ): AppliedIngredientTotal[] {
+    const totals = new Map<string, AppliedIngredientTotal>();
+    for (const action of treatments) {
+      const ta = action.treatmentAction;
+      const product = ta?.treatmentProduct;
+      if (!ta || !product) continue; // uncatalogued treatment: no composition
+      const masses = computeTreatmentIngredientMasses(ta.quantity, ta.unit, {
+        density: product.density,
+        ingredients: product.ingredients.map((i) => ({
+          activeIngredientId: i.activeIngredientId,
+          concentration: i.concentration,
+          concentrationUnit: i.concentrationUnit as ConcentrationUnit,
+        })),
+      });
+      for (const ing of product.ingredients) {
+        const res = masses[ing.activeIngredientId];
+        const entry =
+          totals.get(ing.activeIngredientId) ??
+          ({
+            activeIngredientId: ing.activeIngredientId,
+            key: ing.activeIngredient.key,
+            name: ing.activeIngredient.name,
+            totalMg: 0,
+            incompleteCount: 0,
+          } satisfies AppliedIngredientTotal);
+        if (res.incomplete || res.mg == null) {
+          entry.incompleteCount += 1;
+        } else {
+          entry.totalMg += res.mg;
+        }
+        totals.set(ing.activeIngredientId, entry);
+      }
+    }
+    return [...totals.values()].sort((a, b) => b.totalMg - a.totalMg);
+  }
+
+  private computeWithdrawal(
+    treatments: Awaited<ReturnType<typeof this.fetchTreatments>>,
+  ) {
+    const now = Date.now();
+    let latestUntil = 0;
+    let source: { productName: string; productId: string; until: Date } | null =
+      null;
+    for (const action of treatments) {
+      const product = action.treatmentAction?.treatmentProduct;
+      if (!product || product.withdrawalPeriodDays == null) continue;
+      const until =
+        action.date.getTime() +
+        product.withdrawalPeriodDays * 24 * 60 * 60 * 1000;
+      if (until > latestUntil) {
+        latestUntil = until;
+        source = {
+          productName: product.name,
+          productId: product.id,
+          until: new Date(until),
+        };
+      }
+    }
+    if (!source) return { inWithdrawal: false, until: null, product: null };
+    return {
+      inWithdrawal: latestUntil > now,
+      until: source.until,
+      product: { id: source.productId, name: source.productName },
+    };
+  }
+
+  private async assertNameFree(userId: string, name: string) {
+    const clash = await this.prisma.treatmentProduct.findFirst({
+      where: { userId, name },
+      select: { id: true },
+    });
+    if (clash) {
+      throw new ConflictException('You already have a product with this name');
+    }
+  }
+}

--- a/apps/backend/src/treatment-products/units.spec.ts
+++ b/apps/backend/src/treatment-products/units.spec.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeAppliedMassMg,
+  concentrationToMgPerBase,
+  amountToBase,
+  computeTreatmentIngredientMasses,
+} from 'shared-schemas';
+
+describe('concentrationToMgPerBase', () => {
+  it('mg/ml -> volume basis, mg per ml', () => {
+    expect(concentrationToMgPerBase(44, 'mg/ml')).toEqual({
+      dim: 'VOLUME',
+      mgPerBase: 44,
+    });
+  });
+  it('g/l equals mg/ml (1 g/l = 1 mg/ml)', () => {
+    expect(concentrationToMgPerBase(10, 'g/l')).toEqual({
+      dim: 'VOLUME',
+      mgPerBase: 10,
+    });
+  });
+  it('%w/w -> mass basis, 1% = 10 mg/g', () => {
+    expect(concentrationToMgPerBase(25, '%w/w')).toEqual({
+      dim: 'MASS',
+      mgPerBase: 250,
+    });
+  });
+  it('mg/g -> mass basis', () => {
+    expect(concentrationToMgPerBase(886, 'mg/g')).toEqual({
+      dim: 'MASS',
+      mgPerBase: 886,
+    });
+  });
+  it('mg/piece -> count basis', () => {
+    expect(concentrationToMgPerBase(500, 'mg/piece')).toEqual({
+      dim: 'COUNT',
+      mgPerBase: 500,
+    });
+  });
+});
+
+describe('amountToBase', () => {
+  it('normalizes volume to ml', () => {
+    expect(amountToBase(2, 'l')).toEqual({ dim: 'VOLUME', value: 2000 });
+  });
+  it('normalizes mass to g', () => {
+    expect(amountToBase(1, 'kg')).toEqual({ dim: 'MASS', value: 1000 });
+  });
+  it('counts strips as pieces', () => {
+    expect(amountToBase(3, 'strips')).toEqual({ dim: 'COUNT', value: 3 });
+  });
+  it('returns null for unknown units', () => {
+    expect(amountToBase(1, 'bushels')).toBeNull();
+  });
+});
+
+describe('computeAppliedMassMg — same dimension', () => {
+  it('VarroMed: 30 ml at 44 mg/ml = 1320 mg oxalic acid', () => {
+    expect(
+      computeAppliedMassMg({
+        amount: 30,
+        amountUnit: 'ml',
+        concentration: 44,
+        concentrationUnit: 'mg/ml',
+      }),
+    ).toEqual({ mg: 1320, incomplete: false });
+  });
+
+  it('Apiguard: 50 g at 25 %w/w = 12500 mg (12.5 g) thymol', () => {
+    expect(
+      computeAppliedMassMg({
+        amount: 50,
+        amountUnit: 'g',
+        concentration: 25,
+        concentrationUnit: '%w/w',
+      }),
+    ).toEqual({ mg: 12500, incomplete: false });
+  });
+
+  it('Api-Bioxal: 35 g at 886 mg/g = 31010 mg oxalic acid', () => {
+    expect(
+      computeAppliedMassMg({
+        amount: 35,
+        amountUnit: 'g',
+        concentration: 886,
+        concentrationUnit: 'mg/g',
+      }),
+    ).toEqual({ mg: 31010, incomplete: false });
+  });
+
+  it('Apivar: 2 strips at 500 mg/piece = 1000 mg amitraz', () => {
+    expect(
+      computeAppliedMassMg({
+        amount: 2,
+        amountUnit: 'pcs',
+        concentration: 500,
+        concentrationUnit: 'mg/piece',
+      }),
+    ).toEqual({ mg: 1000, incomplete: false });
+  });
+
+  it('scales larger units (1 kg at 1000 mg/g = 1_000_000 mg)', () => {
+    expect(
+      computeAppliedMassMg({
+        amount: 1,
+        amountUnit: 'kg',
+        concentration: 1000,
+        concentrationUnit: 'mg/g',
+      }).mg,
+    ).toBe(1_000_000);
+  });
+});
+
+describe('computeAppliedMassMg — density bridge (volume <-> mass)', () => {
+  it('grams amount with mg/ml concentration: 33 g at density 1.1 -> 30 ml x 44 = 1320 mg', () => {
+    const r = computeAppliedMassMg({
+      amount: 33,
+      amountUnit: 'g',
+      concentration: 44,
+      concentrationUnit: 'mg/ml',
+      density: 1.1,
+    });
+    expect(r.incomplete).toBe(false);
+    expect(r.mg).toBeCloseTo(1320, 6);
+  });
+
+  it('ml amount with mg/g concentration: 30 ml at density 1.1 -> 33 g x 886 = 29238 mg', () => {
+    const r = computeAppliedMassMg({
+      amount: 30,
+      amountUnit: 'ml',
+      concentration: 886,
+      concentrationUnit: 'mg/g',
+      density: 1.1,
+    });
+    expect(r.incomplete).toBe(false);
+    expect(r.mg).toBeCloseTo(29238, 6);
+  });
+
+  it('flags incomplete when density is required but missing', () => {
+    expect(
+      computeAppliedMassMg({
+        amount: 33,
+        amountUnit: 'g',
+        concentration: 44,
+        concentrationUnit: 'mg/ml',
+      }),
+    ).toEqual({ mg: null, incomplete: true, reason: 'density-required' });
+  });
+});
+
+describe('computeAppliedMassMg — incompatible / missing', () => {
+  it('count amount vs volume concentration is incompatible', () => {
+    expect(
+      computeAppliedMassMg({
+        amount: 2,
+        amountUnit: 'pcs',
+        concentration: 44,
+        concentrationUnit: 'mg/ml',
+      }),
+    ).toEqual({
+      mg: null,
+      incomplete: true,
+      reason: 'incompatible-dimensions',
+    });
+  });
+
+  it('unknown amount unit is incomplete', () => {
+    expect(
+      computeAppliedMassMg({
+        amount: 1,
+        amountUnit: 'handful',
+        concentration: 1,
+        concentrationUnit: 'mg/g',
+      }).reason,
+    ).toBe('unknown-amount-unit');
+  });
+
+  it('missing amount is incomplete', () => {
+    expect(
+      computeAppliedMassMg({
+        amount: null,
+        amountUnit: 'ml',
+        concentration: 44,
+        concentrationUnit: 'mg/ml',
+      }).reason,
+    ).toBe('no-amount');
+  });
+});
+
+describe('computeTreatmentIngredientMasses — full product', () => {
+  it('VarroMed 30 ml yields both formic and oxalic masses', () => {
+    const res = computeTreatmentIngredientMasses(30, 'ml', {
+      density: null,
+      ingredients: [
+        { activeIngredientId: 'formic', concentration: 5, concentrationUnit: 'mg/ml' },
+        { activeIngredientId: 'oxalic', concentration: 44, concentrationUnit: 'mg/ml' },
+      ],
+    });
+    expect(res.formic).toEqual({ mg: 150, incomplete: false });
+    expect(res.oxalic).toEqual({ mg: 1320, incomplete: false });
+  });
+});

--- a/apps/e2e/tests/auth.setup.ts
+++ b/apps/e2e/tests/auth.setup.ts
@@ -7,7 +7,7 @@ setup('authenticate as admin', async ({ page }) => {
   await page.goto('/login');
   await page.getByLabel('email').fill(process.env.ADMIN_EMAIL);
   await page.getByLabel('password').fill(process.env.ADMIN_PASSWORD);
-  await page.getByRole('button', { name: /sign in/i }).click();
+  await page.getByRole('button', { name: 'Sign in', exact: true }).click();
   await expect(page.getByRole('heading', { name: 'Hive Pal' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Dashboard' })).toBeVisible();
   await page.context().storageState({ path: adminFile });

--- a/apps/e2e/tests/treatment-products/treatment-products.spec.ts
+++ b/apps/e2e/tests/treatment-products/treatment-products.spec.ts
@@ -1,0 +1,61 @@
+import { test } from '../auth/auth.fixture';
+import { expect } from '@playwright/test';
+
+test.use({ storageState: 'playwright/.auth/user.json' });
+
+/**
+ * Custom treatment products & cross-product active-ingredient tracking.
+ *
+ * The built-in catalog is seeded by the database migration, so it is
+ * available to every user without any additional setup.
+ */
+test.describe('Treatment products', () => {
+  test('built-in catalog renders products with their composition', async ({
+    page,
+  }) => {
+    await page.goto('/treatment-products');
+
+    await expect(
+      page.getByRole('heading', { name: /treatment products/i }),
+    ).toBeVisible();
+
+    // VarroMed is a combination product — it must list BOTH active
+    // ingredients (oxalic + formic acid). This is the core of the feature:
+    // a product is defined by its active-ingredient composition.
+    const varroMed = page
+      .locator('[data-test="treatment-product-card"]', { hasText: 'VarroMed' })
+      .first();
+    await expect(varroMed).toBeVisible();
+    await expect(varroMed).toContainText(/oxalic/i);
+    await expect(varroMed).toContainText(/formic/i);
+  });
+
+  test('a user can define a custom product with a composition', async ({
+    page,
+  }) => {
+    await page.goto('/treatment-products');
+
+    const name = `E2E Oxalic 3.5% ${Date.now()}`;
+
+    await page.locator('[data-test="add-treatment-product"]').click();
+    await page.locator('[data-test="tp-name"]').fill(name);
+
+    await page.locator('[data-test="tp-add-ingredient"]').click();
+    await page.locator('[data-test="tp-ingredient-select"]').first().click();
+    await page
+      .getByRole('option')
+      .filter({ hasText: /oxalic/i })
+      .first()
+      .click();
+    await page.locator('[data-test="tp-conc"]').first().fill('35');
+
+    await page.locator('[data-test="tp-save"]').click();
+
+    // The new product shows up in the user's catalog.
+    await expect(
+      page
+        .locator('[data-test="treatment-product-card"]', { hasText: name })
+        .first(),
+    ).toBeVisible();
+  });
+});

--- a/apps/frontend/public/locales/en/common.json
+++ b/apps/frontend/public/locales/en/common.json
@@ -36,7 +36,8 @@
     "swarmManagement": "Swarm Management",
     "liebefelder": "Liebefelder Method",
     "varroaManagement": "Varroa Management",
-    "documentation": "Documentation"
+    "documentation": "Documentation",
+    "treatmentProducts": "Treatment products"
   },
   "actions": {
     "save": "Save",
@@ -1236,6 +1237,8 @@
   "reports": {
     "title": "Reports",
     "selectApiary": "Select an apiary to view reports",
+    "treatmentTotals": "Active ingredients applied (across products)",
+    "treatmentTotalsEmpty": "No treatments recorded for this period.",
     "tabs": {
       "overview": "Overview",
       "charts": "Charts",
@@ -1716,5 +1719,29 @@
         }
       }
     }
+  },
+  "treatmentProducts": {
+    "title": "Treatment products",
+    "subtitle": "Define your own treatment products and their active-ingredient composition.",
+    "add": "Add product",
+    "noComposition": "No composition set",
+    "withdrawalDays": "Withdrawal: {{d}} days",
+    "withdrawalUnknown": "Withdrawal: n/a",
+    "editTitle": "Edit product",
+    "dialogHint": "Set the physical form and the active ingredients with their concentration.",
+    "name": "Name",
+    "form": "Physical form",
+    "method": "Application (optional)",
+    "defaultUnit": "Amount unit",
+    "withdrawal": "Withdrawal (days)",
+    "composition": "Active ingredients",
+    "addIngredient": "Add ingredient",
+    "density": "Density (g/ml)",
+    "densityHint": "Density is required to convert between the amount unit and a concentration measured differently.",
+    "advanced": "Advanced",
+    "cancel": "Cancel",
+    "save": "Save",
+    "deleteTitle": "Delete treatment product?",
+    "deleteDesc": "This removes your custom product. This cannot be undone."
   }
 }

--- a/apps/frontend/public/locales/en/hive.json
+++ b/apps/frontend/public/locales/en/hive.json
@@ -306,5 +306,12 @@
       "harvest": "Harvest",
       "note": "Note"
     }
+  },
+  "treatmentSummary": {
+    "title": "Applied active ingredients",
+    "inWithdrawal": "In withdrawal until {{date}} ({{product}})",
+    "safeToHarvest": "Withdrawal passed — safe to harvest",
+    "empty": "No treatments with a known composition yet.",
+    "incompleteHint": "{{n}} treatment(s) could not be converted (missing density / incompatible units)"
   }
 }

--- a/apps/frontend/public/locales/en/inspection.json
+++ b/apps/frontend/public/locales/en/inspection.json
@@ -297,7 +297,15 @@
         "selectUnit": "Select unit",
         "amount": "Amount",
         "notesOptional": "Notes (optional)",
-        "notesPlaceholder": "Add any additional notes about this treatment"
+        "notesPlaceholder": "Add any additional notes about this treatment",
+        "other": "Other (free text)",
+        "manageProducts": "Manage products",
+        "addEfficacy": "+ Add mite counts (efficacy)",
+        "miteMethod": "Mite count method",
+        "miteBefore": "Mites before",
+        "miteAfter": "Mites after",
+        "sampleSize": "Sample size (bees)",
+        "efficacy": "{{p}}% efficacy"
       },
       "frames_section": {
         "title": "Frames",

--- a/apps/frontend/src/api/hooks/index.ts
+++ b/apps/frontend/src/api/hooks/index.ts
@@ -24,3 +24,4 @@ export * from './useAdminMedia';
 export * from './useHiveScale';
 export * from './useAssistant';
 export * from './useTodos';
+export * from './useTreatmentProducts';

--- a/apps/frontend/src/api/hooks/useInspections.ts
+++ b/apps/frontend/src/api/hooks/useInspections.ts
@@ -159,8 +159,20 @@ export const transformActionsForApi = (
             details: {
               type: action.type,
               product: action.treatmentType,
+              productId: action.productId ?? null,
               quantity: action.amount,
               unit: action.unit,
+              miteCountMethod:
+                (action.miteCountMethod as
+                  | 'NATURAL_DROP'
+                  | 'SUGAR_ROLL'
+                  | 'ALCOHOL_WASH'
+                  | 'CO2'
+                  | 'OTHER'
+                  | null) ?? null,
+              miteCountBefore: action.miteCountBefore ?? null,
+              miteCountAfter: action.miteCountAfter ?? null,
+              miteSampleSize: action.miteSampleSize ?? null,
             },
           };
         case 'FRAME':

--- a/apps/frontend/src/api/hooks/useTreatmentProducts.ts
+++ b/apps/frontend/src/api/hooks/useTreatmentProducts.ts
@@ -1,0 +1,167 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../client';
+import { toast } from 'sonner';
+import {
+  ActiveIngredient,
+  AppliedIngredientTotal,
+  CreateActiveIngredientDto,
+  CreateTreatmentProductDto,
+  TreatmentProduct,
+  UpdateTreatmentProductDto,
+} from 'shared-schemas';
+import { AxiosError } from 'axios';
+
+const TP_KEYS = {
+  all: ['treatment-products'] as const,
+  lists: () => [...TP_KEYS.all, 'list'] as const,
+  ingredients: () => ['active-ingredients'] as const,
+  hiveSummary: (hiveId: string) =>
+    [...TP_KEYS.all, 'hive-summary', hiveId] as const,
+  apiaryTotals: (apiaryId: string) =>
+    [...TP_KEYS.all, 'apiary-totals', apiaryId] as const,
+};
+
+const errMsg = (e: AxiosError<{ message?: string }>, fallback: string) =>
+  e.response?.data?.message ?? fallback;
+
+export const useTreatmentProducts = () =>
+  useQuery<TreatmentProduct[]>({
+    queryKey: TP_KEYS.lists(),
+    queryFn: async () =>
+      (await apiClient.get<TreatmentProduct[]>('/api/treatment-products')).data,
+  });
+
+export const useActiveIngredients = () =>
+  useQuery<ActiveIngredient[]>({
+    queryKey: TP_KEYS.ingredients(),
+    queryFn: async () =>
+      (await apiClient.get<ActiveIngredient[]>('/api/active-ingredients')).data,
+  });
+
+export const useCreateTreatmentProduct = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (dto: CreateTreatmentProductDto) =>
+      (await apiClient.post<TreatmentProduct>('/api/treatment-products', dto))
+        .data,
+    onSuccess: () => {
+      toast.success('Treatment product created');
+      qc.invalidateQueries({ queryKey: TP_KEYS.lists() });
+    },
+    onError: (e: AxiosError<{ message?: string }>) =>
+      toast.error(errMsg(e, 'Failed to create product')),
+  });
+};
+
+export const useUpdateTreatmentProduct = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      dto,
+    }: {
+      id: string;
+      dto: UpdateTreatmentProductDto;
+    }) =>
+      (await apiClient.put<TreatmentProduct>(
+        `/api/treatment-products/${id}`,
+        dto,
+      )).data,
+    onSuccess: () => {
+      toast.success('Treatment product updated');
+      qc.invalidateQueries({ queryKey: TP_KEYS.lists() });
+    },
+    onError: (e: AxiosError<{ message?: string }>) =>
+      toast.error(errMsg(e, 'Failed to update product')),
+  });
+};
+
+export const useDeleteTreatmentProduct = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) =>
+      (await apiClient.delete(`/api/treatment-products/${id}`)).data,
+    onSuccess: () => {
+      toast.success('Treatment product deleted');
+      qc.invalidateQueries({ queryKey: TP_KEYS.lists() });
+    },
+    onError: (e: AxiosError<{ message?: string }>) =>
+      toast.error(errMsg(e, 'Failed to delete product')),
+  });
+};
+
+export const useCreateActiveIngredient = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (dto: CreateActiveIngredientDto) =>
+      (await apiClient.post<ActiveIngredient>('/api/active-ingredients', dto))
+        .data,
+    onSuccess: () => {
+      toast.success('Active ingredient added');
+      qc.invalidateQueries({ queryKey: TP_KEYS.ingredients() });
+    },
+    onError: (e: AxiosError<{ message?: string }>) =>
+      toast.error(errMsg(e, 'Failed to add ingredient')),
+  });
+};
+
+// --- Per-colony aggregation views ---
+
+export interface HiveTreatmentSummary {
+  hiveId: string;
+  from: string | null;
+  to: string | null;
+  ingredientTotals: AppliedIngredientTotal[];
+  withdrawal: {
+    inWithdrawal: boolean;
+    until: string | null;
+    product: { id: string; name: string } | null;
+  };
+}
+
+export const useHiveTreatmentSummary = (
+  hiveId: string | undefined,
+  range?: { from?: string; to?: string },
+) =>
+  useQuery<HiveTreatmentSummary>({
+    queryKey: [...TP_KEYS.hiveSummary(hiveId ?? ''), range?.from, range?.to],
+    enabled: !!hiveId,
+    queryFn: async () =>
+      (
+        await apiClient.get<HiveTreatmentSummary>(
+          `/api/hives/${hiveId}/treatment-summary`,
+          { params: { from: range?.from, to: range?.to } },
+        )
+      ).data,
+  });
+
+export interface ApiaryTreatmentTotals {
+  apiaryId: string;
+  from: string | null;
+  to: string | null;
+  byHive: Array<{
+    hiveId: string;
+    hiveName: string;
+    ingredientTotals: AppliedIngredientTotal[];
+  }>;
+}
+
+export const useApiaryTreatmentTotals = (
+  apiaryId: string | undefined,
+  range?: { from?: string; to?: string },
+) =>
+  useQuery<ApiaryTreatmentTotals>({
+    queryKey: [
+      ...TP_KEYS.apiaryTotals(apiaryId ?? ''),
+      range?.from,
+      range?.to,
+    ],
+    enabled: !!apiaryId,
+    queryFn: async () =>
+      (
+        await apiClient.get<ApiaryTreatmentTotals>(
+          `/api/apiaries/${apiaryId}/treatment-ingredient-totals`,
+          { params: { from: range?.from, to: range?.to } },
+        )
+      ).data,
+  });

--- a/apps/frontend/src/components/app-sidebar.tsx
+++ b/apps/frontend/src/components/app-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   MapPin,
   Droplets,
   Package,
+  FlaskConical,
   Layers,
   Calendar,
   BarChart3,
@@ -154,6 +155,13 @@ const getNavData = (t: TFunction<'common'>, aiEnabled: boolean) => ({
       title: t('navigation.equipment', { defaultValue: 'Equipment' }),
       url: '/equipment',
       icon: Package,
+    },
+    {
+      title: t('navigation.treatmentProducts', {
+        defaultValue: 'Treatment products',
+      }),
+      url: '/treatment-products',
+      icon: FlaskConical,
     },
     ...(aiEnabled
       ? [

--- a/apps/frontend/src/pages/hive/hive-detail-page/page.tsx
+++ b/apps/frontend/src/pages/hive/hive-detail-page/page.tsx
@@ -18,6 +18,7 @@ import { useBreadcrumbStore } from '@/stores/breadcrumb-store';
 import { QueenHistoryTab } from './queen-history-tab';
 import { HiveStatusButton } from './hive-status-button';
 import { HiveTodos } from './hive-todos';
+import { TreatmentSummary } from './treatment-summary';
 import { buildBoxGradient } from '@/utils/box-gradient';
 import { useImageDisplayStore } from '@/stores/image-display-store';
 import { AlertTriangle, Map } from 'lucide-react';
@@ -259,6 +260,7 @@ export const HiveDetailPage = () => {
                 </Alert>
               )}
               {hiveId && <HiveTodos hiveId={hiveId} />}
+              {hiveId && <TreatmentSummary hiveId={hiveId} />}
               <HiveTimeline hiveId={hiveId} apiaryId={hive?.apiaryId} />
             </TabsContent>
 

--- a/apps/frontend/src/pages/hive/hive-detail-page/treatment-summary.tsx
+++ b/apps/frontend/src/pages/hive/hive-detail-page/treatment-summary.tsx
@@ -1,0 +1,114 @@
+import { useTranslation } from 'react-i18next';
+import { FlaskConical, AlertTriangle, ShieldCheck, ShieldAlert } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { useHiveTreatmentSummary } from '@/api/hooks';
+
+interface Props {
+  hiveId: string;
+  variant?: 'inline' | 'full';
+}
+
+/** Human-readable mass: mg below 1 g, otherwise g with up to 2 decimals. */
+function formatMass(mg: number): string {
+  if (mg < 1000) return `${Math.round(mg)} mg`;
+  const g = mg / 1000;
+  return `${g >= 100 ? g.toFixed(0) : g.toFixed(2)} g`;
+}
+
+export function TreatmentSummary({ hiveId }: Props) {
+  const { t } = useTranslation('hive');
+  const { data, isLoading } = useHiveTreatmentSummary(hiveId);
+
+  const totals = data?.ingredientTotals ?? [];
+  const withdrawal = data?.withdrawal;
+
+  return (
+    <Card data-test="treatment-summary-card">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <FlaskConical className="h-4 w-4" />
+          {t('treatmentSummary.title', {
+            defaultValue: 'Applied active ingredients',
+          })}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Withdrawal status */}
+        {withdrawal && (
+          <div>
+            {withdrawal.inWithdrawal ? (
+              <Badge
+                variant="destructive"
+                className="gap-1"
+                data-test="withdrawal-active"
+              >
+                <ShieldAlert className="h-3.5 w-3.5" />
+                {t('treatmentSummary.inWithdrawal', {
+                  defaultValue: 'In withdrawal until {{date}} ({{product}})',
+                  date: withdrawal.until
+                    ? new Date(withdrawal.until).toLocaleDateString()
+                    : '',
+                  product: withdrawal.product?.name ?? '',
+                })}
+              </Badge>
+            ) : withdrawal.product ? (
+              <Badge variant="secondary" className="gap-1" data-test="withdrawal-clear">
+                <ShieldCheck className="h-3.5 w-3.5" />
+                {t('treatmentSummary.safeToHarvest', {
+                  defaultValue: 'Withdrawal passed — safe to harvest',
+                })}
+              </Badge>
+            ) : null}
+          </div>
+        )}
+
+        {isLoading && (
+          <p className="text-sm text-muted-foreground">Loading…</p>
+        )}
+
+        {!isLoading && totals.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            {t('treatmentSummary.empty', {
+              defaultValue: 'No treatments with a known composition yet.',
+            })}
+          </p>
+        )}
+
+        {totals.length > 0 && (
+          <ul className="divide-y" data-test="ingredient-totals">
+            {totals.map((it) => (
+              <li
+                key={it.activeIngredientId}
+                className="flex items-center justify-between py-1.5 text-sm"
+              >
+                <span>{it.name}</span>
+                <span className="flex items-center gap-2 font-medium">
+                  {formatMass(it.totalMg)}
+                  {it.incompleteCount > 0 && (
+                    <span
+                      title={t('treatmentSummary.incompleteHint', {
+                        defaultValue:
+                          '{{n}} treatment(s) could not be converted (missing density / incompatible units)',
+                        n: it.incompleteCount,
+                      })}
+                    >
+                      <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+                    </span>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default TreatmentSummary;

--- a/apps/frontend/src/pages/inspection/components/inspection-form/actions/treatment.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/actions/treatment.tsx
@@ -6,7 +6,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import NumericInputField from '@/components/common/numeric-input-field.tsx';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -14,25 +15,35 @@ import { TEST_SELECTORS } from '@/utils/test-selectors.ts';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { useUnitFormat } from '@/hooks/use-unit-format';
+import { useTreatmentProducts } from '@/api/hooks';
 import {
   parseVolume,
   parseMass,
   formatTreatmentQuantity,
   getTreatmentDisplayUnit,
 } from '@/utils/unit-conversion';
-import {
-  TREATMENT_PRODUCTS,
-  TREATMENT_UNITS,
-  TreatmentProductId,
-} from 'shared-schemas';
+import { TREATMENT_UNITS } from 'shared-schemas';
 import { ActionViewRenderer } from './action-view-container';
+
+const MITE_METHODS = [
+  'NATURAL_DROP',
+  'SUGAR_ROLL',
+  'ALCOHOL_WASH',
+  'CO2',
+  'OTHER',
+] as const;
 
 export type TreatmentActionType = {
   type: 'TREATMENT';
   treatmentType: string;
+  productId?: string | null;
   amount: number | null;
   unit: string;
   notes?: string;
+  miteCountMethod?: string | null;
+  miteCountBefore?: number | null;
+  miteCountAfter?: number | null;
+  miteSampleSize?: number | null;
 };
 
 type TreatmentActionProps = {
@@ -41,146 +52,175 @@ type TreatmentActionProps = {
   onRemove: (action: 'TREATMENT') => void;
 };
 
+const OTHER = 'OTHER';
+
 export const TreatmentForm: React.FC<TreatmentActionProps> = ({
   action,
   onSave,
 }) => {
   const { t } = useTranslation('inspection');
   const { unitPreference } = useUnitFormat();
+  const { data: products } = useTreatmentProducts();
 
-  // Get initial values from action or defaults
-  const getInitialUnit = (): string => {
-    if (action?.unit) return action.unit;
-    const config =
-      TREATMENT_PRODUCTS[action?.treatmentType as TreatmentProductId];
-    return config?.defaultUnit ?? 'ml';
-  };
+  // Resolve initial selection: prefer the linked productId, then a name match, else custom.
+  const initialSelection = useMemo(() => {
+    if (action?.productId) return action.productId;
+    if (action?.treatmentType && products) {
+      const byName = products.find((p) => p.name === action.treatmentType);
+      if (byName) return byName.id;
+    }
+    return action?.treatmentType ? OTHER : '';
+  }, [action?.productId, action?.treatmentType, products]);
 
-  const [treatmentType, setTreatmentType] = useState<string>(
-    action?.treatmentType ?? 'OXALIC_ACID',
-  );
+  const [selectedId, setSelectedId] = useState<string>(initialSelection);
   const [customProductName, setCustomProductName] = useState<string>(
-    // If treatmentType is not in TREATMENT_PRODUCTS, it's a custom name
-    action?.treatmentType && !(action.treatmentType in TREATMENT_PRODUCTS)
-      ? action.treatmentType
-      : '',
+    action?.productId ? '' : (action?.treatmentType ?? ''),
   );
-  const [unit, setUnit] = useState<string>(getInitialUnit());
+  const [unit, setUnit] = useState<string>(action?.unit ?? 'ml');
   const [amount, setAmount] = useState<number | null>(action?.amount ?? 1);
   const [notes, setNotes] = useState<string>(action?.notes ?? '');
+  const [showEfficacy, setShowEfficacy] = useState<boolean>(
+    action?.miteCountBefore != null || action?.miteCountAfter != null,
+  );
+  const [miteMethod, setMiteMethod] = useState<string>(
+    action?.miteCountMethod ?? '',
+  );
+  const [miteBefore, setMiteBefore] = useState<number | null>(
+    action?.miteCountBefore ?? null,
+  );
+  const [miteAfter, setMiteAfter] = useState<number | null>(
+    action?.miteCountAfter ?? null,
+  );
+  const [sampleSize, setSampleSize] = useState<number | null>(
+    action?.miteSampleSize ?? null,
+  );
 
-  // Get config for current treatment type
-  const currentConfig = TREATMENT_PRODUCTS[treatmentType as TreatmentProductId];
-  const requiresQuantity = currentConfig?.requiresQuantity ?? true;
-  const isOther = treatmentType === 'OTHER';
-
-  // Get display unit based on storage unit and user preference
+  const selectedProduct = products?.find((p) => p.id === selectedId);
+  const isOther = selectedId === OTHER;
   const displayUnit = getTreatmentDisplayUnit(unit, unitPreference);
 
-  const handleTreatmentTypeChange = (newType: string) => {
-    setTreatmentType(newType);
-    const config = TREATMENT_PRODUCTS[newType as TreatmentProductId];
-    if (config) {
-      setUnit(config.defaultUnit);
-      if (!config.requiresQuantity) {
-        setAmount(null);
-      } else if (amount === null) {
-        setAmount(1);
-      }
-    }
-    // Clear custom name when switching away from OTHER
-    if (newType !== 'OTHER') {
-      setCustomProductName('');
-    }
+  const handleProductChange = (value: string) => {
+    setSelectedId(value);
+    if (value === OTHER) return;
+    const product = products?.find((p) => p.id === value);
+    if (product?.defaultUnit) setUnit(product.defaultUnit);
+    setCustomProductName('');
   };
 
   const handleSave = () => {
-    // Determine the product name to store
-    const product = isOther ? customProductName : treatmentType;
+    const productName = isOther
+      ? customProductName
+      : (selectedProduct?.name ?? '');
 
-    // Convert user input to metric for storage
     let apiAmount = amount;
     if (amount !== null) {
       if (unit === 'ml' && unitPreference === 'imperial') {
-        // User entered fl oz, convert to ml
-        const volumeInLiters = parseVolume(amount, 'fl oz', unitPreference);
-        apiAmount = volumeInLiters * 1000;
+        apiAmount = parseVolume(amount, 'fl oz', unitPreference) * 1000;
       } else if (unit === 'g' && unitPreference === 'imperial') {
-        // User entered oz, convert to g
         apiAmount = parseMass(amount, 'oz', unitPreference);
       }
-      // pcs doesn't need conversion
     }
 
     onSave({
       type: 'TREATMENT',
-      treatmentType: product,
-      amount: requiresQuantity ? apiAmount : null,
+      treatmentType: productName,
+      productId: isOther ? null : selectedId,
+      amount: apiAmount,
       unit,
       notes: notes.trim() || undefined,
+      miteCountMethod: showEfficacy && miteMethod ? miteMethod : null,
+      miteCountBefore: showEfficacy ? miteBefore : null,
+      miteCountAfter: showEfficacy ? miteAfter : null,
+      miteSampleSize: showEfficacy ? sampleSize : null,
     });
   };
 
-  // Validate form: need treatment type (and custom name if OTHER) and amount if required
   const isValid =
-    treatmentType &&
-    (!isOther || customProductName.trim()) &&
-    (!requiresQuantity || (amount !== null && amount > 0));
+    (isOther ? customProductName.trim() : selectedId) &&
+    amount !== null &&
+    amount > 0;
 
   return (
     <div
       className={'grid grid-cols-2 gap-4 mt-5'}
       data-test={TEST_SELECTORS.TREATMENT_FORM}
     >
-      <h3 className="col-span-2 text-lg font-bold">{t('inspection:form.actions.treatment_section.title')}</h3>
+      <h3 className="col-span-2 text-lg font-bold">
+        {t('inspection:form.actions.treatment_section.title')}
+      </h3>
 
-      {/* Treatment Type Selector */}
+      {/* Product Selector (catalog: built-ins + custom) */}
       <div className={'col-span-2 lg:col-span-1 flex flex-col gap-4'}>
-        <label htmlFor={'treatment-type'}>{t('inspection:form.actions.treatment_section.treatmentType')}</label>
-        <Select value={treatmentType} onValueChange={handleTreatmentTypeChange}>
-          <SelectTrigger className={'w-full'}>
+        <label htmlFor={'treatment-type'}>
+          {t('inspection:form.actions.treatment_section.treatmentType')}
+        </label>
+        <Select value={selectedId} onValueChange={handleProductChange}>
+          <SelectTrigger className={'w-full'} data-test="treatment-product-select">
             <SelectValue
               id={'treatment-type'}
-              placeholder={t('inspection:form.actions.treatment_section.selectTreatmentType')}
-            >
-              {TREATMENT_PRODUCTS[treatmentType as TreatmentProductId]?.label ??
-                treatmentType}
-            </SelectValue>
+              placeholder={t(
+                'inspection:form.actions.treatment_section.selectTreatmentType',
+              )}
+            />
           </SelectTrigger>
           <SelectContent>
-            {Object.entries(TREATMENT_PRODUCTS).map(([id, config]) => (
-              <SelectItem key={id} value={id}>
-                {config.label}
+            {products?.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.name}
               </SelectItem>
             ))}
+            <SelectItem value={OTHER}>
+              {t('inspection:form.actions.treatment_section.other', {
+                defaultValue: 'Other (free text)',
+              })}
+            </SelectItem>
           </SelectContent>
         </Select>
+        <Link
+          to="/treatment-products"
+          className="text-xs text-muted-foreground underline"
+        >
+          {t('inspection:form.actions.treatment_section.manageProducts', {
+            defaultValue: 'Manage products',
+          })}
+        </Link>
       </div>
 
-      {/* Custom Product Name (shown only for OTHER) */}
+      {/* Custom Product Name (OTHER) */}
       {isOther && (
         <div className={'col-span-2 lg:col-span-1 flex flex-col gap-4'}>
-          <label htmlFor={'custom-product'}>{t('inspection:form.actions.treatment_section.productName')}</label>
+          <label htmlFor={'custom-product'}>
+            {t('inspection:form.actions.treatment_section.productName')}
+          </label>
           <Input
             id={'custom-product'}
-            placeholder={t('inspection:form.actions.treatment_section.productNamePlaceholder')}
+            placeholder={t(
+              'inspection:form.actions.treatment_section.productNamePlaceholder',
+            )}
             value={customProductName}
-            onChange={e => setCustomProductName(e.target.value)}
+            onChange={(e) => setCustomProductName(e.target.value)}
           />
         </div>
       )}
 
       {/* Unit Selector */}
       <div className={`col-span-2 lg:col-span-1 flex flex-col gap-4`}>
-        <label htmlFor={'unit'}>{t('inspection:form.actions.treatment_section.unit')}</label>
+        <label htmlFor={'unit'}>
+          {t('inspection:form.actions.treatment_section.unit')}
+        </label>
         <Select value={unit} onValueChange={setUnit}>
           <SelectTrigger className={'w-full'}>
-            <SelectValue id={'unit'} placeholder={t('inspection:form.actions.treatment_section.selectUnit')}>
+            <SelectValue
+              id={'unit'}
+              placeholder={t(
+                'inspection:form.actions.treatment_section.selectUnit',
+              )}
+            >
               {displayUnit}
             </SelectValue>
           </SelectTrigger>
           <SelectContent>
-            {TREATMENT_UNITS.map(u => (
+            {TREATMENT_UNITS.map((u) => (
               <SelectItem key={u} value={u}>
                 {getTreatmentDisplayUnit(u, unitPreference)}
               </SelectItem>
@@ -189,36 +229,116 @@ export const TreatmentForm: React.FC<TreatmentActionProps> = ({
         </Select>
       </div>
 
-      {/* Amount (conditionally shown based on requiresQuantity) */}
-      {requiresQuantity && (
-        <div className={'col-span-2 lg:col-span-1 flex flex-col gap-4'}>
-          <label htmlFor={'amount'}>{t('inspection:form.actions.treatment_section.amount')}</label>
-          <NumericInputField
-            id={'amount'}
-            step={unit === 'pcs' ? 1 : 5}
-            min={0}
-            value={amount}
-            onChange={e => setAmount(e)}
-            unit={displayUnit}
-          />
-        </div>
-      )}
+      {/* Amount */}
+      <div className={'col-span-2 lg:col-span-1 flex flex-col gap-4'}>
+        <label htmlFor={'amount'}>
+          {t('inspection:form.actions.treatment_section.amount')}
+        </label>
+        <NumericInputField
+          id={'amount'}
+          step={unit === 'pcs' ? 1 : 5}
+          min={0}
+          value={amount}
+          onChange={(e) => setAmount(e)}
+          unit={displayUnit}
+        />
+      </div>
+
+      {/* Efficacy (optional) */}
+      <div className="col-span-2">
+        {!showEfficacy ? (
+          <button
+            type="button"
+            className="text-xs text-muted-foreground underline"
+            onClick={() => setShowEfficacy(true)}
+          >
+            {t('inspection:form.actions.treatment_section.addEfficacy', {
+              defaultValue: '+ Add mite counts (efficacy)',
+            })}
+          </button>
+        ) : (
+          <div className="grid grid-cols-2 gap-3 rounded border p-3">
+            <div className="col-span-2 flex flex-col gap-1">
+              <label className="text-sm">
+                {t('inspection:form.actions.treatment_section.miteMethod', {
+                  defaultValue: 'Mite count method',
+                })}
+              </label>
+              <Select value={miteMethod} onValueChange={setMiteMethod}>
+                <SelectTrigger data-test="mite-method">
+                  <SelectValue placeholder="—" />
+                </SelectTrigger>
+                <SelectContent>
+                  {MITE_METHODS.map((m) => (
+                    <SelectItem key={m} value={m}>
+                      {m}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-sm">
+                {t('inspection:form.actions.treatment_section.miteBefore', {
+                  defaultValue: 'Mites before',
+                })}
+              </label>
+              <NumericInputField
+                min={0}
+                value={miteBefore}
+                onChange={(e) => setMiteBefore(e)}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-sm">
+                {t('inspection:form.actions.treatment_section.miteAfter', {
+                  defaultValue: 'Mites after',
+                })}
+              </label>
+              <NumericInputField
+                min={0}
+                value={miteAfter}
+                onChange={(e) => setMiteAfter(e)}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-sm">
+                {t('inspection:form.actions.treatment_section.sampleSize', {
+                  defaultValue: 'Sample size (bees)',
+                })}
+              </label>
+              <NumericInputField
+                min={0}
+                value={sampleSize}
+                onChange={(e) => setSampleSize(e)}
+              />
+            </div>
+          </div>
+        )}
+      </div>
 
       {/* Notes */}
       <div className="col-span-2 flex flex-col gap-4">
-        <label htmlFor="notes">{t('inspection:form.actions.treatment_section.notesOptional')}</label>
+        <label htmlFor="notes">
+          {t('inspection:form.actions.treatment_section.notesOptional')}
+        </label>
         <Textarea
           id="notes"
-          placeholder={t('inspection:form.actions.treatment_section.notesPlaceholder')}
+          placeholder={t(
+            'inspection:form.actions.treatment_section.notesPlaceholder',
+          )}
           value={notes}
-          onChange={e => setNotes(e.target.value)}
+          onChange={(e) => setNotes(e.target.value)}
           data-test={TEST_SELECTORS.TREATMENT_NOTES}
         />
       </div>
 
-      {/* Save Button */}
       <div className="col-span-2 flex justify-end">
-        {isValid && <Button onClick={handleSave}>{t('inspection:form.actions.save')}</Button>}
+        {isValid && (
+          <Button onClick={handleSave} data-test="treatment-save">
+            {t('inspection:form.actions.save')}
+          </Button>
+        )}
       </div>
     </div>
   );
@@ -237,21 +357,27 @@ export const TreatmentView: React.FC<TreatmentActionProps> = ({
     return null;
   }
 
-  // Get treatment label - either from TREATMENT_PRODUCTS or use raw value for custom
-  const treatmentLabel =
-    TREATMENT_PRODUCTS[action.treatmentType as TreatmentProductId]?.label ??
-    action.treatmentType;
+  const treatmentLabel = action.treatmentType;
 
-  // Format the quantity display based on unit type and user preference
   const getDisplayValue = () => {
     if (action.amount === null || action.amount === undefined) {
-      return null; // No quantity to display
+      return null;
     }
     return formatTreatmentQuantity(action.amount, action.unit, unitPreference)
       .label;
   };
 
   const displayValue = getDisplayValue();
+  const efficacy =
+    action.miteCountBefore != null &&
+    action.miteCountAfter != null &&
+    action.miteCountBefore > 0
+      ? Math.round(
+          ((action.miteCountBefore - action.miteCountAfter) /
+            action.miteCountBefore) *
+            100,
+        )
+      : null;
 
   const handleSave = (updatedAction: TreatmentActionType) => {
     onSave(updatedAction);
@@ -259,11 +385,7 @@ export const TreatmentView: React.FC<TreatmentActionProps> = ({
   };
 
   return isEditing ? (
-    <TreatmentForm
-      action={action}
-      onSave={handleSave}
-      onRemove={onRemove}
-    />
+    <TreatmentForm action={action} onSave={handleSave} onRemove={onRemove} />
   ) : (
     <ActionViewRenderer
       title={t('inspection:form.actions.treatment_section.title')}
@@ -271,6 +393,14 @@ export const TreatmentView: React.FC<TreatmentActionProps> = ({
         <>
           <Badge>{treatmentLabel}</Badge>
           {displayValue && <span>{displayValue}</span>}
+          {efficacy != null && (
+            <Badge variant="secondary" data-test="treatment-efficacy">
+              {t('inspection:form.actions.treatment_section.efficacy', {
+                defaultValue: '{{p}}% efficacy',
+                p: efficacy,
+              })}
+            </Badge>
+          )}
         </>
       }
       notes={action.notes}

--- a/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
@@ -155,7 +155,12 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
               notes: action.notes ?? '',
               amount: details.quantity,
               treatmentType: details.product,
+              productId: details.productId ?? null,
               unit: details.unit,
+              miteCountMethod: details.miteCountMethod ?? null,
+              miteCountBefore: details.miteCountBefore ?? null,
+              miteCountAfter: details.miteCountAfter ?? null,
+              miteSampleSize: details.miteSampleSize ?? null,
             };
           }
 

--- a/apps/frontend/src/pages/inspection/components/inspection-form/schema.ts
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/schema.ts
@@ -33,9 +33,14 @@ export const feedingActionSchema = z.object({
 export const treatmentActionSchema = z.object({
   type: z.literal(ActionType.TREATMENT),
   treatmentType: z.string(),
-  amount: z.number(),
+  productId: z.string().nullish(),
+  amount: z.number().nullable(),
   unit: z.string(),
   notes: z.string().optional(),
+  miteCountMethod: z.string().nullish(),
+  miteCountBefore: z.number().nullish(),
+  miteCountAfter: z.number().nullish(),
+  miteSampleSize: z.number().nullish(),
 });
 
 // Frames action

--- a/apps/frontend/src/pages/reports/components/treatment-totals-card.tsx
+++ b/apps/frontend/src/pages/reports/components/treatment-totals-card.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useApiaryTreatmentTotals } from '@/api/hooks';
+
+interface Props {
+  apiaryId?: string;
+  period?: string;
+}
+
+function periodToFrom(period?: string): string | undefined {
+  const now = new Date();
+  switch (period) {
+    case '1month':
+      return new Date(now.setMonth(now.getMonth() - 1)).toISOString();
+    case '3months':
+      return new Date(now.setMonth(now.getMonth() - 3)).toISOString();
+    case '6months':
+      return new Date(now.setMonth(now.getMonth() - 6)).toISOString();
+    case '1year':
+      return new Date(now.setFullYear(now.getFullYear() - 1)).toISOString();
+    case 'ytd':
+      return new Date(now.getFullYear(), 0, 1).toISOString();
+    default:
+      return undefined; // all time
+  }
+}
+
+function formatMass(mg: number): string {
+  if (mg < 1000) return `${Math.round(mg)} mg`;
+  const g = mg / 1000;
+  return `${g >= 100 ? g.toFixed(0) : g.toFixed(2)} g`;
+}
+
+export function TreatmentTotalsCard({ apiaryId, period }: Props) {
+  const { t } = useTranslation('common');
+  const from = useMemo(() => periodToFrom(period), [period]);
+  const { data } = useApiaryTreatmentTotals(apiaryId, { from });
+
+  // Sum each active ingredient across all hives in the apiary.
+  const summed = useMemo(() => {
+    const map = new Map<string, { name: string; mg: number }>();
+    for (const hive of data?.byHive ?? []) {
+      for (const it of hive.ingredientTotals) {
+        const cur = map.get(it.activeIngredientId) ?? { name: it.name, mg: 0 };
+        cur.mg += it.totalMg;
+        map.set(it.activeIngredientId, cur);
+      }
+    }
+    return [...map.values()].sort((a, b) => b.mg - a.mg);
+  }, [data]);
+
+  const max = summed[0]?.mg ?? 0;
+
+  return (
+    <Card data-test="treatment-totals-card">
+      <CardHeader>
+        <CardTitle>
+          {t('reports.treatmentTotals', {
+            defaultValue: 'Active ingredients applied (across products)',
+          })}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {summed.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t('reports.treatmentTotalsEmpty', {
+              defaultValue: 'No treatments recorded for this period.',
+            })}
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {summed.map((s) => (
+              <li key={s.name}>
+                <div className="flex items-center justify-between text-sm mb-0.5">
+                  <span>{s.name}</span>
+                  <span className="font-medium">{formatMass(s.mg)}</span>
+                </div>
+                <div className="h-2 rounded bg-muted overflow-hidden">
+                  <div
+                    className="h-full bg-primary"
+                    style={{ width: `${max ? (s.mg / max) * 100 : 0}%` }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default TreatmentTotalsCard;

--- a/apps/frontend/src/pages/reports/reports-page.tsx
+++ b/apps/frontend/src/pages/reports/reports-page.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { ReportPeriod } from 'shared-schemas';
 import { toast } from 'sonner';
 import { FeedingTotalsChart } from './components/charts/feeding-totals-chart';
+import { TreatmentTotalsCard } from './components/treatment-totals-card';
 import { FeedingTrendChart } from './components/charts/feeding-trend-chart';
 import { HealthTrendChart } from './components/charts/health-trend-chart';
 import { HiveScoreTrendChart } from './components/charts/hive-score-trend-chart';
@@ -151,6 +152,10 @@ export const ReportsPage = () => {
               <FeedingTotalsChart
                 data={statistics?.feedingTotals.byHive}
                 isLoading={isLoading}
+              />
+              <TreatmentTotalsCard
+                apiaryId={activeApiaryId || undefined}
+                period={period}
               />
             </TabsContent>
             <TabsContent value="trends" className="space-y-6 pt-4">

--- a/apps/frontend/src/pages/treatment-products/treatment-products-page.tsx
+++ b/apps/frontend/src/pages/treatment-products/treatment-products-page.tsx
@@ -1,0 +1,567 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Plus, Pencil, Trash2, FlaskConical, Lock } from 'lucide-react';
+import {
+  amountUnitDimension,
+  concentrationToMgPerBase,
+  CONCENTRATION_UNITS,
+  type ConcentrationUnit,
+  type CreateTreatmentProductDto,
+  type TreatmentProduct,
+} from 'shared-schemas';
+import {
+  useActiveIngredients,
+  useCreateTreatmentProduct,
+  useDeleteTreatmentProduct,
+  useTreatmentProducts,
+  useUpdateTreatmentProduct,
+} from '@/api/hooks';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { DeleteConfirmDialog } from '@/components/common/delete-confirm-dialog';
+import { useDeleteDialog } from '@/hooks/useDeleteDialog';
+
+const PHYSICAL_FORMS = ['LIQUID', 'POWDER', 'GEL', 'STRIP', 'GASEOUS'] as const;
+const APPLICATION_METHODS = [
+  'TRICKLE',
+  'SPRAY',
+  'SUBLIMATE',
+  'EVAPORATE',
+  'INSERT',
+  'OTHER',
+] as const;
+const AMOUNT_UNITS = ['ml', 'g', 'pcs'] as const;
+
+interface IngredientRow {
+  activeIngredientId: string;
+  concentration: string;
+  concentrationUnit: ConcentrationUnit;
+}
+interface ProductForm {
+  name: string;
+  physicalForm: (typeof PHYSICAL_FORMS)[number];
+  applicationMethod: string;
+  defaultUnit: string;
+  density: string;
+  withdrawalPeriodDays: string;
+  ingredients: IngredientRow[];
+}
+
+const emptyForm: ProductForm = {
+  name: '',
+  physicalForm: 'LIQUID',
+  applicationMethod: '',
+  defaultUnit: 'ml',
+  density: '',
+  withdrawalPeriodDays: '',
+  ingredients: [],
+};
+
+/** Density is only needed when the amount unit and a concentration basis differ dimensions (volume<->mass). */
+function densityNeeded(form: ProductForm): boolean {
+  const amtDim = amountUnitDimension(form.defaultUnit);
+  if (!amtDim) return false;
+  return form.ingredients.some((i) => {
+    const cDim = concentrationToMgPerBase(1, i.concentrationUnit).dim;
+    return (
+      (amtDim === 'VOLUME' && cDim === 'MASS') ||
+      (amtDim === 'MASS' && cDim === 'VOLUME')
+    );
+  });
+}
+
+export function TreatmentProductsPage() {
+  const { t } = useTranslation('hive');
+  const { data: products, isLoading } = useTreatmentProducts();
+  const { data: ingredients } = useActiveIngredients();
+  const createMut = useCreateTreatmentProduct();
+  const updateMut = useUpdateTreatmentProduct();
+  const deleteMut = useDeleteTreatmentProduct();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<TreatmentProduct | null>(null);
+  const [form, setForm] = useState<ProductForm>(emptyForm);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [toDelete, setToDelete] = useState<TreatmentProduct | null>(null);
+
+  const deleteDialog = useDeleteDialog(async () => {
+    if (toDelete) await deleteMut.mutateAsync(toDelete.id);
+  });
+
+  const ingredientName = (id: string) =>
+    ingredients?.find((i) => i.id === id)?.name ?? id;
+
+  const openCreate = () => {
+    setEditing(null);
+    setForm(emptyForm);
+    setShowAdvanced(false);
+    setDialogOpen(true);
+  };
+  const openEdit = (p: TreatmentProduct) => {
+    setEditing(p);
+    setForm({
+      name: p.name,
+      physicalForm: p.physicalForm,
+      applicationMethod: p.applicationMethod ?? '',
+      defaultUnit: p.defaultUnit ?? 'ml',
+      density: p.density != null ? String(p.density) : '',
+      withdrawalPeriodDays:
+        p.withdrawalPeriodDays != null ? String(p.withdrawalPeriodDays) : '',
+      ingredients: p.ingredients.map((i) => ({
+        activeIngredientId: i.activeIngredientId,
+        concentration: String(i.concentration),
+        concentrationUnit: i.concentrationUnit,
+      })),
+    });
+    setShowAdvanced(p.density != null);
+    setDialogOpen(true);
+  };
+
+  const setField = <K extends keyof ProductForm>(k: K, v: ProductForm[K]) =>
+    setForm((prev) => ({ ...prev, [k]: v }));
+
+  const addIngredientRow = () =>
+    setForm((prev) => ({
+      ...prev,
+      ingredients: [
+        ...prev.ingredients,
+        {
+          activeIngredientId: ingredients?.[0]?.id ?? '',
+          concentration: '',
+          concentrationUnit: 'mg/ml',
+        },
+      ],
+    }));
+  const setIngredient = (idx: number, patch: Partial<IngredientRow>) =>
+    setForm((prev) => ({
+      ...prev,
+      ingredients: prev.ingredients.map((r, i) =>
+        i === idx ? { ...r, ...patch } : r,
+      ),
+    }));
+  const removeIngredient = (idx: number) =>
+    setForm((prev) => ({
+      ...prev,
+      ingredients: prev.ingredients.filter((_, i) => i !== idx),
+    }));
+
+  const needDensity = densityNeeded(form);
+
+  const canSave =
+    form.name.trim().length >= 2 &&
+    form.ingredients.every(
+      (i) => i.activeIngredientId && Number(i.concentration) > 0,
+    );
+
+  const handleSave = async () => {
+    const dto: CreateTreatmentProductDto = {
+      name: form.name.trim(),
+      physicalForm: form.physicalForm,
+      applicationMethod: form.applicationMethod
+        ? (form.applicationMethod as CreateTreatmentProductDto['applicationMethod'])
+        : null,
+      defaultUnit: form.defaultUnit || null,
+      density: form.density ? Number(form.density) : null,
+      withdrawalPeriodDays: form.withdrawalPeriodDays
+        ? Number(form.withdrawalPeriodDays)
+        : null,
+      ingredients: form.ingredients.map((i) => ({
+        activeIngredientId: i.activeIngredientId,
+        concentration: Number(i.concentration),
+        concentrationUnit: i.concentrationUnit,
+      })),
+    };
+    if (editing) await updateMut.mutateAsync({ id: editing.id, dto });
+    else await createMut.mutateAsync(dto);
+    setDialogOpen(false);
+  };
+
+  const sorted = useMemo(
+    () =>
+      [...(products ?? [])].sort(
+        (a, b) =>
+          Number(b.isBuiltIn) - Number(a.isBuiltIn) ||
+          a.name.localeCompare(b.name),
+      ),
+    [products],
+  );
+
+  return (
+    <div className="container mx-auto max-w-4xl py-6 space-y-4" data-test="treatment-products-page">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold flex items-center gap-2">
+            <FlaskConical className="h-6 w-6" />
+            {t('treatmentProducts.title', { defaultValue: 'Treatment products' })}
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            {t('treatmentProducts.subtitle', {
+              defaultValue:
+                'Define your own treatment products and their active-ingredient composition.',
+            })}
+          </p>
+        </div>
+        <Button onClick={openCreate} data-test="add-treatment-product">
+          <Plus className="h-4 w-4 mr-1" />
+          {t('treatmentProducts.add', { defaultValue: 'Add product' })}
+        </Button>
+      </div>
+
+      {isLoading && <p className="text-muted-foreground">Loading…</p>}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {sorted.map((p) => (
+          <Card key={p.id} data-test="treatment-product-card">
+            <CardHeader className="pb-2">
+              <div className="flex items-start justify-between gap-2">
+                <CardTitle className="text-base flex items-center gap-2">
+                  {p.name}
+                  {p.isBuiltIn && (
+                    <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+                  )}
+                </CardTitle>
+                <div className="flex gap-1">
+                  <Badge variant="secondary">{p.physicalForm}</Badge>
+                </div>
+              </div>
+              <CardDescription>
+                {p.ingredients.length === 0
+                  ? t('treatmentProducts.noComposition', {
+                      defaultValue: 'No composition set',
+                    })
+                  : p.ingredients
+                      .map(
+                        (i) =>
+                          `${ingredientName(i.activeIngredientId)} ${i.concentration} ${i.concentrationUnit}`,
+                      )
+                      .join(' · ')}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex items-center justify-between pt-0">
+              <span className="text-xs text-muted-foreground">
+                {p.withdrawalPeriodDays != null
+                  ? t('treatmentProducts.withdrawalDays', {
+                      defaultValue: 'Withdrawal: {{d}} days',
+                      d: p.withdrawalPeriodDays,
+                    })
+                  : t('treatmentProducts.withdrawalUnknown', {
+                      defaultValue: 'Withdrawal: n/a',
+                    })}
+              </span>
+              {!p.isBuiltIn && (
+                <div className="flex gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => openEdit(p)}
+                    data-test="edit-treatment-product"
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => {
+                      setToDelete(p);
+                      deleteDialog.open();
+                    }}
+                    data-test="delete-treatment-product"
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              {editing
+                ? t('treatmentProducts.editTitle', { defaultValue: 'Edit product' })
+                : t('treatmentProducts.add', { defaultValue: 'Add product' })}
+            </DialogTitle>
+            <DialogDescription>
+              {t('treatmentProducts.dialogHint', {
+                defaultValue:
+                  'Set the physical form and the active ingredients with their concentration.',
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label>{t('treatmentProducts.name', { defaultValue: 'Name' })}</Label>
+              <Input
+                value={form.name}
+                onChange={(e) => setField('name', e.target.value)}
+                data-test="tp-name"
+                placeholder="VarroMed"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label>
+                  {t('treatmentProducts.form', { defaultValue: 'Physical form' })}
+                </Label>
+                <Select
+                  value={form.physicalForm}
+                  onValueChange={(v) =>
+                    setField('physicalForm', v as ProductForm['physicalForm'])
+                  }
+                >
+                  <SelectTrigger data-test="tp-form">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PHYSICAL_FORMS.map((f) => (
+                      <SelectItem key={f} value={f}>
+                        {f}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <Label>
+                  {t('treatmentProducts.method', {
+                    defaultValue: 'Application (optional)',
+                  })}
+                </Label>
+                <Select
+                  value={form.applicationMethod || 'none'}
+                  onValueChange={(v) =>
+                    setField('applicationMethod', v === 'none' ? '' : v)
+                  }
+                >
+                  <SelectTrigger data-test="tp-method">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">—</SelectItem>
+                    {APPLICATION_METHODS.map((m) => (
+                      <SelectItem key={m} value={m}>
+                        {m}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label>
+                  {t('treatmentProducts.defaultUnit', {
+                    defaultValue: 'Amount unit',
+                  })}
+                </Label>
+                <Select
+                  value={form.defaultUnit}
+                  onValueChange={(v) => setField('defaultUnit', v)}
+                >
+                  <SelectTrigger data-test="tp-unit">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AMOUNT_UNITS.map((u) => (
+                      <SelectItem key={u} value={u}>
+                        {u}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1">
+                <Label>
+                  {t('treatmentProducts.withdrawal', {
+                    defaultValue: 'Withdrawal (days)',
+                  })}
+                </Label>
+                <Input
+                  type="number"
+                  min={0}
+                  value={form.withdrawalPeriodDays}
+                  onChange={(e) =>
+                    setField('withdrawalPeriodDays', e.target.value)
+                  }
+                  data-test="tp-withdrawal"
+                />
+              </div>
+            </div>
+
+            {/* Composition editor */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label>
+                  {t('treatmentProducts.composition', {
+                    defaultValue: 'Active ingredients',
+                  })}
+                </Label>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={addIngredientRow}
+                  data-test="tp-add-ingredient"
+                >
+                  <Plus className="h-3 w-3 mr-1" />
+                  {t('treatmentProducts.addIngredient', {
+                    defaultValue: 'Add ingredient',
+                  })}
+                </Button>
+              </div>
+              {form.ingredients.map((row, idx) => (
+                <div key={idx} className="flex gap-2 items-center" data-test="tp-ingredient-row">
+                  <Select
+                    value={row.activeIngredientId}
+                    onValueChange={(v) =>
+                      setIngredient(idx, { activeIngredientId: v })
+                    }
+                  >
+                    <SelectTrigger className="flex-1" data-test="tp-ingredient-select">
+                      <SelectValue placeholder="Ingredient" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ingredients?.map((ing) => (
+                        <SelectItem key={ing.id} value={ing.id}>
+                          {ing.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Input
+                    type="number"
+                    className="w-20"
+                    value={row.concentration}
+                    onChange={(e) =>
+                      setIngredient(idx, { concentration: e.target.value })
+                    }
+                    data-test="tp-conc"
+                    placeholder="44"
+                  />
+                  <Select
+                    value={row.concentrationUnit}
+                    onValueChange={(v) =>
+                      setIngredient(idx, {
+                        concentrationUnit: v as ConcentrationUnit,
+                      })
+                    }
+                  >
+                    <SelectTrigger className="w-28" data-test="tp-conc-unit">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CONCENTRATION_UNITS.map((u) => (
+                        <SelectItem key={u} value={u}>
+                          {u}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => removeIngredient(idx)}
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+
+            {/* Density: shown when needed, or under advanced */}
+            {(needDensity || showAdvanced) && (
+              <div className="space-y-1">
+                <Label>
+                  {t('treatmentProducts.density', {
+                    defaultValue: 'Density (g/ml)',
+                  })}
+                </Label>
+                <Input
+                  type="number"
+                  step="0.01"
+                  value={form.density}
+                  onChange={(e) => setField('density', e.target.value)}
+                  data-test="tp-density"
+                />
+                {needDensity && (
+                  <p className="text-xs text-amber-600">
+                    {t('treatmentProducts.densityHint', {
+                      defaultValue:
+                        'Density is required to convert between the amount unit and a concentration measured differently.',
+                    })}
+                  </p>
+                )}
+              </div>
+            )}
+            {!needDensity && !showAdvanced && (
+              <button
+                type="button"
+                className="text-xs text-muted-foreground underline"
+                onClick={() => setShowAdvanced(true)}
+              >
+                {t('treatmentProducts.advanced', { defaultValue: 'Advanced' })}
+              </button>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+              {t('treatmentProducts.cancel', { defaultValue: 'Cancel' })}
+            </Button>
+            <Button
+              onClick={handleSave}
+              disabled={!canSave || createMut.isPending || updateMut.isPending}
+              data-test="tp-save"
+            >
+              {t('treatmentProducts.save', { defaultValue: 'Save' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <DeleteConfirmDialog
+        open={deleteDialog.isOpen}
+        isPending={deleteDialog.isPending}
+        onOpenChange={(o) => !o && deleteDialog.close()}
+        onConfirm={deleteDialog.handleDelete}
+        title={t('treatmentProducts.deleteTitle', {
+          defaultValue: 'Delete treatment product?',
+        })}
+        description={t('treatmentProducts.deleteDesc', {
+          defaultValue: 'This removes your custom product. This cannot be undone.',
+        })}
+      />
+    </div>
+  );
+}
+
+export default TreatmentProductsPage;

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -72,6 +72,11 @@ const ReportsPage = lazyWithRetry(() =>
     default: m.ReportsPage,
   })),
 );
+const TreatmentProductsPage = lazyWithRetry(() =>
+  import('@/pages/treatment-products/treatment-products-page').then(m => ({
+    default: m.TreatmentProductsPage,
+  })),
+);
 const CalendarPage = lazyWithRetry(() =>
   import('@/pages/calendar/calendar-page').then(m => ({
     default: m.CalendarPage,
@@ -473,6 +478,14 @@ const router = createBrowserRouter([
         element: (
           <LazyPage>
             <EquipmentSettingsPage />
+          </LazyPage>
+        ),
+      },
+      {
+        path: '/treatment-products',
+        element: (
+          <LazyPage>
+            <TreatmentProductsPage />
           </LazyPage>
         ),
       },

--- a/packages/shared-schemas/src/actions/details.schema.ts
+++ b/packages/shared-schemas/src/actions/details.schema.ts
@@ -35,9 +35,20 @@ export const feedingActionDetailsSchema = z.object({
 export const treatmentActionDetailsSchema = z.object({
   type: z.literal(ActionType.TREATMENT),
   product: z.string(),
+  // Optional link to a catalog product (built-in or the user's custom). When
+  // set, its composition + quantity/unit drive per-colony ingredient totals.
+  productId: z.string().uuid().optional().nullable(),
   quantity: z.number().positive().optional().nullable(),
   unit: z.string(),
   duration: z.string().optional(),
+  // Optional efficacy tracking (mite counts around the treatment).
+  miteCountMethod: z
+    .enum(['NATURAL_DROP', 'SUGAR_ROLL', 'ALCOHOL_WASH', 'CO2', 'OTHER'])
+    .optional()
+    .nullable(),
+  miteCountBefore: z.number().nonnegative().optional().nullable(),
+  miteCountAfter: z.number().nonnegative().optional().nullable(),
+  miteSampleSize: z.number().int().positive().optional().nullable(),
 });
 
 export const frameActionDetailsSchema = z.object({

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -1,5 +1,6 @@
 // Export all schema modules
 export * from './actions';
+export * from './treatments';
 export * from './audio';
 export * from './calendar';
 export * from './inspections';

--- a/packages/shared-schemas/src/treatments/index.ts
+++ b/packages/shared-schemas/src/treatments/index.ts
@@ -1,0 +1,2 @@
+export * from './treatment-product.schema';
+export * from './units';

--- a/packages/shared-schemas/src/treatments/treatment-product.schema.ts
+++ b/packages/shared-schemas/src/treatments/treatment-product.schema.ts
@@ -1,0 +1,164 @@
+import { z } from 'zod';
+
+// --- Enums (mirror the Prisma enums) ---
+
+export const TreatmentPhysicalForm = {
+  LIQUID: 'LIQUID',
+  POWDER: 'POWDER',
+  GEL: 'GEL',
+  STRIP: 'STRIP',
+  GASEOUS: 'GASEOUS',
+} as const;
+export type TreatmentPhysicalForm =
+  (typeof TreatmentPhysicalForm)[keyof typeof TreatmentPhysicalForm];
+export const treatmentPhysicalFormSchema = z.enum([
+  'LIQUID',
+  'POWDER',
+  'GEL',
+  'STRIP',
+  'GASEOUS',
+]);
+
+export const TreatmentApplicationMethod = {
+  TRICKLE: 'TRICKLE',
+  SPRAY: 'SPRAY',
+  SUBLIMATE: 'SUBLIMATE',
+  EVAPORATE: 'EVAPORATE',
+  INSERT: 'INSERT',
+  OTHER: 'OTHER',
+} as const;
+export type TreatmentApplicationMethod =
+  (typeof TreatmentApplicationMethod)[keyof typeof TreatmentApplicationMethod];
+export const treatmentApplicationMethodSchema = z.enum([
+  'TRICKLE',
+  'SPRAY',
+  'SUBLIMATE',
+  'EVAPORATE',
+  'INSERT',
+  'OTHER',
+]);
+
+// Concentration bases. mass-per-volume (mg/ml, g/l), mass-per-mass (%w/w, mg/g),
+// mass-per-count (mg/piece). Used by the units engine to normalize to mass.
+export const CONCENTRATION_UNITS = [
+  'mg/ml',
+  'g/l',
+  '%w/w',
+  'mg/g',
+  'mg/piece',
+] as const;
+export type ConcentrationUnit = (typeof CONCENTRATION_UNITS)[number];
+export const concentrationUnitSchema = z.enum(CONCENTRATION_UNITS);
+
+export const MiteCountMethod = {
+  NATURAL_DROP: 'NATURAL_DROP',
+  SUGAR_ROLL: 'SUGAR_ROLL',
+  ALCOHOL_WASH: 'ALCOHOL_WASH',
+  CO2: 'CO2',
+  OTHER: 'OTHER',
+} as const;
+export type MiteCountMethod =
+  (typeof MiteCountMethod)[keyof typeof MiteCountMethod];
+export const miteCountMethodSchema = z.enum([
+  'NATURAL_DROP',
+  'SUGAR_ROLL',
+  'ALCOHOL_WASH',
+  'CO2',
+  'OTHER',
+]);
+
+// --- Active ingredient ---
+
+export const activeIngredientSchema = z.object({
+  id: z.string().uuid(),
+  key: z.string(),
+  name: z.string(),
+  isBuiltIn: z.boolean(),
+  createdByUserId: z.string().uuid().nullable(),
+  createdAt: z.string().or(z.date()),
+  updatedAt: z.string().or(z.date()),
+});
+export type ActiveIngredient = z.infer<typeof activeIngredientSchema>;
+
+export const createActiveIngredientSchema = z.object({
+  key: z
+    .string()
+    .min(2)
+    .max(64)
+    .regex(/^[A-Z0-9_]+$/, 'Key must be UPPER_SNAKE_CASE'),
+  name: z.string().min(2).max(120),
+});
+export type CreateActiveIngredientDto = z.infer<
+  typeof createActiveIngredientSchema
+>;
+
+// --- Composition (one active-ingredient entry of a product) ---
+
+export const productIngredientInputSchema = z.object({
+  activeIngredientId: z.string().uuid(),
+  concentration: z.number().positive(),
+  concentrationUnit: concentrationUnitSchema,
+});
+export type ProductIngredientInput = z.infer<
+  typeof productIngredientInputSchema
+>;
+
+export const productIngredientSchema = productIngredientInputSchema.extend({
+  id: z.string().uuid(),
+  activeIngredient: activeIngredientSchema.optional(),
+});
+export type ProductIngredient = z.infer<typeof productIngredientSchema>;
+
+// --- Treatment product ---
+
+export const treatmentProductSchema = z.object({
+  id: z.string().uuid(),
+  userId: z.string().uuid().nullable(), // null = global built-in
+  name: z.string(),
+  physicalForm: treatmentPhysicalFormSchema,
+  applicationMethod: treatmentApplicationMethodSchema.nullable(),
+  defaultUnit: z.string().nullable(),
+  density: z.number().positive().nullable(),
+  withdrawalPeriodDays: z.number().int().nonnegative().nullable(),
+  isBuiltIn: z.boolean(),
+  ingredients: z.array(productIngredientSchema),
+  createdAt: z.string().or(z.date()),
+  updatedAt: z.string().or(z.date()),
+});
+export type TreatmentProduct = z.infer<typeof treatmentProductSchema>;
+
+export const treatmentProductListSchema = z.array(treatmentProductSchema);
+export type TreatmentProductList = z.infer<typeof treatmentProductListSchema>;
+
+export const createTreatmentProductSchema = z.object({
+  name: z.string().min(2, 'Name must be at least 2 characters').max(120),
+  physicalForm: treatmentPhysicalFormSchema,
+  applicationMethod: treatmentApplicationMethodSchema.optional().nullable(),
+  defaultUnit: z.string().max(16).optional().nullable(),
+  density: z.number().positive().optional().nullable(),
+  withdrawalPeriodDays: z.number().int().nonnegative().optional().nullable(),
+  ingredients: z.array(productIngredientInputSchema).default([]),
+});
+export type CreateTreatmentProductDto = z.infer<
+  typeof createTreatmentProductSchema
+>;
+
+export const updateTreatmentProductSchema =
+  createTreatmentProductSchema.partial();
+export type UpdateTreatmentProductDto = z.infer<
+  typeof updateTreatmentProductSchema
+>;
+
+// --- Per-colony applied active-ingredient totals (reporting) ---
+
+export const appliedIngredientTotalSchema = z.object({
+  activeIngredientId: z.string().uuid(),
+  key: z.string(),
+  name: z.string(),
+  totalMg: z.number(), // normalized mass applied over the period
+  /** Number of treatment records that could not be normalized (missing density/incompatible units). */
+  incompleteCount: z.number().int().nonnegative().default(0),
+});
+export type AppliedIngredientTotal = z.infer<
+  typeof appliedIngredientTotalSchema
+>;

--- a/packages/shared-schemas/src/treatments/units.ts
+++ b/packages/shared-schemas/src/treatments/units.ts
@@ -1,0 +1,170 @@
+// Dimensioned unit engine for treatment dosing.
+//
+// Goal: given an amount of product applied (in some unit) and a single active
+// ingredient's concentration (in some basis), compute the mass of that active
+// ingredient in **milligrams**. Concentrations can be per volume, per mass or
+// per count; amounts can be volume, mass or count. When the amount's dimension
+// differs from the concentration's basis (e.g. concentration in mg/ml but the
+// amount was recorded in grams), the product's **density (g/ml)** bridges
+// volume<->mass. If bridging is impossible (missing density, or count vs.
+// volume/mass), the result is flagged `incomplete` instead of guessed.
+
+import type { ConcentrationUnit } from './treatment-product.schema';
+
+export type Dimension = 'VOLUME' | 'MASS' | 'COUNT';
+
+// Amount units -> { dimension, factor to that dimension's base }.
+// Bases: volume = ml, mass = g, count = piece.
+const AMOUNT_UNITS: Record<string, { dim: Dimension; toBase: number }> = {
+  // volume (base ml)
+  ml: { dim: 'VOLUME', toBase: 1 },
+  l: { dim: 'VOLUME', toBase: 1000 },
+  L: { dim: 'VOLUME', toBase: 1000 },
+  'fl oz': { dim: 'VOLUME', toBase: 29.5735 },
+  qt: { dim: 'VOLUME', toBase: 946.353 },
+  gal: { dim: 'VOLUME', toBase: 3785.41 },
+  // mass (base g)
+  mg: { dim: 'MASS', toBase: 0.001 },
+  g: { dim: 'MASS', toBase: 1 },
+  kg: { dim: 'MASS', toBase: 1000 },
+  oz: { dim: 'MASS', toBase: 28.3495 },
+  lb: { dim: 'MASS', toBase: 453.592 },
+  // count (base piece)
+  pcs: { dim: 'COUNT', toBase: 1 },
+  piece: { dim: 'COUNT', toBase: 1 },
+  strip: { dim: 'COUNT', toBase: 1 },
+  strips: { dim: 'COUNT', toBase: 1 },
+};
+
+export function amountUnitDimension(unit: string): Dimension | null {
+  return AMOUNT_UNITS[unit]?.dim ?? null;
+}
+
+/** Normalize an amount to its dimension's base unit (ml / g / piece). */
+export function amountToBase(
+  amount: number,
+  unit: string,
+): { dim: Dimension; value: number } | null {
+  const u = AMOUNT_UNITS[unit];
+  if (!u) return null;
+  return { dim: u.dim, value: amount * u.toBase };
+}
+
+// Concentration -> { basis dimension, mg per base unit of that dimension }.
+// Bases: VOLUME -> mg per ml, MASS -> mg per g, COUNT -> mg per piece.
+export function concentrationToMgPerBase(
+  concentration: number,
+  unit: ConcentrationUnit,
+): { dim: Dimension; mgPerBase: number } {
+  switch (unit) {
+    case 'mg/ml':
+      return { dim: 'VOLUME', mgPerBase: concentration };
+    case 'g/l':
+      // 1 g/l = 1000 mg / 1000 ml = 1 mg/ml
+      return { dim: 'VOLUME', mgPerBase: concentration };
+    case 'mg/g':
+      return { dim: 'MASS', mgPerBase: concentration };
+    case '%w/w':
+      // 1 % w/w = 1 g per 100 g = 10 mg per g
+      return { dim: 'MASS', mgPerBase: concentration * 10 };
+    case 'mg/piece':
+      return { dim: 'COUNT', mgPerBase: concentration };
+    default: {
+      // Exhaustiveness guard
+      const _never: never = unit;
+      return _never;
+    }
+  }
+}
+
+export interface AppliedMassInput {
+  amount: number | null | undefined;
+  amountUnit: string;
+  concentration: number;
+  concentrationUnit: ConcentrationUnit;
+  /** Product density in g/ml — only consulted when volume<->mass bridging is needed. */
+  density?: number | null;
+}
+
+export interface AppliedMassResult {
+  /** Applied active-ingredient mass in mg, or null if it could not be computed. */
+  mg: number | null;
+  incomplete: boolean;
+  reason?: string;
+}
+
+/**
+ * Compute the applied active-ingredient mass (mg) for one composition entry.
+ * Returns `{ mg: null, incomplete: true, reason }` when it cannot be normalized.
+ */
+export function computeAppliedMassMg(input: AppliedMassInput): AppliedMassResult {
+  const { amount, amountUnit, concentration, concentrationUnit, density } =
+    input;
+
+  if (amount == null || !Number.isFinite(amount)) {
+    return { mg: null, incomplete: true, reason: 'no-amount' };
+  }
+  const a = amountToBase(amount, amountUnit);
+  if (!a) {
+    return { mg: null, incomplete: true, reason: 'unknown-amount-unit' };
+  }
+  const c = concentrationToMgPerBase(concentration, concentrationUnit);
+
+  // Same dimension: direct multiply.
+  if (a.dim === c.dim) {
+    return { mg: a.value * c.mgPerBase, incomplete: false };
+  }
+
+  // Bridging volume <-> mass via density.
+  if (
+    (a.dim === 'VOLUME' && c.dim === 'MASS') ||
+    (a.dim === 'MASS' && c.dim === 'VOLUME')
+  ) {
+    if (!density || !Number.isFinite(density) || density <= 0) {
+      return { mg: null, incomplete: true, reason: 'density-required' };
+    }
+    if (a.dim === 'VOLUME') {
+      // ml -> g via density (g/ml), then * mgPerG
+      const grams = a.value * density;
+      return { mg: grams * c.mgPerBase, incomplete: false };
+    }
+    // MASS amount vs VOLUME concentration: g -> ml via density, then * mgPerMl
+    const ml = a.value / density;
+    return { mg: ml * c.mgPerBase, incomplete: false };
+  }
+
+  // COUNT vs VOLUME/MASS (or vice versa) cannot be reconciled.
+  return { mg: null, incomplete: true, reason: 'incompatible-dimensions' };
+}
+
+export interface ProductLikeForMass {
+  density?: number | null;
+  ingredients: Array<{
+    activeIngredientId: string;
+    concentration: number;
+    concentrationUnit: ConcentrationUnit;
+  }>;
+}
+
+/**
+ * For one applied treatment (amount + product), compute the mass (mg) of each
+ * active ingredient. Returns a map keyed by activeIngredientId with the mass and
+ * whether that entry was incomplete.
+ */
+export function computeTreatmentIngredientMasses(
+  amount: number | null | undefined,
+  amountUnit: string,
+  product: ProductLikeForMass,
+): Record<string, AppliedMassResult> {
+  const out: Record<string, AppliedMassResult> = {};
+  for (const ing of product.ingredients) {
+    out[ing.activeIngredientId] = computeAppliedMassMg({
+      amount,
+      amountUnit,
+      concentration: ing.concentration,
+      concentrationUnit: ing.concentrationUnit,
+      density: product.density,
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #224 

Implements the treatment-products catalog proposed in the linked issue — see
there for the full motivation and the survey of how other tools handle this.
This description focuses on how the implementation works and what reviewers
should look at.

One commit, based directly on current `main`; 33 files, ~2.6k insertions.

## Implementation

### Data model (`schema.prisma`, migration `add_treatment_products`)

- Three new tables: `ActiveIngredient`, `TreatmentProduct`,
  `TreatmentProductIngredient` (join with per-ingredient concentration + unit).
- **Scoping:** `TreatmentProduct.userId` is nullable — `NULL` marks a built-in
  visible to everyone and read-only; a set `userId` marks a private custom
  product. Two partial unique indexes keep names unique within each scope.
  This also leaves room for a shared community catalog later without another
  migration.
- `TreatmentAction` gains an optional `productId` (FK with `ON DELETE SET
  NULL`, so treatment history survives product deletion) plus optional
  mite-count fields (`method`, `before`, `after`, `sampleSize`) for efficacy.
- **Backward compatibility:** the legacy free-text `product` column is kept and
  still written on every create, so nothing existing breaks. A data-migration
  step back-fills `productId` on old rows by matching the legacy name strings.
- The migration seeds 11 active ingredients and 12 built-in products
  (VarroMed, Api-Bioxal, Apivar, Apiguard, Apistan, CheckMite+, MAQS,
  HopGuard, …) with concentrations taken from the products' SPC sheets and
  withdrawal periods where applicable (e.g. CheckMite+ = 42 days).

### Dose engine (`packages/shared-schemas/src/treatments/units.ts`)

Pure functions that turn *(amount × concentration)* into normalized **mg of
active ingredient**. Each amount unit has a dimension (volume / mass / count);
each concentration unit maps to a base dimension (`mg/ml`, `g/l` → volume;
`%w/w`, `mg/g` → mass; `mg/piece` → count). When the dimensions differ (e.g.
ml of product but a concentration quoted in mg/g), an optional product
**density** bridges volume↔mass. If no valid conversion exists, the treatment
is flagged `incomplete` with a reason instead of silently guessing — wrong
residue numbers would be worse than none.

### API (`apps/backend/src/treatment-products/`)

- CRUD for products and active ingredients; mutating a built-in returns 403.
- `GET /hives/:id/treatment-summary` and
  `GET /apiaries/:id/treatment-ingredient-totals` run the aggregation
  server-side, with optional `from`/`to` range.
- Everything sits behind the existing auth guard; hive/apiary access is checked
  through a new shared `apiaryAccessWhere` helper (owner or active member).

### Frontend

- New **Treatment products** page: catalog cards (built-ins locked, custom
  editable) and an add/edit dialog with a composition editor; density and
  withdrawal live under an "Advanced" toggle so the common case stays simple.
- The inspection **treatment action** now offers a product select fed from the
  catalog, keeps an "Other (free text)" escape hatch, and has a collapsible
  mite-count section.
- Colony detail gets an *Applied active ingredients* card; the reports charts
  tab gets a per-apiary ingredient totals card.
- Only **English** strings are added; other languages fall back to English, and
  no `de`/Weblate-managed files are touched.

## Screenshots

The demo data behind these: one colony treated with VarroMed 30 ml,
Api-Bioxal 35 g and CheckMite+ 2 strips.

| | |
| --- | --- |
| <img width="1280" height="1222" alt="01treatmentproducts(1)" src="https://github.com/user-attachments/assets/f4194fc6-9b78-459d-92a5-2d1d4967109a" /> |<img width="1280" height="900" alt="02createproductdialog(1)" src="https://github.com/user-attachments/assets/fa376d3d-7467-427b-adab-1e496333f962" /> |
| *Catalog: 12 seeded built-ins with form badges and composition lines, plus a user-created product (edit/delete icons).* | *Composition editor: ingredient + concentration + unit per row; amount unit and withdrawal in the same dialog.* |
|<img width="714" height="247" alt="03hiveingredienttotals(1)" src="https://github.com/user-attachments/assets/13ae0e69-2cd0-40f2-a4ed-31a9fe2b4c65" />| <img width="656" height="203" alt="04reportsingredienttotals(1)" src="https://github.com/user-attachments/assets/d5b58297-18df-42eb-bf69-3d0996e37902" /> |
| *Colony card: three products collapse into three ingredient totals; the CheckMite+ withdrawal badge is active.* | *Reports: the same totals summed apiary-wide as ranked bars.* |

## Testing

- **Unit:** 21 tests on the dose engine
  (`apps/backend/src/treatment-products/units.spec.ts`) — same-dimension
  conversions, the density bridge, incompatible-unit and missing-density cases.
- **E2E (Playwright):** `apps/e2e/tests/treatment-products/…` asserts the
  seeded catalog renders a combination product with both of its ingredients,
  and that a user can create a custom product through the dialog.
- **End-to-end arithmetic check** against a seeded stack: the three treatments
  above produce oxalic acid **32.33 g** (44 mg/ml × 30 ml + 886 mg/g × 35 g),
  formic acid **150 mg**, coumaphos **2.72 g**, and a withdrawal date 42 days
  after the CheckMite+ application — matching hand calculation.
- `pnpm typecheck` passes for backend and frontend; the migration applies
  cleanly on a fresh database.

## Notes for reviewers

- The heaviest file is the migration (DDL + seed + back-fill) — the seed values
  are the part worth double-checking against the product SPCs.
- `apps/e2e/tests/auth.setup.ts` gets a one-line fix: the "Sign in" selector
  also matched "Sign in with passkey" under strict mode, which aborts the whole
  e2e setup project. Included here because the new e2e spec depends on it;
  happy to split it out if preferred.
