### PR TITLE
fix(pwa): offer deployed updates instead of getting stuck on a cached build

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -51,6 +51,11 @@ import { AssistantModule } from './assistant/assistant.module';
 import { MeasurementsModule } from './measurements/measurements.module';
 import { AccountTransferModule } from './account-transfer/account-transfer.module';
 
+// Static files that must always be revalidated rather than served from the
+// browser's HTTP cache, so a deployed update is picked up (see the
+// ServeStaticModule setHeaders hook below).
+const NO_STORE_FILES = /(?:^|[\\/])(?:sw\.js|registerSW\.js|index\.html)$/;
+
 @Module({
   imports: [
     SentryModule.forRoot(),
@@ -66,6 +71,22 @@ import { AccountTransferModule } from './account-transfer/account-transfer.modul
       rootPath: join(__dirname, '..', 'static'),
       exclude: ['/api{/*path}'],
       renderPath: /^(?!\/assets\/)/,
+      serveStaticOptions: {
+        setHeaders: (res, filePath) => {
+          // The service worker script and its registration shim must never be
+          // answered from the HTTP cache: browsers are allowed to reuse a
+          // cached sw.js for up to 24h, which is how clients stay stuck on the
+          // previous build after a deploy — the new worker is never fetched, so
+          // no update is offered. Hashed files under /assets are content-
+          // addressed and stay cacheable.
+          if (NO_STORE_FILES.test(filePath)) {
+            res.setHeader(
+              'Cache-Control',
+              'no-cache, no-store, must-revalidate',
+            );
+          }
+        },
+      },
     }),
     StorageModule,
     BetterAuthModule,

--- a/apps/frontend/public/locales/de/common.json
+++ b/apps/frontend/public/locales/de/common.json
@@ -1051,5 +1051,9 @@
         }
       }
     }
+  },
+  "pwa": {
+    "updateAvailable": "Eine neue Version ist verfügbar",
+    "reload": "Neu laden"
   }
 }

--- a/apps/frontend/public/locales/en/common.json
+++ b/apps/frontend/public/locales/en/common.json
@@ -1716,5 +1716,9 @@
         }
       }
     }
+  },
+  "pwa": {
+    "updateAvailable": "A new version is available",
+    "reload": "Reload"
   }
 }

--- a/apps/frontend/src/components/pwa-update-prompt.tsx
+++ b/apps/frontend/src/components/pwa-update-prompt.tsx
@@ -3,23 +3,61 @@ import { useRegisterSW } from 'virtual:pwa-register/react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 
+// How often an open tab asks the browser to re-check for a newly deployed
+// service worker. Without this a long-lived tab only notices a deployment on
+// its next navigation.
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
+// Keeps the toast from stacking up if the effect runs again.
+const TOAST_ID = 'pwa-update-available';
+
+/**
+ * Registers the service worker and offers the user a new version once one has
+ * been deployed. This is the app's single registration point — see main.tsx.
+ *
+ * The worker is built in 'prompt' mode, so a new version installs and then
+ * waits: nothing changes under the user's feet until they accept here.
+ */
 export function PWAUpdatePrompt() {
   const { t } = useTranslation();
   const {
     needRefresh: [needRefresh],
     updateServiceWorker,
-  } = useRegisterSW();
+  } = useRegisterSW({
+    immediate: true,
+    onRegisteredSW(swUrl, registration) {
+      if (!registration) return;
+
+      if (import.meta.env.PROD) {
+        window.setInterval(() => {
+          registration.update().catch(() => {
+            // Offline or a transient network error — retry on the next tick.
+          });
+        }, UPDATE_CHECK_INTERVAL_MS);
+      }
+
+      console.debug('[PWA] service worker registered:', swUrl);
+    },
+    onRegisterError(error) {
+      console.error('[PWA] service worker registration error', error);
+    },
+    onOfflineReady() {
+      console.debug('[PWA] app ready to work offline');
+    },
+  });
 
   useEffect(() => {
-    if (needRefresh) {
-      toast(t('pwa.updateAvailable', 'A new version is available'), {
-        duration: Infinity,
-        action: {
-          label: t('pwa.reload', 'Reload'),
-          onClick: () => updateServiceWorker(true),
-        },
-      });
-    }
+    if (!needRefresh) return;
+
+    toast(t('pwa.updateAvailable', 'A new version is available'), {
+      id: TOAST_ID,
+      duration: Infinity,
+      action: {
+        label: t('pwa.reload', 'Reload'),
+        // `true` activates the waiting worker and reloads the page.
+        onClick: () => updateServiceWorker(true),
+      },
+    });
   }, [needRefresh, updateServiceWorker, t]);
 
   return null;

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -2,37 +2,15 @@ import * as Sentry from '@sentry/react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
-import { registerSW } from 'virtual:pwa-register';
 import './index.css';
 import './lib/i18n';
 import { initFaro } from './lib/faro';
 import App from './App.tsx';
 
-// Register PWA service worker using auto-update behavior.
-// This keeps deployed clients fresher without requiring a manual hard refresh.
-registerSW({
-  onRegisteredSW(swUrl, registration) {
-    if (!registration) return;
-
-    // Optional periodic update check while the app stays open.
-    // Helps long-lived tabs pick up new deployments sooner.
-    if (import.meta.env.PROD) {
-      window.setInterval(() => {
-        registration.update().catch(() => {
-          // ignore update polling errors
-        });
-      }, 60 * 60 * 1000);
-    }
-
-    console.debug('[PWA] service worker registered:', swUrl);
-  },
-  onRegisterError(error) {
-    console.error('[PWA] service worker registration error', error);
-  },
-  onOfflineReady() {
-    console.debug('[PWA] app ready to work offline');
-  },
-});
+// The service worker is registered exactly once, from PWAUpdatePrompt (rendered
+// by App), because that component also needs the registration's update state.
+// Registering here as well would create a second Workbox instance with its own
+// listeners, which made update detection unreliable.
 
 // Handle chunk load errors from version skew (new deploy with old chunks cached)
 window.addEventListener('vite:preloadError', () => {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -14,7 +14,12 @@ export default defineConfig(({ isSsrBuild }) => ({
       ? []
       : [
           VitePWA({
-            registerType: 'autoUpdate',
+            // 'prompt', not 'autoUpdate': inspections are long forms, so a new
+            // deployment must never swap itself in and reload the page while a
+            // beekeeper is typing. It is also what makes `needRefresh` fire,
+            // which is what PWAUpdatePrompt shows the user (in 'autoUpdate'
+            // mode that flag stays false and the prompt is dead code).
+            registerType: 'prompt',
             includeAssets: [
               'favicon.ico',
               'favicon-16x16.png',
@@ -26,7 +31,10 @@ export default defineConfig(({ isSsrBuild }) => ({
             manifest: false, // use existing site.webmanifest
             workbox: {
               clientsClaim: true,
-              skipWaiting: true,
+              // Deliberately no `skipWaiting`: a freshly installed worker has to
+              // stay in "waiting" until the user accepts the update, otherwise it
+              // activates behind their back and the prompt never appears.
+              // `updateServiceWorker(true)` sends SKIP_WAITING on accept.
               globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}'],
               // The service worker falls back to index.html for navigation requests.
               // Backend-handled routes (API + better-auth, e.g. the magic-link verify


### PR DESCRIPTION
Closes #226 

Makes a deployment actually reach browsers that already have the app open, and puts the decision to apply it in the user's hands.

## The three fixes

**Update mode.** The worker was generated with `registerType: 'autoUpdate'`, where `needRefresh` is never raised — which is exactly the flag `PWAUpdatePrompt` waits for, so its toast could not fire. Switched to `'prompt'` and removed `skipWaiting` from the workbox options: a new worker now installs, stays in *waiting*, and takes over only when the user confirms. That ordering matters for this app — inspections are long forms, and a self-triggered reload halfway through would throw away typed input.

**One registration.** `main.tsx` registered the worker at module scope *and* `PWAUpdatePrompt` registered it again through `useRegisterSW`, so two Workbox instances competed over the same lifecycle. Registration now lives solely in the component, which is also where the update state is needed. The hourly `registration.update()` poll for long-lived tabs moved along with it, and `immediate: true` keeps registration from waiting on the `load` event.

**Cacheable worker script.** `sw.js` went out with `ServeStaticModule`'s default headers, and browsers may keep a cached worker script for up to 24 hours — during which no update can even be discovered. `sw.js`, `registerSW.js` and `index.html` are now sent with `no-cache, no-store, must-revalidate`; content-hashed files under `/assets` stay cacheable.

Also adds the `pwa.updateAvailable` / `pwa.reload` strings (en, de) that the toast previously only had as inline English fallbacks.

## Verification

The generated worker was inspected after `vite build` to confirm the new contract — `skipWaiting` is now reachable only through the client's message, instead of running unconditionally:

```js
self.addEventListener("message", s => {
  s.data && "SKIP_WAITING" === s.data.type && self.skipWaiting()
});
clientsClaim();
precacheAndRoute([ … 97 entries … ]);
```

Both header paths were checked against `@nestjs/serve-static` 5.0.4: `setHeaders` is applied for statically served files and, at `express.loader.js:62`, for the SPA fallback as well — and `send` leaves an already-set `Cache-Control` alone, so the value survives.

`typecheck` and ESLint pass for backend and frontend.

## Rolling it out

Existing clients still carry the old `autoUpdate` worker, which claims control on its own. They will therefore take this change up automatically once, and from the next deployment onwards see the prompt. Sessions that are wedged today (worker cached, no update offered) still need one manual clear — after that the mechanism keeps itself healthy.

Not addressed here, since it is a separate concern: when storage is not configured the photo section silently renders nothing, which is easy to mistake for a caching problem of this kind.
