### PR TITLE
fix(inspections): tell the user when a photo cannot be attached

### DIFF
--- a/apps/frontend/public/locales/de/inspection.json
+++ b/apps/frontend/public/locales/de/inspection.json
@@ -300,6 +300,21 @@
             "title": "Audio-Notizen",
             "pendingUpload": "{{count}} ausstehend zum Hochladen",
             "uploadWarning": "Audioaufnahmen werden beim Speichern der Inspektion hochgeladen."
+        },
+        "photos": {
+            "title": "Fotos",
+            "takePhoto": "Foto aufnehmen",
+            "addPhoto": "Foto hinzufügen",
+            "pendingUpload": "{{count}} ausstehend zum Hochladen",
+            "uploadWarning": "Fotos werden beim Speichern der Durchsicht hochgeladen.",
+            "deleteConfirm": "Dieses Foto löschen?",
+            "maxReached": "Maximal {{max}} Fotos pro Durchsicht",
+            "unsupportedType": "{{name}}: nicht unterstütztes Bildformat",
+            "tooLarge": "{{name}} ist größer als {{max}} MB",
+            "uploadFailed": "{{name}} konnte nicht hochgeladen werden",
+            "deleteFailed": "Das Foto konnte nicht gelöscht werden",
+            "someFailed_one": "{{count}} Foto konnte nicht hochgeladen werden",
+            "someFailed_other": "{{count}} Fotos konnten nicht hochgeladen werden"
         }
     },
     "detailSidebar": {

--- a/apps/frontend/public/locales/en/inspection.json
+++ b/apps/frontend/public/locales/en/inspection.json
@@ -344,7 +344,13 @@
       "pendingUpload": "{{count}} pending upload",
       "uploadWarning": "Photos will be uploaded when you save the inspection.",
       "deleteConfirm": "Delete this photo?",
-      "maxReached": "Maximum {{max}} photos per inspection"
+      "maxReached": "Maximum {{max}} photos per inspection",
+      "unsupportedType": "{{name}}: unsupported image format",
+      "tooLarge": "{{name}} is larger than {{max}} MB",
+      "uploadFailed": "Could not upload {{name}}",
+      "deleteFailed": "Could not delete the photo",
+      "someFailed_one": "{{count}} photo could not be uploaded",
+      "someFailed_other": "{{count}} photos could not be uploaded"
     }
   },
   "detailSidebar": {

--- a/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/index.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
 import {
   Form,
   FormControl,
@@ -321,14 +322,24 @@ export const InspectionForm: React.FC<InspectionFormProps> = ({
 
   const onSubmit = useUpsertInspection(inspectionId, {
     onBeforeNavigate: async (id: string) => {
-      await Promise.all([
+      const [, photoResult] = await Promise.all([
         pendingRecordings.length > 0
           ? uploadPendingRecordings(id, pendingRecordings)
           : Promise.resolve(),
         pendingPhotos.length > 0
           ? uploadPendingPhotos(id, pendingPhotos)
-          : Promise.resolve(),
+          : Promise.resolve(null),
       ]);
+
+      // The inspection itself saved fine at this point, so a dropped photo
+      // would otherwise look to the user like it had been stored.
+      if (photoResult && photoResult.failed.length > 0) {
+        toast.error(
+          t('inspection:form.photos.someFailed', {
+            count: photoResult.failed.length,
+          }),
+        );
+      }
     },
   });
 

--- a/apps/frontend/src/pages/inspection/components/inspection-form/photos-section.spec.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/photos-section.spec.tsx
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import {
+  PhotosForExistingInspection,
+  PhotosForNewInspection,
+} from './photos-section.story';
+
+const INSPECTION_ID = '11111111-1111-1111-1111-111111111111';
+
+const IMAGE = {
+  name: 'brood-frame.jpg',
+  mimeType: 'image/jpeg',
+  buffer: Buffer.from('not-a-real-jpeg-but-enough-for-an-upload'),
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/features', route =>
+    route.fulfill({ json: { storageEnabled: true, aiEnabled: false } }),
+  );
+  await page.route(`**/api/inspections/${INSPECTION_ID}/photos`, route => {
+    if (route.request().method() === 'GET') return route.fulfill({ json: [] });
+    return route.continue();
+  });
+});
+
+test('reports it when the API rejects the upload', async ({ mount, page }) => {
+  await page.route(`**/api/inspections/${INSPECTION_ID}/photos`, route => {
+    if (route.request().method() === 'GET') return route.fulfill({ json: [] });
+    return route.fulfill({
+      status: 400,
+      json: { message: 'File size exceeds maximum allowed (10MB)' },
+    });
+  });
+
+  const component = await mount(<PhotosForExistingInspection />);
+  await component
+    .locator('input[type="file"]:not([capture])')
+    .setInputFiles(IMAGE);
+
+  // Previously the rejection was swallowed and nothing happened at all.
+  await expect(
+    page.getByText('File size exceeds maximum allowed (10MB)'),
+  ).toBeVisible();
+});
+
+test('reports it when the request never reaches the API', async ({
+  mount,
+  page,
+}) => {
+  await page.route(`**/api/inspections/${INSPECTION_ID}/photos`, route => {
+    if (route.request().method() === 'GET') return route.fulfill({ json: [] });
+    // What a reverse proxy does with a body above its limit.
+    return route.fulfill({ status: 413, body: 'Payload Too Large' });
+  });
+
+  const component = await mount(<PhotosForExistingInspection />);
+  await component
+    .locator('input[type="file"]:not([capture])')
+    .setInputFiles(IMAGE);
+
+  await expect(page.getByText(/larger than 10 MB/i)).toBeVisible();
+});
+
+test('rejects an unsupported file without contacting the API', async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(<PhotosForNewInspection />);
+  await component.locator('input[type="file"]:not([capture])').setInputFiles({
+    name: 'notes.pdf',
+    mimeType: 'application/pdf',
+    buffer: Buffer.from('%PDF-1.4'),
+  });
+
+  await expect(page.getByText(/unsupported image format/i)).toBeVisible();
+  await expect(component.locator('img')).toHaveCount(0);
+});
+
+test('shows a thumbnail for a photo picked on an unsaved inspection', async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(<PhotosForNewInspection />);
+  await component
+    .locator('input[type="file"]:not([capture])')
+    .setInputFiles(IMAGE);
+
+  await expect(component.locator('img')).toHaveCount(1);
+  await expect(page.getByText(/pending upload/i)).toBeVisible();
+});

--- a/apps/frontend/src/pages/inspection/components/inspection-form/photos-section.story.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/photos-section.story.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { Toaster } from 'sonner';
+import { PhotosSection, PendingPhoto } from './photos-section';
+
+/**
+ * Photo section of an inspection that already exists, so picking a file uploads
+ * it right away. Rendered with a Toaster so the component test can assert on
+ * the feedback the user gets.
+ */
+export const PhotosForExistingInspection = () => {
+  const [pending, setPending] = useState<PendingPhoto[]>([]);
+  return (
+    <div style={{ width: 640, padding: 16 }}>
+      <PhotosSection
+        inspectionId="11111111-1111-1111-1111-111111111111"
+        pendingPhotos={pending}
+        onPendingPhotosChange={setPending}
+      />
+      <Toaster />
+    </div>
+  );
+};
+
+/** Same section on an inspection that has not been saved yet. */
+export const PhotosForNewInspection = () => {
+  const [pending, setPending] = useState<PendingPhoto[]>([]);
+  return (
+    <div style={{ width: 640, padding: 16 }}>
+      <PhotosSection pendingPhotos={pending} onPendingPhotosChange={setPending} />
+      <Toaster />
+    </div>
+  );
+};

--- a/apps/frontend/src/pages/inspection/components/inspection-form/photos-section.tsx
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/photos-section.tsx
@@ -1,5 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isAxiosError } from 'axios';
+import { toast } from 'sonner';
 import { Camera, Loader2, Info, X, ImagePlus } from 'lucide-react';
 import {
   useInspectionPhotos,
@@ -12,6 +14,51 @@ import { Button } from '@/components/ui/button';
 
 const MAX_PHOTOS = 5;
 const ACCEPTED_TYPES = 'image/jpeg,image/png,image/webp,image/heic';
+const ACCEPTED_TYPE_LIST = ACCEPTED_TYPES.split(',');
+// Mirrors the limit the API enforces (photos.service.ts). Checking here too
+// lets us name the offending file instead of failing anonymously mid-upload.
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_FILE_SIZE_MB = MAX_FILE_SIZE / 1024 / 1024;
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+/** Returns why a file cannot be accepted, or null when it is fine. */
+function rejectionReason(file: File, t: Translate): string | null {
+  // Some browsers report an empty type for HEIC; only reject what we can judge.
+  if (file.type && !ACCEPTED_TYPE_LIST.includes(file.type)) {
+    return t('inspection:form.photos.unsupportedType', { name: file.name });
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return t('inspection:form.photos.tooLarge', {
+      name: file.name,
+      max: MAX_FILE_SIZE_MB,
+    });
+  }
+  return null;
+}
+
+function uploadErrorMessage(
+  error: unknown,
+  fileName: string,
+  t: Translate,
+): string {
+  if (isAxiosError(error)) {
+    // A reverse proxy can reject the body before it ever reaches the API,
+    // in which case there is no API message to show.
+    if (error.response?.status === 413) {
+      return t('inspection:form.photos.tooLarge', {
+        name: fileName,
+        max: MAX_FILE_SIZE_MB,
+      });
+    }
+    const apiMessage = (error.response?.data as { message?: unknown } | undefined)
+      ?.message;
+    if (typeof apiMessage === 'string' && apiMessage.length > 0) {
+      return apiMessage;
+    }
+  }
+  return t('inspection:form.photos.uploadFailed', { name: fileName });
+}
 
 export interface PendingPhoto {
   id: string;
@@ -64,7 +111,26 @@ export function PhotosSection({
       e.target.value = '';
 
       const remaining = MAX_PHOTOS - totalCount;
-      const filesToAdd = files.slice(0, remaining);
+      if (remaining <= 0) {
+        toast.error(t('inspection:form.photos.maxReached', { max: MAX_PHOTOS }));
+        return;
+      }
+
+      const accepted: File[] = [];
+      for (const file of files) {
+        const reason = rejectionReason(file, t);
+        if (reason) {
+          toast.error(reason);
+        } else {
+          accepted.push(file);
+        }
+      }
+      if (accepted.length === 0) return;
+
+      const filesToAdd = accepted.slice(0, remaining);
+      if (filesToAdd.length < accepted.length) {
+        toast.error(t('inspection:form.photos.maxReached', { max: MAX_PHOTOS }));
+      }
 
       if (isNewInspection) {
         const newPending: PendingPhoto[] = filesToAdd.map(file => ({
@@ -73,12 +139,20 @@ export function PhotosSection({
           previewUrl: URL.createObjectURL(file),
         }));
         onPendingPhotosChange?.([...pendingPhotos, ...newPending]);
-      } else {
-        for (const file of filesToAdd) {
+        return;
+      }
+
+      for (const file of filesToAdd) {
+        try {
           const formData = new FormData();
           formData.append('file', file);
           formData.append('fileName', file.name);
           await uploadPhoto(formData);
+        } catch (error) {
+          // Without this the rejection was swallowed by the event handler and
+          // the picked photo simply never appeared.
+          console.error('Failed to upload photo:', file.name, error);
+          toast.error(uploadErrorMessage(error, file.name, t));
         }
       }
     },
@@ -88,6 +162,7 @@ export function PhotosSection({
       onPendingPhotosChange,
       pendingPhotos,
       uploadPhoto,
+      t,
     ],
   );
 
@@ -97,11 +172,17 @@ export function PhotosSection({
         const photo = pendingPhotos.find(p => p.id === photoId);
         if (photo) URL.revokeObjectURL(photo.previewUrl);
         onPendingPhotosChange?.(pendingPhotos.filter(p => p.id !== photoId));
-      } else {
+        return;
+      }
+
+      try {
         await deletePhoto.mutateAsync(photoId);
+      } catch (error) {
+        console.error('Failed to delete photo:', photoId, error);
+        toast.error(t('inspection:form.photos.deleteFailed'));
       }
     },
-    [onPendingPhotosChange, pendingPhotos, deletePhoto],
+    [onPendingPhotosChange, pendingPhotos, deletePhoto, t],
   );
 
   if (features && !features.storageEnabled) {

--- a/apps/frontend/src/pages/inspection/components/inspection-form/upload-pending-photos.ts
+++ b/apps/frontend/src/pages/inspection/components/inspection-form/upload-pending-photos.ts
@@ -1,3 +1,4 @@
+import { isAxiosError } from 'axios';
 import { apiClient } from '@/api/client';
 
 interface PendingPhoto {
@@ -7,15 +8,44 @@ interface PendingPhoto {
   caption?: string;
 }
 
+export interface FailedPhotoUpload {
+  fileName: string;
+  message: string;
+}
+
+export interface PendingPhotoUploadResult {
+  uploaded: number;
+  failed: FailedPhotoUpload[];
+}
+
+function failureMessage(error: unknown): string {
+  if (isAxiosError(error)) {
+    const apiMessage = (error.response?.data as { message?: unknown } | undefined)
+      ?.message;
+    if (typeof apiMessage === 'string' && apiMessage.length > 0) {
+      return apiMessage;
+    }
+    if (error.response?.status) return `HTTP ${error.response.status}`;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
- * Upload all pending photos after inspection is created
+ * Uploads the photos picked while the inspection did not exist yet, once it has
+ * been created.
+ *
+ * One failing photo must not stop the others, so failures are collected and
+ * returned instead of thrown — the caller is expected to tell the user about
+ * them. Reporting matters here: the inspection itself saves fine, so silently
+ * dropping a photo looks to the beekeeper as if it had been stored.
  */
 export async function uploadPendingPhotos(
   inspectionId: string,
   pendingPhotos: PendingPhoto[],
   onProgress?: (completed: number, total: number) => void,
-): Promise<void> {
+): Promise<PendingPhotoUploadResult> {
   const total = pendingPhotos.length;
+  const failed: FailedPhotoUpload[] = [];
   let completed = 0;
 
   for (const photo of pendingPhotos) {
@@ -33,7 +63,12 @@ export async function uploadPendingPhotos(
       onProgress?.(completed, total);
     } catch (error) {
       console.error('Failed to upload photo:', photo.file.name, error);
-      // Continue with other photos
+      failed.push({
+        fileName: photo.file.name,
+        message: failureMessage(error),
+      });
     }
   }
+
+  return { uploaded: completed, failed };
 }


### PR DESCRIPTION
Closes #228 

Picking a photo in an inspection could lead to nothing whatsoever — no thumbnail, no message — and that was true even when the API had answered with a perfectly clear reason.

## What changed

**Uploads on a saved inspection** now run inside `try`/`catch`. The message shown is the API's own where it sent one (`Invalid photo format`, `File size exceeds maximum allowed (10MB)`, `Maximum 5 photos per inspection`), so wording stays in one place. A `413` is treated separately: it usually comes from a reverse proxy that cut the body off before the API saw it, so there is no message to relay and a size hint is shown instead.

**Uploads that happen after a new inspection is created** were the more deceptive case: `uploadPendingPhotos` logged failures and carried on, and since the inspection itself saved fine, a lost photo looked stored. It now returns what failed, and the form reports the count once the save completes.

**Before uploading**, format and size are checked against the same limits the API enforces. It saves a pointless round trip for a phone photo well over the limit, and it lets the message name the file — which the server response cannot do when several files are picked at once.

**Deleting a stored photo** was silent in the same way; a failure now says so instead of leaving the thumbnail in place.

The German photo strings were missing entirely and had been falling back to English; they are added along with the new messages.

## Tests

Four component tests cover the paths (`photos-section.spec.tsx`):

| Scenario | Expectation |
|---|---|
| API rejects with a message | that message is shown |
| `413` with no API message | size hint is shown |
| Unsupported file type | rejected locally, no request, no thumbnail |
| File picked on an unsaved inspection | thumbnail plus pending marker |

The first three fail against the current code and pass with this change; the fourth passes either way and is there to keep the working path from regressing.

`typecheck` and ESLint pass.

##Screenshots of a toast
<img width="3832" height="1824" alt="image" src="https://github.com/user-attachments/assets/5af012ea-4fba-4950-903d-cba1f2325dd4" />


## Note for reviewers

`uploadPendingRecordings` discards audio-upload failures exactly the same way. It is left untouched here to keep this diff to the reported problem, but it deserves the same treatment.